### PR TITLE
fix(events): pass session to event handlers via event bus (F0.9.3)

### DIFF
--- a/src/core/container.py
+++ b/src/core/container.py
@@ -431,10 +431,11 @@ def get_event_bus() -> "EventBusProtocol":  # noqa: F821
     # Create event handlers
     logging_handler = LoggingEventHandler(logger=get_logger())
 
-    # Audit handler manages its own database sessions for audit writes.
-    # Pass database instance - handler creates audit adapter per event.
-    # This ensures proper session lifecycle (commit per audit write).
-    audit_handler = AuditEventHandler(database=get_database())
+    # Audit handler uses database session from event bus (if provided).
+    # Pass both database (fallback) and event_bus (preferred session source).
+    # This prevents "Event loop is closed" errors in tests by avoiding
+    # session creation inside event handlers.
+    audit_handler = AuditEventHandler(database=get_database(), event_bus=event_bus)
 
     email_handler = EmailEventHandler(logger=get_logger())
     session_handler = SessionEventHandler(logger=get_logger())


### PR DESCRIPTION
## F0.9.3: Audit Event Handler Session Lifecycle Fix

### Problem
AuditEventHandler was creating database sessions inside event handlers using `async with self._database.get_session()`, which caused **"Event loop is closed"** errors in 5 integration tests during teardown.

### Root Cause
Event handlers creating async database sessions violated async context lifecycle management - the session factory was invoked after the event loop context was closed in test teardown.

### Solution
Pass database session through EventBusProtocol to handlers that need it, following proper dependency injection pattern.

---

## Changes

### Protocol Layer
- **EventBusProtocol**: Added optional `session: AsyncSession | None` parameter to `publish()` signature
- Backward compatible (defaults to None)

### Infrastructure Layer
- **InMemoryEventBus**: 
  - Store session during `publish()` execution in `self._session`
  - Expose via `get_session()` method for handlers
  - Clear session in `finally` block after publish completes
- **AuditEventHandler**:
  - Accept `event_bus` in constructor (in addition to `database`)
  - Use `event_bus.get_session()` to get session (preferred)
  - Fall back to creating own session if none provided (backward compatibility)

### Container
- **get_event_bus()**: Pass `event_bus` to AuditEventHandler constructor

### Tests
- **Integration tests**: Pass session to all `event_bus.publish()` calls
- **Unit tests**: Add `mock_event_bus` fixture with `get_session()` returning None

### Documentation
- Added **Session Lifecycle Management** section to `docs/architecture/domain-events-architecture.md`
- Documents problem, solution, architecture, usage, benefits, and relationship to F0.9.1

---

## Benefits

✅ **Proper session lifecycle**: Session created by caller, passed to handlers  
✅ **No "Event loop is closed" errors**: Session lifecycle managed by caller, not handler  
✅ **Backward compatible**: Falls back to creating own session if none provided  
✅ **Aligns with F0.9.1**: Uses same separate audit session concept, just better injection  
✅ **Clean architecture**: Dependency injection pattern (not service locator)

---

## Results

### Tests
- ✅ **302/302 tests passing** (5 previously failing tests now pass):
  - `test_password_change_succeeded_creates_audit_record`
  - `test_token_refresh_failed_creates_audit_record`
  - `test_same_event_published_multiple_times`
  - `test_handlers_execute_concurrently`
  - `test_event_fields_preserved_in_audit_record`
- ✅ **Coverage: 86%** (unchanged, exceeds 85% target)

### Quality Checks
- ✅ Lint (ruff): All checks passed
- ✅ Format (ruff format): 1 file reformatted, 84 unchanged
- ✅ Type-check (mypy): No issues in 62 source files
- ✅ Markdown linting: 0 errors
- ✅ Docs build: 0 warnings (strict mode)

---

## Files Changed (7)

```
docs/architecture/domain-events-architecture.md     +109 lines
src/core/container.py                               +5/-2 lines
src/domain/protocols/event_bus_protocol.py          +9/-1 lines
src/infrastructure/events/handlers/audit_event_handler.py  +48/-15 lines
src/infrastructure/events/in_memory_event_bus.py    +50/-15 lines
tests/integration/test_domain_events_flow.py        +26/-10 lines
tests/unit/test_infrastructure_event_handlers.py    +17/-8 lines
```

**Total**: 7 files changed, 345 insertions(+), 118 deletions(-)

---

## Related

- **F0.9.1** (Separate Audit Session): Audit durability via independent session
- **F0.9.3** (This PR): Proper session lifecycle management for event handlers
- **Roadmap**: `~/starter/dashtam-feature-roadmap.md` lines 883-944

---

## Checklist

- [x] Pre-development planning completed
- [x] All tests passing (302/302)
- [x] Code quality verified (lint, format, type-check)
- [x] Documentation updated (architecture + session lifecycle)
- [x] Markdown linting clean (0 errors)
- [x] MkDocs builds clean (0 warnings, strict mode)
- [x] Conventional commit message
- [x] Feature branch pushed

Closes F0.9.3