### PR TITLE
docs(workflow): add markdown linting infrastructure and workflow

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  
+  // Default: all rules enabled
+  "default": true,
+  
+  // Disable or customize specific rules for Dashtam project
+  
+  // MD013: Line length (disabled - we have long lines in code examples and commands)
+  "MD013": false,
+  
+  // MD024: Multiple headings with same content (siblings only - allow if different levels)
+  "MD024": {
+    "siblings_only": true
+  },
+  
+  // MD033: Inline HTML (allow - needed for custom formatting in some docs)
+  "MD033": false,
+  
+  // MD034: Bare URLs (disabled - acceptable in certain contexts like references)
+  "MD034": false,
+  
+  // MD041: First line should be top-level heading (disabled - some files have metadata)
+  "MD041": false,
+  
+  // MD046: Code block style (enforce fenced code blocks with ```)
+  "MD046": {
+    "style": "fenced"
+  },
+  
+  // MD048: Code fence style (enforce backticks, not tildes)
+  "MD048": {
+    "style": "backtick"
+  },
+  
+  // MD049: Emphasis style (enforce asterisks for *italic*)
+  "MD049": {
+    "style": "asterisk"
+  },
+  
+  // MD050: Strong style (enforce asterisks for **bold**)
+  "MD050": {
+    "style": "asterisk"
+  }
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,28 @@
+# markdownlint ignore patterns for Dashtam project
+
+# Node modules and dependencies
+node_modules/
+
+# Build outputs
+site/
+build/
+dist/
+.pytest_cache/
+__pycache__/
+
+# Archived documentation (may have old formatting)
+docs/research/archived/
+
+# Auto-generated files
+CHANGELOG.md
+
+# External documentation
+vendor/
+
+# Python/UV artifacts
+.venv/
+venv/
+*.egg-info/
+
+# Docker artifacts
+.dockerignore

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ make test-verify    # Quick core functionality verification
 # Code Quality (runs in dev environment)
 make lint           # Run code linting (ruff check)
 make format         # Format code (ruff format)
+make lint-md        # Lint all markdown files
+make lint-md-fix    # Fix auto-fixable markdown issues
+make lint-md-file FILE="path/to/file.md"  # Lint specific markdown file
 
 # CI/CD (run tests as they run in GitHub Actions)
 make ci-test        # Run CI tests locally
@@ -332,6 +335,8 @@ The test suite uses **pytest markers** for isolation:
 
 ### Code Quality
 
+#### Python Code
+
 ```bash
 # Format code
 make format
@@ -342,6 +347,25 @@ make lint
 # Run both in CI mode locally
 make ci-test
 ```
+
+#### Markdown Documentation
+
+All markdown files must pass linting before commit:
+
+```bash
+# Lint all markdown files
+make lint-md
+
+# Lint specific file (relative or absolute path)
+make lint-md-file FILE="docs/development/guides/my-guide.md"
+
+# Auto-fix issues (careful! review changes)
+make lint-md-fix
+```
+
+**Workflow**: Create/edit markdown → Lint → Fix violations → Commit
+
+See [WARP.md](WARP.md) section "Documentation: Markdown Quality" for complete workflow.
 
 ### Development Workflow
 

--- a/WARP.md
+++ b/WARP.md
@@ -262,6 +262,75 @@ PR checklist additions (for any API endpoint change):
 - [ ] Kept examples free of real secrets and used variables/placeholders
 - [ ] Updated docs/README.md navigation if structure changed
 
+### Documentation: Markdown Quality (All Documentation Files)
+**CRITICAL RULE**: All markdown files (guides, docs, READMEs, etc.) must pass markdown linting before commit.
+
+**Workflow for Creating/Updating Markdown Files:**
+1. **Create or edit** markdown file using `create_file` or `edit_files` tool
+2. **Lint immediately** after creation/edit:
+   ```bash
+   docker compose -f compose/docker-compose.dev.yml exec app \
+     uv run markdownlint-cli2 "path/to/file.md"
+   ```
+3. **Fix all violations** - Zero tolerance for linting errors
+4. **Re-lint** until clean (exit code 0)
+5. **Then commit** - Only commit lint-clean markdown files
+
+**Why This Matters:**
+- Ensures consistent markdown formatting across all documentation
+- Catches formatting issues (headings, lists, links) early
+- Prevents accumulation of technical debt in docs
+- Maintains professional documentation quality
+- Follows project rule: "Always verify with the user that all requirements have been satisfied and properly handled before marking any task as complete"
+
+**Forbidden Patterns:**
+- ❌ **NEVER commit markdown files without linting first**
+- ❌ **NEVER skip linting because "it's just docs"**
+- ❌ **NEVER assume markdown is correctly formatted**
+- ❌ **NEVER use time-based estimates** ("Week 1-2", "2-3 hours") - Violates WARP.md flexible development rule
+
+**Quick Lint Command:**
+```bash
+# Lint single file
+make lint-md FILE=path/to/file.md
+
+# Lint all markdown files in project
+make lint-md
+```
+
+**Integration with Phase Completion Workflow:**
+This markdown linting step is part of the **Code Quality** phase:
+- Create/edit markdown → Lint markdown → Fix violations → Commit
+- Follows same discipline as Python linting (`make lint`) and formatting (`make format`)
+
+**Example Workflow:**
+```bash
+# 1. Create new guide
+vim docs/development/guides/new-guide.md
+
+# 2. Lint immediately
+docker compose -f compose/docker-compose.dev.yml exec app \
+  uv run markdownlint-cli2 "docs/development/guides/new-guide.md"
+
+# 3. Fix violations, re-lint until clean
+# ... edit file to fix issues ...
+
+# 4. Verify clean
+docker compose -f compose/docker-compose.dev.yml exec app \
+  uv run markdownlint-cli2 "docs/development/guides/new-guide.md"
+# ✅ Output: no errors (exit 0)
+
+# 5. Now safe to commit
+git add docs/development/guides/new-guide.md
+git commit -m "docs(guides): add new development guide"
+```
+
+**PR Checklist Additions (for any documentation change):**
+- [ ] All markdown files linted with `markdownlint-cli2`
+- [ ] All linting violations fixed (zero errors)
+- [ ] No time-based estimates in task lists or plans
+- [ ] Followed project documentation structure (`docs/` hierarchy)
+
 ### Python Code Style
 - **Type Hints**: ALWAYS use type hints for function parameters and return values
 - **Docstrings**: Use Google-style docstrings for all functions and classes

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,27 @@ For API flows, use kebab-case filenames and keep each flow focused on a single u
 
 ## 📝 Contributing to Documentation
 
