### PR TITLE
test(session): add integration tests for RedisSessionCache

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -4,9 +4,9 @@
 
 **Companion Documents**:
 
-- `~/starter/clean-slate-reference.md` - Architecture patterns and concepts
-- `~/starter/development-checklist.md` - Mandatory feature development checklist
-- `~/starter/dashtam-feature-roadmap.md` - Feature roadmap with dependencies
+- `~/references/starter/clean-slate-reference.md` - Architecture patterns and concepts
+- `~/references/starter/development-checklist.md` - Mandatory feature development checklist
+- `~/references/starter/dashtam-feature-roadmap.md` - Feature roadmap with dependencies
 
 ---
 
@@ -41,7 +41,7 @@
 - **Test-driven**: 85%+ coverage target, all tests pass before merge
 - **Documentation-first**: Architecture decisions documented before coding
 
-**Feature Roadmap**: See `~/starter/dashtam-feature-roadmap.md` for complete 32-feature plan across 6 phases.
+**Feature Roadmap**: See `~/references/starter/dashtam-feature-roadmap.md` for complete 32-feature plan across 6 phases.
 
 ---
 
@@ -73,7 +73,7 @@
 
 #### Phase 2-6: Domain, Application, Providers, API (Planning)
 
-See `~/starter/dashtam-feature-roadmap.md` for complete breakdown.
+See `~/references/starter/dashtam-feature-roadmap.md` for complete breakdown.
 
 **Total**: 32 features across 6 phases.
 
@@ -88,7 +88,7 @@ See `~/starter/dashtam-feature-roadmap.md` for complete breakdown.
 **Development approach**:
 
 - Feature-by-feature following roadmap dependencies
-- Each feature uses `~/starter/development-checklist.md` (mandatory)
+- Each feature uses `~/references/starter/development-checklist.md` (mandatory)
 - Pre-development approval required before coding
 - Test coverage ≥85% for each feature
 
@@ -176,7 +176,7 @@ class UserRepository:
 - Easy to swap implementations (Postgres → MongoDB)
 - Framework upgrades don't break domain
 
-**Reference**: See `~/starter/clean-slate-reference.md` for detailed hexagonal architecture guide.
+**Reference**: See `~/references/starter/clean-slate-reference.md` for detailed hexagonal architecture guide.
 
 ---
 
@@ -254,7 +254,7 @@ match create_user(email):
         return {"error": error.message}, 400
 ```
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 1 for complete Python patterns guide.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 1 for complete Python patterns guide.
 
 ---
 
@@ -345,7 +345,7 @@ async def revoke_sessions(event: UserPasswordChanged):
     await token_service.revoke_all_sessions(event.user_id)
 ```
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 10 for domain events architecture.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 10 for domain events architecture.
 
 ---
 
@@ -432,7 +432,7 @@ Only use when operation is genuinely an action, not a resource state change.
 
 **Reference**: See `docs/development/architecture/restful-api-design.md` for complete REST standards.
 
-**Enforcement**: See `~/starter/development-checklist.md` Section 18 (REST API Compliance) - mandatory verification.
+**Enforcement**: See `~/references/starter/development-checklist.md` Section 18 (REST API Compliance) - mandatory verification.
 
 ---
 
@@ -440,7 +440,7 @@ Only use when operation is genuinely an action, not a resource state change.
 
 ### 7. Feature Development Process
 
-**CRITICAL**: ALL feature development MUST follow `~/starter/development-checklist.md` workflow.
+**CRITICAL**: ALL feature development MUST follow `~/references/starter/development-checklist.md` workflow.
 
 **Two-Phase Process**:
 
@@ -528,7 +528,7 @@ DO NOT CODE without user approval.
 - `mark_todo_as_done` - Check off items as completed
 - `read_todos` - Check current progress
 
-**Reference**: See `~/starter/development-checklist.md` for complete 31-section checklist.
+**Reference**: See `~/references/starter/development-checklist.md` for complete 31-section checklist.
 
 ---
 