+### Markdown Quality Standards
+
+All markdown files **must pass linting** before commit:
+
+```bash
+# Lint specific file
+make lint-md-file FILE="docs/path/to/file.md"
+
+# Lint all markdown files
+make lint-md
+
+# Auto-fix issues (review changes carefully)
+make lint-md-fix
+```
+
+**Workflow**: Create/edit → Lint → Fix violations → Visual inspection → Commit
+
+See [WARP.md](../WARP.md) section "Documentation: Markdown Quality" for complete workflow and rules.
+
+### Structure Guidelines
+
 When adding new documentation, follow this structure:
 
 - **Development docs** → `docs/development/[category]/`


### PR DESCRIPTION
## Description

Establishes comprehensive markdown linting infrastructure and workflow for maintaining consistent documentation quality across the project.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation
- [x] Infrastructure/Tooling

## What's Changed

### Infrastructure Setup

1. **Makefile Enhancements**
   - Fixed `lint-md-file` command to handle both relative and absolute paths
   - Added path conversion logic (absolute → relative for Docker container)
   - Updated help text with parameter examples

2. **Configuration Files**
   - Added `.markdownlint.jsonc` with project-specific rules
   - Added `.markdownlintignore` for excluding generated/external files
   - Uses `markdownlint-cli2` via one-off Node.js containers (no local installation needed)

3. **WARP.md Documentation Rule**
   - Added comprehensive "Documentation: Markdown Quality" section
   - Complete 5-step workflow: Create → Lint → Fix → Re-lint → Commit
   - Integration with existing Phase Completion Workflow
   - Examples and quick commands included

4. **README Updates**
   - Main README.md: Added markdown linting commands to Code Quality section
   - docs/README.md: Added markdown quality standards at the top

### Workflow Established

```bash
# 1. Create/edit markdown file
vim docs/new-guide.md

# 2. Lint immediately
make lint-md-file FILE="docs/new-guide.md"

# 3. Fix all violations (zero tolerance)
# ... edit file to fix issues ...

# 4. Re-lint until clean (exit code 0)
make lint-md-file FILE="docs/new-guide.md"

# 5. Commit lint-clean file
git add docs/new-guide.md
git commit -m "docs: add new guide"
```

### Commands Available

- `make lint-md` - Lint all markdown files in project
- `make lint-md-fix` - Auto-fix issues (with warning prompt)
- `make lint-md-file FILE="path/to/file.md"` - Lint specific file (relative or absolute path supported)

## Testing

- [x] Tested `lint-md-file` with relative paths ✅
- [x] Tested `lint-md-file` with absolute paths (converts to relative) ✅
- [x] Verified Docker container approach works without local Node.js ✅
- [x] Confirmed linting runs and reports violations correctly ✅

## Pre-existing Violations Note

⚠️ **Important**: This PR establishes the **workflow and tooling**, not retroactive fixes.

Current markdown files have **300+ pre-existing linting violations**:
- README.md: 96 errors
- WARP.md: 203 errors  
- docs/README.md: 8 errors
- Other documentation files: Various

**Decision**: We're bypassing strict enforcement for **this PR only** to establish the infrastructure. Going forward:
- ✅ All **NEW** markdown files must be lint-clean before commit
- ✅ All **UPDATED** markdown files should fix violations in changed sections
- 📋 Markdown cleanup backlog tracked for future dedicated PR

## Related Issues

Part of documentation quality initiative.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated (WARP.md, README.md, docs/README.md)
- [x] Makefile commands tested with both relative and absolute paths
- [x] WARP.md rule documented for future markdown work
- [x] Configuration files added (.markdownlint.jsonc, .markdownlintignore)
- [x] Pre-existing violations documented (not fixed in this PR)

## Future Work

- [ ] Create dedicated PR to fix pre-existing markdown violations (300+ errors)
- [ ] Add markdown linting to CI/CD pipeline (optional enforcement)
- [ ] Consider auto-format on save for markdown in IDE
- [ ] Update contributing guide with markdown workflow reference

## Additional Notes

This change aligns with the project's commitment to documentation quality and follows the pattern established for Python code quality (ruff linting/formatting). The workflow is now documented in WARP.md and will be followed for all future markdown work.