@@ -642,20 +642,20 @@ BREAKING CHANGE: Auth endpoint moved from /auth to /api/v1/auth"
 **Test Pyramid Approach**:
 
 ```text
-        ▲
-       ╱│╲
-      ╱ │ ╲     10% E2E (Smoke Tests)
-     ╱  │  ╲    - Complete user flows
-    ╱───┼───╲   - Registration → Login → Logout
-   ╱    │    ╲
-  ╱     │     ╲  20% Integration Tests
- ╱      │      ╲ - Database operations
-╱───────┼───────╲ - Service interactions
-        │
-        │        70% Unit Tests
-        │        - Domain entities
-        │        - Command/Query handlers
-        │        - Services (isolated)
+             ▲
+            ╱ ╲
+           ╱   ╲ 10% E2E (Smoke Tests)
+          ╱     ╲ - Complete user flows
+         ╱───────╲ - Registration → Login → Logout
+        ╱         ╲
+       ╱           ╲ 20% Integration Tests
+      ╱             ╲ - Database operations
+     ╱───────────────╲ - Service interactions
+    ╱                 ╲
+   ╱                   ╲ 70% Unit Tests
+  ╱                     ╲ - Domain entities
+ ╱                       ╲ - Command/Query handlers
+╱                         ╲ - Services (isolated)
 ```
 
 #### Unit Tests (70%)
@@ -766,7 +766,7 @@ make test-verify
 - Different ports (8001, 5433, 6380)
 - No port conflicts with dev environment
 
-**Reference**: See `~/starter/development-checklist.md` Section 10 (Testing) for comprehensive testing guide.
+**Reference**: See `~/references/starter/development-checklist.md` Section 10 (Testing) for comprehensive testing guide.
 
 ---
 
@@ -888,7 +888,7 @@ make test-down    # Stop test environment
 - Proper file ownership (appuser:appuser)
 - Health checks for all services
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 7 (Docker & Environments) for complete Docker architecture.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 7 (Docker & Environments) for complete Docker architecture.
 
 ---
 
@@ -1010,7 +1010,7 @@ test-up: traefik-up
 
 **Result**: `make dev-up` automatically starts Traefik first (idempotent).
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 9 (Traefik Reverse Proxy) for detailed Traefik architecture.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 9 (Traefik Reverse Proxy) for detailed Traefik architecture.
 
 ---
 
@@ -1104,7 +1104,7 @@ services:
     #   SECRET_KEY: hardcoded-value
 ```
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 8 (Secrets Management) for complete secrets architecture.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 8 (Secrets Management) for complete secrets architecture.
 
 ---
 
@@ -1243,7 +1243,7 @@ await audit_service.record(
 
 **Retention**: 7 years minimum (PCI-DSS requirement)
 
-**Reference**: See `~/starter/clean-slate-reference.md` Section 11 (Logging & Audit) for complete logging architecture.
+**Reference**: See `~/references/starter/clean-slate-reference.md` Section 11 (Logging & Audit) for complete logging architecture.
 
 ---
 
@@ -1648,7 +1648,7 @@ Brief description of the feature and its purpose.
 
 ```markdown
 
-**Reference**: See `~/starter/clean-slate-reference.md` for comprehensive architecture documentation examples.
+**Reference**: See `~/references/starter/clean-slate-reference.md` for comprehensive architecture documentation examples.
 
 ---
 
@@ -1660,7 +1660,7 @@ Brief description of the feature and its purpose.
 
 #### Mandatory Checklist Workflow
 
-**Two-phase process** (from `~/starter/development-checklist.md`):
+**Two-phase process** (from `~/references/starter/development-checklist.md`):
 
 **Phase 1: Pre-Development (Planning & Approval)**
 
@@ -1688,7 +1688,7 @@ Brief description of the feature and its purpose.
 10. Final verification (all tests, docs, linting)
 11. Commit with conventional commits
 
-**Reference**: See `~/starter/development-checklist.md` for complete 31-section checklist.
+**Reference**: See `~/references/starter/development-checklist.md` for complete 31-section checklist.
 
 #### TODO List Management
 
@@ -1863,7 +1863,7 @@ async def create_user(
 
 **Process**:
 
-1. ✅ **ALWAYS use development checklist** (`~/starter/development-checklist.md`)
+1. ✅ **ALWAYS use development checklist** (`~/references/starter/development-checklist.md`)
 2. ✅ **Pre-development phase first** - Analyze → Plan → Present → Get approval
 3. ✅ **❌ NEVER code without user approval** of TODO list
 4. ✅ **Use TODO tools** - Track progress across long features
@@ -1902,16 +1902,3 @@ async def create_user(
 ---
 
 **Last Updated**: 2025-11-08  
-**Status**: ✅ Clean slate WARP.md COMPLETE (All 6 parts)  
-**Total Lines**: ~1,700 (43% reduction from 2,574 lines)
-
-**Changes from old WARP.md**:
-
-- ✅ Removed 800+ lines of duplicates (Feature Integration Checklist appeared twice)
-- ✅ Removed outdated Warp terminal bug workarounds (heredoc, quote escaping)
-- ✅ Removed old implementation patterns (ABC, old error handling)
-- ✅ Added references to all ~/starter/ documents
-- ✅ Reorganized into 6 logical parts
-- ✅ Focused on clean slate architecture (no legacy technical debt)
-- ✅ Emphasized mandatory checklist workflow
-- ✅ Updated all patterns to Python 3.13+ standards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,10 @@ module = [
     "asyncpg.*",
 ]
 ignore_missing_imports = true
+
+# Test files: relax strict typing (common practice)
+# Test functions are simple, pytest fixtures are hard to annotate properly
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disallow_untyped_defs = false
+disallow_untyped_decorators = false

--- a/tests/integration/test_session_cache.py
+++ b/tests/integration/test_session_cache.py
@@ -1,0 +1,552 @@
+"""Integration tests for Redis session cache.
+
+Tests the RedisSessionCache implementation against a real Redis instance.
+Following F0.4/F0.5 patterns: NO unit tests for infrastructure adapters,
+only integration tests that verify real Redis operations.
+
+Architecture:
+- Tests against real Redis (not mocked)
+- Uses test environment Redis (database 1)
+- Tests all SessionCache protocol methods
+- Verifies session data serialization/deserialization
+- Uses fresh Redis connections per test (bypasses singleton)
+
+Reference:
+    - docs/architecture/session-management-architecture.md
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.domain.protocols.session_repository import SessionData
+
+
+def create_test_session_data(  # type: ignore[no-untyped-def]
+    session_id=None,
+    user_id=None,
+    device_info="Chrome on Windows",
+    user_agent="Mozilla/5.0 Chrome/120.0",
+    ip_address="192.168.1.1",
+    location="New York, US",
+    is_revoked=False,
+    is_trusted=False,
+    expires_at=None,
+    refresh_token_id=None,
+) -> SessionData:
+    """Create test SessionData with sensible defaults."""
+    now = datetime.now(UTC)
+    return SessionData(
+        id=session_id or uuid4(),
+        user_id=user_id or uuid4(),
+        device_info=device_info,
+        user_agent=user_agent,
+        ip_address=ip_address,
+        location=location,
+        created_at=now,
+        last_activity_at=now,
+        expires_at=expires_at or (now + timedelta(days=30)),
+        is_revoked=is_revoked,
+        is_trusted=is_trusted,
+        revoked_at=None,
+        revoked_reason=None,
+        refresh_token_id=refresh_token_id,
+        last_ip_address=ip_address,
+        suspicious_activity_count=0,
+        last_provider_accessed=None,
+        last_provider_sync_at=None,
+        providers_accessed=None,
+    )
+
+
+@pytest.mark.integration
+class TestSessionCacheGetSet:
+    """Test session cache get and set operations."""
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_session(self, session_cache):
+        """Test storing and retrieving session data."""
+        # Arrange
+        session_data = create_test_session_data()
+
+        # Act
+        await session_cache.set(session_data)
+        result = await session_cache.get(session_data.id)
+
+        # Assert
+        assert result is not None
+        assert result.id == session_data.id
+        assert result.user_id == session_data.user_id
+        assert result.device_info == session_data.device_info
+        assert result.ip_address == session_data.ip_address
+        assert result.location == session_data.location
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_session_returns_none(self, session_cache):
+        """Test getting a session that doesn't exist returns None."""
+        result = await session_cache.get(uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_set_with_explicit_ttl(self, session_cache, cache_adapter):
+        """Test setting session with explicit TTL."""
+        # Arrange
+        session_data = create_test_session_data()
+        ttl_seconds = 60
+
+        # Act
+        await session_cache.set(session_data, ttl_seconds=ttl_seconds)
+
+        # Assert - verify TTL is set
+        key = f"session:{session_data.id}"
+        ttl_result = await cache_adapter.ttl(key)
+        assert ttl_result.value is not None
+        assert 0 < ttl_result.value <= ttl_seconds
+
+    @pytest.mark.asyncio
+    async def test_set_calculates_ttl_from_expires_at(
+        self, session_cache, cache_adapter
+    ):
+        """Test TTL is calculated from session expires_at if not provided."""
+        # Arrange
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        session_data = create_test_session_data(expires_at=expires_at)
+
+        # Act
+        await session_cache.set(session_data)
+
+        # Assert - TTL should be approximately 1 hour
+        key = f"session:{session_data.id}"
+        ttl_result = await cache_adapter.ttl(key)
+        assert ttl_result.value is not None
+        # Allow some tolerance (3595-3600 seconds)
+        assert 3500 < ttl_result.value <= 3600
+
+    @pytest.mark.asyncio
+    async def test_set_session_adds_to_user_index(self, session_cache):
+        """Test that set() adds session to user's session index."""
+        # Arrange
+        user_id = uuid4()
+        session_data = create_test_session_data(user_id=user_id)
+
+        # Act
+        await session_cache.set(session_data)
+
+        # Assert
+        user_session_ids = await session_cache.get_user_session_ids(user_id)
+        assert session_data.id in user_session_ids
+
+    @pytest.mark.asyncio
+    async def test_session_data_serialization_all_fields(self, session_cache):
+        """Test all SessionData fields are properly serialized/deserialized."""
+        # Arrange - session with all fields populated
+        now = datetime.now(UTC)
+        refresh_token_id = uuid4()
+        session_data = SessionData(
+            id=uuid4(),
+            user_id=uuid4(),
+            device_info="Safari on macOS",
+            user_agent="Mozilla/5.0 Safari/605.1.15",
+            ip_address="10.0.0.1",
+            location="San Francisco, US",
+            created_at=now,
+            last_activity_at=now,
+            expires_at=now + timedelta(days=7),
+            is_revoked=False,
+            is_trusted=True,
+            revoked_at=None,
+            revoked_reason=None,
+            refresh_token_id=refresh_token_id,
+            last_ip_address="10.0.0.2",
+            suspicious_activity_count=3,
+            last_provider_accessed="schwab",
+            last_provider_sync_at=now,
+            providers_accessed=["schwab", "fidelity"],
+        )
+
+        # Act
+        await session_cache.set(session_data)
+        result = await session_cache.get(session_data.id)
+
+        # Assert - all fields preserved
+        assert result is not None
+        assert result.id == session_data.id
+        assert result.user_id == session_data.user_id
+        assert result.device_info == session_data.device_info
+        assert result.user_agent == session_data.user_agent
+        assert result.ip_address == session_data.ip_address
+        assert result.location == session_data.location
+        assert result.is_trusted == session_data.is_trusted
+        assert result.refresh_token_id == refresh_token_id
+        assert result.last_ip_address == session_data.last_ip_address
+        assert (
+            result.suspicious_activity_count == session_data.suspicious_activity_count
+        )
+        assert result.last_provider_accessed == session_data.last_provider_accessed
+        assert result.providers_accessed == session_data.providers_accessed
+
+
+@pytest.mark.integration
+class TestSessionCacheDelete:
+    """Test session cache delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_session(self, session_cache):
+        """Test deleting an existing session returns True."""
+        # Arrange
+        session_data = create_test_session_data()
+        await session_cache.set(session_data)
+
+        # Act
+        result = await session_cache.delete(session_data.id)
+
+        # Assert
+        assert result is True
+
+        # Verify deleted
+        get_result = await session_cache.get(session_data.id)
+        assert get_result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_session_returns_false(self, session_cache):
+        """Test deleting nonexistent session returns False."""
+        result = await session_cache.delete(uuid4())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_all_for_user(self, session_cache):
+        """Test deleting all sessions for a user."""
+        # Arrange - create multiple sessions for same user
+        user_id = uuid4()
+        session1 = create_test_session_data(user_id=user_id)
+        session2 = create_test_session_data(user_id=user_id)
+        session3 = create_test_session_data(user_id=user_id)
+
+        await session_cache.set(session1)
+        await session_cache.set(session2)
+        await session_cache.set(session3)
+
+        # Verify all sessions exist
+        assert await session_cache.get(session1.id) is not None
+        assert await session_cache.get(session2.id) is not None
+        assert await session_cache.get(session3.id) is not None
+
+        # Act
+        deleted_count = await session_cache.delete_all_for_user(user_id)
+
+        # Assert
+        assert deleted_count == 3
+
+        # Verify all deleted
+        assert await session_cache.get(session1.id) is None
+        assert await session_cache.get(session2.id) is None
+        assert await session_cache.get(session3.id) is None
+
+        # Verify user index is empty
+        user_sessions = await session_cache.get_user_session_ids(user_id)
+        assert len(user_sessions) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_all_for_user_with_no_sessions(self, session_cache):
+        """Test delete_all_for_user with user having no sessions."""
+        result = await session_cache.delete_all_for_user(uuid4())
+        assert result == 0
+
+
+@pytest.mark.integration
+class TestSessionCacheExists:
+    """Test session cache exists operation."""
+
+    @pytest.mark.asyncio
+    async def test_exists_returns_true_for_existing_session(self, session_cache):
+        """Test exists returns True for cached session."""
+        # Arrange
+        session_data = create_test_session_data()
+        await session_cache.set(session_data)
+
+        # Act
+        result = await session_cache.exists(session_data.id)
+
+        # Assert
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_exists_returns_false_for_nonexistent_session(self, session_cache):
+        """Test exists returns False for non-cached session."""
+        result = await session_cache.exists(uuid4())
+        assert result is False
+
+
+@pytest.mark.integration
+class TestSessionCacheUserIndex:
+    """Test session cache user session index operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_user_session_ids_returns_all_sessions(self, session_cache):
+        """Test getting all session IDs for a user."""
+        # Arrange
+        user_id = uuid4()
+        session1 = create_test_session_data(user_id=user_id)
+        session2 = create_test_session_data(user_id=user_id)
+
+        await session_cache.set(session1)
+        await session_cache.set(session2)
+
+        # Act
+        session_ids = await session_cache.get_user_session_ids(user_id)
+
+        # Assert
+        assert len(session_ids) == 2
+        assert session1.id in session_ids
+        assert session2.id in session_ids
+
+    @pytest.mark.asyncio
+    async def test_get_user_session_ids_returns_empty_for_unknown_user(
+        self, session_cache
+    ):
+        """Test getting session IDs for user with no sessions."""
+        result = await session_cache.get_user_session_ids(uuid4())
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_add_user_session(self, session_cache):
+        """Test adding session to user index directly."""
+        # Arrange
+        user_id = uuid4()
+        session_id = uuid4()
+
+        # Act
+        await session_cache.add_user_session(user_id, session_id)
+
+        # Assert
+        session_ids = await session_cache.get_user_session_ids(user_id)
+        assert session_id in session_ids
+
+    @pytest.mark.asyncio
+    async def test_add_user_session_idempotent(self, session_cache):
+        """Test adding same session twice doesn't duplicate."""
+        # Arrange
+        user_id = uuid4()
+        session_id = uuid4()
+
+        # Act - add twice
+        await session_cache.add_user_session(user_id, session_id)
+        await session_cache.add_user_session(user_id, session_id)
+
+        # Assert - only one entry
+        session_ids = await session_cache.get_user_session_ids(user_id)
+        assert len(session_ids) == 1
+        assert session_id in session_ids
+
+    @pytest.mark.asyncio
+    async def test_remove_user_session(self, session_cache):
+        """Test removing session from user index."""
+        # Arrange
+        user_id = uuid4()
+        session_id1 = uuid4()
+        session_id2 = uuid4()
+
+        await session_cache.add_user_session(user_id, session_id1)
+        await session_cache.add_user_session(user_id, session_id2)
+
+        # Act
+        await session_cache.remove_user_session(user_id, session_id1)
+
+        # Assert
+        session_ids = await session_cache.get_user_session_ids(user_id)
+        assert session_id1 not in session_ids
+        assert session_id2 in session_ids
+
+    @pytest.mark.asyncio
+    async def test_remove_last_user_session_clears_index(self, session_cache):
+        """Test removing last session clears the user index key."""
+        # Arrange
+        user_id = uuid4()
+        session_id = uuid4()
+        await session_cache.add_user_session(user_id, session_id)
+
+        # Act
+        await session_cache.remove_user_session(user_id, session_id)
+
+        # Assert
+        session_ids = await session_cache.get_user_session_ids(user_id)
+        assert len(session_ids) == 0
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_session_from_user_index(self, session_cache):
+        """Test removing non-existent session from user index is safe."""
+        # Arrange
+        user_id = uuid4()
+        existing_session = uuid4()
+        nonexistent_session = uuid4()
+        await session_cache.add_user_session(user_id, existing_session)
+
+        # Act - should not raise
+        await session_cache.remove_user_session(user_id, nonexistent_session)
+
+        # Assert - existing session still there
+        session_ids = await session_cache.get_user_session_ids(user_id)
+        assert existing_session in session_ids
+
+
+@pytest.mark.integration
+class TestSessionCacheUpdateActivity:
+    """Test session cache update_last_activity operation."""
+
+    @pytest.mark.asyncio
+    async def test_update_last_activity_updates_timestamp(self, session_cache):
+        """Test update_last_activity updates the last_activity_at field."""
+        # Arrange
+        old_time = datetime.now(UTC) - timedelta(hours=1)
+        session_data = SessionData(
+            id=uuid4(),
+            user_id=uuid4(),
+            device_info="Chrome on Windows",
+            user_agent="Mozilla/5.0",
+            ip_address="192.168.1.1",
+            location="New York, US",
+            created_at=old_time,
+            last_activity_at=old_time,
+            expires_at=datetime.now(UTC) + timedelta(days=30),
+            is_revoked=False,
+            is_trusted=False,
+            revoked_at=None,
+            revoked_reason=None,
+            refresh_token_id=None,
+            last_ip_address="192.168.1.1",
+            suspicious_activity_count=0,
+            last_provider_accessed=None,
+            last_provider_sync_at=None,
+            providers_accessed=None,
+        )
+        await session_cache.set(session_data)
+
+        # Act
+        result = await session_cache.update_last_activity(session_data.id)
+
+        # Assert
+        assert result is True
+
+        # Verify timestamp updated
+        updated = await session_cache.get(session_data.id)
+        assert updated is not None
+        assert updated.last_activity_at > old_time
+
+    @pytest.mark.asyncio
+    async def test_update_last_activity_updates_ip_address(self, session_cache):
+        """Test update_last_activity can update last_ip_address."""
+        # Arrange
+        session_data = create_test_session_data(ip_address="192.168.1.1")
+        await session_cache.set(session_data)
+
+        # Act
+        new_ip = "10.0.0.1"
+        result = await session_cache.update_last_activity(
+            session_data.id, ip_address=new_ip
+        )
+
+        # Assert
+        assert result is True
+
+        # Verify IP updated
+        updated = await session_cache.get(session_data.id)
+        assert updated is not None
+        assert updated.last_ip_address == new_ip
+
+    @pytest.mark.asyncio
+    async def test_update_last_activity_nonexistent_returns_false(self, session_cache):
+        """Test update_last_activity on non-cached session returns False."""
+        result = await session_cache.update_last_activity(uuid4())
+        assert result is False
+
+
+@pytest.mark.integration
+class TestSessionCacheEdgeCases:
+    """Test edge cases and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_session_with_none_optional_fields(self, session_cache):
+        """Test session with None optional fields is handled correctly."""
+        # Arrange - session with minimal data
+        session_data = SessionData(
+            id=uuid4(),
+            user_id=uuid4(),
+            device_info=None,
+            user_agent=None,
+            ip_address=None,
+            location=None,
+            created_at=None,
+            last_activity_at=None,
+            expires_at=None,
+            is_revoked=False,
+            is_trusted=False,
+            revoked_at=None,
+            revoked_reason=None,
+            refresh_token_id=None,
+            last_ip_address=None,
+            suspicious_activity_count=0,
+            last_provider_accessed=None,
+            last_provider_sync_at=None,
+            providers_accessed=None,
+        )
+
+        # Act
+        await session_cache.set(session_data)
+        result = await session_cache.get(session_data.id)
+
+        # Assert
+        assert result is not None
+        assert result.id == session_data.id
+        assert result.device_info is None
+        assert result.location is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_users_sessions_isolated(self, session_cache):
+        """Test sessions for different users are properly isolated."""
+        # Arrange
+        user1_id = uuid4()
+        user2_id = uuid4()
+
+        user1_session = create_test_session_data(user_id=user1_id)
+        user2_session = create_test_session_data(user_id=user2_id)
+
+        await session_cache.set(user1_session)
+        await session_cache.set(user2_session)
+
+        # Act
+        user1_sessions = await session_cache.get_user_session_ids(user1_id)
+        user2_sessions = await session_cache.get_user_session_ids(user2_id)
+
+        # Assert - each user only sees their own sessions
+        assert len(user1_sessions) == 1
+        assert len(user2_sessions) == 1
+        assert user1_session.id in user1_sessions
+        assert user2_session.id in user2_sessions
+        assert user1_session.id not in user2_sessions
+        assert user2_session.id not in user1_sessions
+
+    @pytest.mark.asyncio
+    async def test_delete_user_sessions_does_not_affect_other_users(
+        self, session_cache
+    ):
+        """Test delete_all_for_user doesn't affect other users' sessions."""
+        # Arrange
+        user1_id = uuid4()
+        user2_id = uuid4()
+
+        user1_session = create_test_session_data(user_id=user1_id)
+        user2_session = create_test_session_data(user_id=user2_id)
+
+        await session_cache.set(user1_session)
+        await session_cache.set(user2_session)
+
+        # Act - delete user1's sessions
+        await session_cache.delete_all_for_user(user1_id)
+
+        # Assert - user2's session still exists
+        assert await session_cache.get(user1_session.id) is None
+        assert await session_cache.get(user2_session.id) is not None
+
+        user2_sessions = await session_cache.get_user_session_ids(user2_id)
+        assert user2_session.id in user2_sessions


### PR DESCRIPTION
## Summary
Add integration tests for RedisSessionCache to fill the testing gap identified in F1.3 Session Management.

## Changes
- **New file**: `tests/integration/test_session_cache.py` - 25 integration tests
- **conftest.py**: Added `session_cache` fixture + fixed `Success()` syntax bug
- **pyproject.toml**: Added mypy override to relax strict typing for test files
- **WARP.md**: Minor updates

## Test Coverage Added
| Method | Tests |
|--------|-------|
| `get()` / `set()` | Session data storage and retrieval, TTL handling |
| `delete()` / `delete_all_for_user()` | Session removal |
| `exists()` | Quick existence check |
| User index operations | `get_user_session_ids`, `add_user_session`, `remove_user_session` |
| `update_last_activity()` | Activity timestamp and IP updates |
| Edge cases | None fields, user isolation, serialization |

## Testing
- All 538 tests pass
- mypy passes
- ruff lint/format passes