### PR TITLE
feat(domain): F2.1 - Provider Connection Domain Model

### DIFF
--- a/docs/architecture/provider-domain-model.md
+++ b/docs/architecture/provider-domain-model.md
@@ -1,0 +1,405 @@
+# Provider Domain Model Architecture
+
+Provider Connection Domain Model - the foundation for multi-provider financial data aggregation.
+
+---
+
+## Overview
+
+The Provider Connection domain model represents the relationship between a user and a financial data provider (Schwab, Chase, Plaid, etc.). This model is **authentication-agnostic** - the domain layer has no knowledge of OAuth, API keys, or other authentication mechanisms.
+
+### Core Principle
+
+> The domain cares about CONNECTION STATE, not authentication mechanics. Infrastructure layer handles provider-specific authentication details.
+
+### Design Goals
+
+1. **Authentication Agnostic**: Support OAuth2, API keys, Link tokens, certificates without domain changes
+2. **Provider Extensible**: Adding new providers requires only infrastructure adapters
+3. **Domain Purity**: Zero framework or authentication imports in domain layer
+4. **Credential Security**: Encrypted opaque blobs - domain never sees raw credentials
+
+---
+
+## Domain Model
+
+### Entity: ProviderConnection
+
+```text
+ProviderConnection
+├── id: UUID                           # Unique identifier
+├── user_id: UUID                      # Owning user
+├── provider_id: UUID                  # FK to Provider registry
+├── provider_slug: str                 # Denormalized ("schwab") for logging/display
+├── alias: str | None                  # User-friendly name ("My Schwab IRA")
+├── status: ConnectionStatus           # PENDING, ACTIVE, EXPIRED, etc.
+├── credentials: ProviderCredentials | None  # Encrypted, opaque
+├── connected_at: datetime | None      # When connection established
+├── last_sync_at: datetime | None      # Last successful data sync
+├── created_at: datetime               # Record creation
+└── updated_at: datetime               # Last modification
+```
+
+### Business Methods
+
+All state transition methods return `Result[None, str]` (Railway-Oriented Programming). Handlers create domain events, not the entity.
+
+```python
+class ProviderConnection:
+    # Query methods (read-only)
+    def is_connected(self) -> bool:
+        """Connection is active and credentials valid."""
+    
+    def needs_reauthentication(self) -> bool:
+        """Credentials expired, revoked, or require refresh."""
+    
+    def is_credentials_expired(self) -> bool:
+        """Check if credentials have passed expiration time."""
+    
+    def can_sync(self) -> bool:
+        """Check if connection can perform data synchronization."""
+    
+    # State transition methods (return Result)
+    def mark_connected(self, credentials: ProviderCredentials) -> Result[None, str]:
+        """Transition to ACTIVE with new credentials."""
+    
+    def mark_disconnected(self) -> Result[None, str]:
+        """Transition to DISCONNECTED (terminal state)."""
+    
+    def mark_expired(self) -> Result[None, str]:
+        """Transition to EXPIRED when credentials no longer valid."""
+    
+    def mark_revoked(self) -> Result[None, str]:
+        """Transition to REVOKED when user/provider revokes access."""
+    
+    def mark_failed(self) -> Result[None, str]:
+        """Transition to FAILED when authentication fails."""
+    
+    def update_credentials(self, credentials: ProviderCredentials) -> Result[None, str]:
+        """Update credentials (e.g., after token refresh)."""
+    
+    def record_sync(self) -> Result[None, str]:
+        """Update last_sync_at timestamp after successful data sync."""
+```
+
+### State Machine
+
+```text
+                    ┌─────────────────────────────────────────┐
+                    │                                         │
+                    ▼                                         │
+┌─────────┐   auth success   ┌─────────┐   credentials    ┌─────────┐
+│ PENDING │ ───────────────► │ ACTIVE  │ ───────────────► │ EXPIRED │
+└─────────┘                  └─────────┘   expired        └─────────┘
+     │                            │                            │
+     │ auth failed                │ user/provider              │ re-auth
+     │ or timeout                 │ revokes                    │ success
+     ▼                            ▼                            │
+┌─────────┐                  ┌─────────┐                       │
+│ FAILED  │                  │ REVOKED │                       │
+└─────────┘                  └─────────┘                       │
+     │                            │                            │
+     │                            │                            │
+     ▼                            ▼                            │
+┌──────────────────────────────────────────────────────────────┘
+│                    DISCONNECTED
+│  (terminal state - user explicitly removes connection)
+└──────────────────────────────────────────────────────────────
+```
+
+---
+
+## Value Objects
+
+### ProviderCredentials (Authentication-Agnostic)
+
+```python
+@dataclass(frozen=True)
+class ProviderCredentials:
+    """Encrypted, opaque credential storage.
+    
+    Domain layer treats this as an opaque blob. Only infrastructure
+    layer understands the internal format based on credential_type.
+    
+    Examples:
+    - OAuth2: {"access_token": "...", "refresh_token": "...", "token_type": "Bearer"}
+    - API Key: {"api_key": "...", "api_secret": "..."}
+    - Link Token: {"access_token": "...", "item_id": "..."}
+    """
+    encrypted_data: bytes           # Encrypted credential blob
+    credential_type: CredentialType # Routing hint for infrastructure
+    expires_at: datetime | None     # When credentials expire (None = never)
+    
+    def is_expired(self) -> bool:
+        """Check if credentials have expired."""
+    
+    def time_until_expiry(self) -> timedelta | None:
+        """Time remaining until expiration."""
+```
+
+**Why opaque?** The domain doesn't need to know if we're storing OAuth tokens, API keys, or anything else. This allows:
+
+- Adding new auth mechanisms without domain changes
+- Provider-specific credential formats
+- Future-proofing for unknown auth types
+
+---
+
+## Provider Identification
+
+Providers are dynamic entities managed via a registry rather than hardcoded enums. This allows adding new providers through configuration without code changes.
+
+### Domain Layer Reference
+
+```python
+class ProviderConnection:
+    provider_id: UUID    # FK to Provider registry
+    provider_slug: str   # Denormalized for logging/display ("schwab")
+```
+
+### Infrastructure Layer Registry
+
+```python
+class Provider:  # Stored in DB or config
+    id: UUID
+    slug: str            # "schwab", "chase" (unique, URL-safe)
+    name: str            # "Charles Schwab", "Chase Bank"
+    credential_type: CredentialType
+    is_active: bool
+
+class ProviderRegistry(Protocol):
+    def get_by_id(self, provider_id: UUID) -> Provider | None: ...
+    def get_by_slug(self, slug: str) -> Provider | None: ...
+    def list_available(self) -> list[Provider]: ...
+    def get_credential_handler(self, provider_id: UUID) -> CredentialHandler: ...
+```
+
+---
+
+## Enums
+
+### ConnectionStatus
+
+```python
+class ConnectionStatus(str, Enum):
+    """Provider connection lifecycle states."""
+    PENDING = "pending"           # Auth initiated, awaiting completion
+    ACTIVE = "active"             # Connected and credentials valid
+    EXPIRED = "expired"           # Credentials expired, needs re-auth
+    REVOKED = "revoked"           # Access revoked by user or provider
+    FAILED = "failed"             # Authentication failed
+    DISCONNECTED = "disconnected" # User explicitly disconnected
+```
+
+### CredentialType
+
+```python
+class CredentialType(str, Enum):
+    """Authentication mechanism type - used by infrastructure layer."""
+    OAUTH2 = "oauth2"             # OAuth 2.0 (Schwab, most brokerages)
+    API_KEY = "api_key"           # Simple API key authentication
+    LINK_TOKEN = "link_token"     # Plaid-style link tokens
+    CERTIFICATE = "certificate"   # mTLS certificate-based auth
+    CUSTOM = "custom"             # Provider-specific custom auth
+```
+
+---
+
+## Domain Events
+
+Three workflows × three states = 9 events following the ATTEMPT → OUTCOME pattern.
+
+### Connection Events
+
+```python
+# Workflow: User initiates provider connection
+ProviderConnectionAttempted   # Before auth flow starts
+ProviderConnectionSucceeded   # After successful auth + credential storage
+ProviderConnectionFailed      # Auth failed or user cancelled
+```
+
+### Disconnection Events
+
+```python
+# Workflow: User disconnects provider
+ProviderDisconnectionAttempted  # Before disconnection process
+ProviderDisconnectionSucceeded  # After successful disconnection
+ProviderDisconnectionFailed     # Disconnection failed (rare)
+```
+
+### Token Refresh Events
+
+```python
+# Workflow: System refreshes expiring credentials
+ProviderTokenRefreshAttempted   # Before credential refresh
+ProviderTokenRefreshSucceeded   # After successful refresh
+ProviderTokenRefreshFailed      # Refresh failed, may need re-auth
+```
+
+### Event Data
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class ProviderConnectionSucceeded(DomainEvent):
+    """Emitted after successful provider connection."""
+    connection_id: UUID
+    user_id: UUID
+    provider_id: UUID
+    provider_slug: str  # For logging/audit without lookup
+    # Note: Never include credentials in events
+```
+
+---
+
+## Repository Protocol
+
+```python
+class ProviderConnectionRepository(Protocol):
+    """Port for provider connection persistence."""
+    
+    async def find_by_id(self, connection_id: UUID) -> ProviderConnection | None:
+        """Find connection by ID."""
+        ...
+    
+    async def find_by_user_id(self, user_id: UUID) -> list[ProviderConnection]:
+        """Find all connections for a user."""
+        ...
+    
+    async def find_by_user_and_provider(
+        self, 
+        user_id: UUID, 
+        provider_id: UUID,
+    ) -> list[ProviderConnection]:
+        """Find all connections for user + provider (user may have multiple)."""
+        ...
+    
+    async def find_active_by_user(self, user_id: UUID) -> list[ProviderConnection]:
+        """Find all active connections for a user."""
+        ...
+    
+    async def save(self, connection: ProviderConnection) -> None:
+        """Persist connection (insert or update)."""
+        ...
+    
+    async def delete(self, connection_id: UUID) -> None:
+        """Remove connection record."""
+        ...
+```
+
+---
+
+## Layer Responsibilities
+
+### Domain Layer (This Feature)
+
+- Entity with business methods and state transitions (returns Result types)
+- Value objects for type safety
+- Domain events for audit/side effects (handlers create events, not entity)
+- Repository protocol (port)
+- Error constants for ROP pattern
+- **NO knowledge of OAuth, API keys, encryption**
+
+### Application Layer
+
+- Commands: `ConnectProvider`, `DisconnectProvider`, `RefreshProviderCredentials`
+- Queries: `GetProviderConnection`, `ListUserProviders`
+- Event handlers for logging, audit, notifications
+
+### Infrastructure Layer
+
+- `PostgresProviderConnectionRepository` - Persistence adapter
+- Provider-specific credential handlers:
+  - `SchwabOAuthHandler` - OAuth2 flow + token encryption
+  - `PlaidLinkHandler` - Link token management (future)
+  - `ChaseApiHandler` - API key management (future)
+- Encryption service for credential storage
+
+---
+
+## File Structure
+
+```text
+src/domain/
+├── entities/
+│   └── provider_connection.py      # ProviderConnection entity
+├── value_objects/
+│   └── provider_credentials.py     # ProviderCredentials value object
+├── enums/
+│   ├── connection_status.py        # ConnectionStatus enum
+│   └── credential_type.py          # CredentialType enum
+├── errors/
+│   └── provider_connection_error.py  # Error constants for ROP
+├── events/
+│   └── provider_events.py          # 9 provider domain events
+└── protocols/
+    └── provider_connection_repository.py  # Repository protocol
+
+tests/unit/
+├── test_domain_provider_connection.py     # Entity tests
+├── test_domain_provider_credentials.py    # Value object tests
+└── test_domain_provider_events.py         # Event tests
+```
+
+**Note**: `ProviderType` enum removed - providers are dynamic via registry (F4.x).
+
+---
+
+## Validation Rules
+
+### ProviderConnection
+
+- `id`: Required, valid UUID
+- `user_id`: Required, valid UUID
+- `provider_id`: Required, valid UUID (references Provider registry)
+- `provider_slug`: Required, non-empty string (denormalized from Provider)
+- `alias`: Optional, max 100 characters
+- `status`: Required, valid ConnectionStatus
+- `credentials`: Required when status is ACTIVE
+
+### ProviderCredentials
+
+- `encrypted_data`: Required, non-empty bytes
+- `credential_type`: Required, valid CredentialType
+- `expires_at`: Optional, must be future datetime if provided
+
+### State Transition Rules
+
+- PENDING → ACTIVE: Requires valid credentials
+- PENDING → FAILED: Auth failed or timed out
+- ACTIVE → EXPIRED: Credentials past expiry
+- ACTIVE → REVOKED: User or provider revoked access
+- Any state → DISCONNECTED: User explicitly disconnects
+
+---
+
+## Security Considerations
+
+1. **Credentials never in events**: Domain events contain IDs only, never raw credentials
+2. **Opaque credential storage**: Domain treats credentials as encrypted blobs
+3. **Audit trail**: All state changes emit events for audit logging
+4. **Encryption at rest**: Infrastructure layer encrypts before storage
+5. **No credential logging**: Credentials excluded from all logging contexts
+
+---
+
+## Testing Strategy
+
+### Unit Tests (95%+ coverage)
+
+- Entity state transitions (all paths)
+- Business method logic
+- Value object validation
+- Event emission on state changes
+- Edge cases (expired credentials, invalid transitions)
+
+### Test Categories
+
+1. **Entity Creation**: Valid/invalid construction
+2. **State Transitions**: All valid paths + invalid transition rejection (Result types)
+3. **Business Methods**: `is_connected()`, `needs_reauthentication()`, `can_sync()`, etc.
+4. **Credentials**: Expiration logic, type validation
+5. **Error Constants**: Verify correct error messages
+
+---
+
+**Created**: 2025-11-29 | **Last Updated**: 2025-11-29

--- a/src/domain/entities/__init__.py
+++ b/src/domain/entities/__init__.py
@@ -3,8 +3,9 @@
 Pure business logic entities with no framework dependencies.
 """
 
+from src.domain.entities.provider_connection import ProviderConnection
 from src.domain.entities.security_config import SecurityConfig
 from src.domain.entities.session import Session
 from src.domain.entities.user import User
 
-__all__ = ["SecurityConfig", "Session", "User"]
+__all__ = ["ProviderConnection", "SecurityConfig", "Session", "User"]

--- a/src/domain/entities/provider_connection.py
+++ b/src/domain/entities/provider_connection.py
@@ -1,0 +1,347 @@
+"""Provider connection domain entity.
+
+Represents the connection between a user and a financial data provider.
+Authentication-agnostic - domain has no knowledge of OAuth, API keys, etc.
+
+Architecture:
+    - Pure domain entity (no infrastructure dependencies)
+    - Uses Result types (railway-oriented programming)
+    - NO event collection (handlers create events)
+    - State machine with validated transitions
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+
+Usage:
+    from src.domain.entities import ProviderConnection
+    from src.domain.enums import ConnectionStatus
+
+    connection = ProviderConnection(
+        id=uuid4(),
+        user_id=user.id,
+        provider_id=provider_uuid,
+        provider_slug="schwab",
+        status=ConnectionStatus.PENDING,
+    )
+
+    # After successful authentication
+    result = connection.mark_connected(credentials)
+    match result:
+        case Success(_):
+            assert connection.is_connected()
+        case Failure(error):
+            # Handle error
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from uuid import UUID
+
+from src.core.result import Failure, Result, Success
+from src.domain.enums.connection_status import ConnectionStatus
+from src.domain.errors.provider_connection_error import ProviderConnectionError
+from src.domain.value_objects.provider_credentials import ProviderCredentials
+
+
+@dataclass
+class ProviderConnection:
+    """Connection between a user and a financial data provider.
+
+    Represents the user's connection to an external provider like Schwab,
+    Chase, or Plaid. The connection tracks status, credentials, and sync state.
+
+    Authentication Agnostic:
+        Domain layer has no knowledge of authentication mechanisms.
+        Credentials are stored as opaque encrypted blobs with a type hint
+        for the infrastructure layer to handle.
+
+    State Machine:
+        PENDING → ACTIVE ↔ EXPIRED/REVOKED → DISCONNECTED
+
+    Railway-Oriented Programming:
+        All state transition methods return Result[None, str] instead of
+        raising exceptions. Use pattern matching to handle success/failure.
+
+    Attributes:
+        id: Unique connection identifier.
+        user_id: Owning user's ID.
+        provider_id: FK to Provider registry (infrastructure).
+        provider_slug: Denormalized provider identifier for logging.
+        alias: User-defined nickname (e.g., "My Schwab IRA").
+        status: Current connection status.
+        credentials: Encrypted credentials (None when pending/disconnected).
+        connected_at: When connection was first established.
+        last_sync_at: Last successful data synchronization.
+        created_at: Record creation timestamp.
+        updated_at: Last modification timestamp.
+
+    Example:
+        >>> conn = ProviderConnection(
+        ...     id=uuid4(),
+        ...     user_id=user_id,
+        ...     provider_id=provider_id,
+        ...     provider_slug="schwab",
+        ...     status=ConnectionStatus.PENDING,
+        ... )
+        >>> conn.is_connected()
+        False
+        >>> result = conn.mark_connected(credentials)
+        >>> match result:
+        ...     case Success(_): print("Connected!")
+        ...     case Failure(e): print(f"Error: {e}")
+    """
+
+    id: UUID
+    user_id: UUID
+    provider_id: UUID
+    provider_slug: str
+    status: ConnectionStatus
+    alias: str | None = None
+    credentials: ProviderCredentials | None = None
+    connected_at: datetime | None = None
+    last_sync_at: datetime | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        """Validate connection after initialization.
+
+        Raises:
+            ValueError: If required fields are invalid.
+
+        Note:
+            __post_init__ still raises ValueError for construction errors.
+            These are programming errors, not business logic failures.
+        """
+        if not self.provider_slug:
+            raise ValueError(ProviderConnectionError.INVALID_PROVIDER_SLUG)
+
+        if len(self.provider_slug) > 50:
+            raise ValueError(ProviderConnectionError.INVALID_PROVIDER_SLUG)
+
+        if self.alias is not None and len(self.alias) > 100:
+            raise ValueError(ProviderConnectionError.INVALID_ALIAS)
+
+        # Validate status consistency
+        if self.status == ConnectionStatus.ACTIVE and self.credentials is None:
+            raise ValueError(ProviderConnectionError.ACTIVE_WITHOUT_CREDENTIALS)
+
+    # -------------------------------------------------------------------------
+    # Query Methods (Read-Only)
+    # -------------------------------------------------------------------------
+
+    def is_connected(self) -> bool:
+        """Check if connection is active and usable.
+
+        Returns:
+            bool: True if status is ACTIVE and credentials exist.
+        """
+        return self.status == ConnectionStatus.ACTIVE and self.credentials is not None
+
+    def needs_reauthentication(self) -> bool:
+        """Check if connection requires user to re-authenticate.
+
+        Returns:
+            bool: True if status is EXPIRED, REVOKED, or FAILED.
+        """
+        return self.status in ConnectionStatus.needs_reauth_states()
+
+    def is_credentials_expired(self) -> bool:
+        """Check if credentials have passed expiration time.
+
+        Returns:
+            bool: True if credentials exist and are expired.
+        """
+        if self.credentials is None:
+            return False
+        return self.credentials.is_expired()
+
+    def is_credentials_expiring_soon(self) -> bool:
+        """Check if credentials will expire within 5 minutes.
+
+        Returns:
+            bool: True if credentials exist and expiring soon.
+        """
+        if self.credentials is None:
+            return False
+        return self.credentials.is_expiring_soon()
+
+    def can_sync(self) -> bool:
+        """Check if connection can perform data synchronization.
+
+        Returns:
+            bool: True if connected and credentials not expired.
+        """
+        return self.is_connected() and not self.is_credentials_expired()
+
+    # -------------------------------------------------------------------------
+    # State Transition Methods (Return Result)
+    # -------------------------------------------------------------------------
+
+    def mark_connected(self, credentials: ProviderCredentials) -> Result[None, str]:
+        """Transition to ACTIVE status with credentials.
+
+        Called after successful authentication. Updates status and
+        records connection timestamp.
+
+        Args:
+            credentials: Encrypted credentials from provider.
+
+        Returns:
+            Success(None): Transition successful.
+            Failure(error): Credentials missing or invalid state transition.
+
+        Side Effects (on success):
+            - Sets status to ACTIVE
+            - Stores credentials
+            - Sets connected_at if first connection
+            - Updates updated_at
+        """
+        if credentials is None:
+            return Failure(error=ProviderConnectionError.CREDENTIALS_REQUIRED)
+
+        # Allow from PENDING, EXPIRED, REVOKED, FAILED
+        allowed_from = [
+            ConnectionStatus.PENDING,
+            ConnectionStatus.EXPIRED,
+            ConnectionStatus.REVOKED,
+            ConnectionStatus.FAILED,
+        ]
+        if self.status not in allowed_from:
+            return Failure(error=ProviderConnectionError.CANNOT_TRANSITION_TO_ACTIVE)
+
+        self.status = ConnectionStatus.ACTIVE
+        self.credentials = credentials
+        self.updated_at = datetime.now(UTC)
+
+        if self.connected_at is None:
+            self.connected_at = datetime.now(UTC)
+
+        return Success(value=None)
+
+    def mark_disconnected(self) -> Result[None, str]:
+        """Transition to DISCONNECTED status.
+
+        Called when user explicitly removes the connection.
+        Terminal state - credentials are cleared.
+
+        Returns:
+            Success(None): Transition successful (always succeeds).
+
+        Side Effects:
+            - Sets status to DISCONNECTED
+            - Clears credentials
+            - Updates updated_at
+        """
+        self.status = ConnectionStatus.DISCONNECTED
+        self.credentials = None
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)
+
+    def mark_expired(self) -> Result[None, str]:
+        """Transition to EXPIRED status.
+
+        Called when credentials have expired and cannot be refreshed.
+
+        Returns:
+            Success(None): Transition successful.
+            Failure(error): Not currently ACTIVE.
+
+        Side Effects (on success):
+            - Sets status to EXPIRED
+            - Updates updated_at
+            - Does NOT clear credentials (may still contain refresh token)
+        """
+        if self.status != ConnectionStatus.ACTIVE:
+            return Failure(error=ProviderConnectionError.CANNOT_TRANSITION_TO_EXPIRED)
+
+        self.status = ConnectionStatus.EXPIRED
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)
+
+    def mark_revoked(self) -> Result[None, str]:
+        """Transition to REVOKED status.
+
+        Called when user or provider explicitly revokes access.
+
+        Returns:
+            Success(None): Transition successful.
+            Failure(error): Not currently ACTIVE.
+
+        Side Effects (on success):
+            - Sets status to REVOKED
+            - Updates updated_at
+            - Does NOT clear credentials (audit trail)
+        """
+        if self.status != ConnectionStatus.ACTIVE:
+            return Failure(error=ProviderConnectionError.CANNOT_TRANSITION_TO_REVOKED)
+
+        self.status = ConnectionStatus.REVOKED
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)
+
+    def mark_failed(self) -> Result[None, str]:
+        """Transition to FAILED status.
+
+        Called when authentication attempt fails.
+
+        Returns:
+            Success(None): Transition successful.
+            Failure(error): Not currently PENDING.
+
+        Side Effects (on success):
+            - Sets status to FAILED
+            - Updates updated_at
+        """
+        if self.status != ConnectionStatus.PENDING:
+            return Failure(error=ProviderConnectionError.CANNOT_TRANSITION_TO_FAILED)
+
+        self.status = ConnectionStatus.FAILED
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)
+
+    def update_credentials(self, credentials: ProviderCredentials) -> Result[None, str]:
+        """Update credentials after token refresh.
+
+        Called when credentials are refreshed without user interaction.
+
+        Args:
+            credentials: New encrypted credentials.
+
+        Returns:
+            Success(None): Update successful.
+            Failure(error): Credentials missing or not ACTIVE.
+
+        Side Effects (on success):
+            - Updates credentials
+            - Updates updated_at
+        """
+        if credentials is None:
+            return Failure(error=ProviderConnectionError.CREDENTIALS_REQUIRED)
+
+        if self.status != ConnectionStatus.ACTIVE:
+            return Failure(error=ProviderConnectionError.NOT_CONNECTED)
+
+        self.credentials = credentials
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)
+
+    def record_sync(self) -> Result[None, str]:
+        """Record successful data synchronization.
+
+        Updates last_sync_at timestamp.
+
+        Returns:
+            Success(None): Sync recorded.
+            Failure(error): Not currently ACTIVE.
+
+        Side Effects (on success):
+            - Updates last_sync_at
+            - Updates updated_at
+        """
+        if self.status != ConnectionStatus.ACTIVE:
+            return Failure(error=ProviderConnectionError.NOT_CONNECTED)
+
+        self.last_sync_at = datetime.now(UTC)
+        self.updated_at = datetime.now(UTC)
+        return Success(value=None)

--- a/src/domain/enums/__init__.py
+++ b/src/domain/enums/__init__.py
@@ -16,8 +16,18 @@ Available Enums:
 """
 
 from src.domain.enums.audit_action import AuditAction
+from src.domain.enums.connection_status import ConnectionStatus
+from src.domain.enums.credential_type import CredentialType
 from src.domain.enums.permission import Action, Resource
 from src.domain.enums.rate_limit_scope import RateLimitScope
 from src.domain.enums.user_role import UserRole
 
-__all__ = ["AuditAction", "RateLimitScope", "UserRole", "Resource", "Action"]
+__all__ = [
+    "AuditAction",
+    "ConnectionStatus",
+    "CredentialType",
+    "RateLimitScope",
+    "UserRole",
+    "Resource",
+    "Action",
+]

--- a/src/domain/enums/connection_status.py
+++ b/src/domain/enums/connection_status.py
@@ -1,0 +1,138 @@
+"""Provider connection lifecycle states.
+
+Defines the status state machine for provider connections.
+
+State Machine:
+    PENDING → ACTIVE ↔ EXPIRED/REVOKED → DISCONNECTED
+
+    - PENDING: Auth initiated, awaiting completion
+    - ACTIVE: Connected with valid credentials
+    - EXPIRED: Credentials expired, needs re-auth
+    - REVOKED: Access revoked by user or provider
+    - FAILED: Authentication failed
+    - DISCONNECTED: User explicitly disconnected (terminal)
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+
+Usage:
+    from src.domain.enums import ConnectionStatus
+
+    if connection.status == ConnectionStatus.ACTIVE:
+        # Connection is usable
+"""
+
+from enum import Enum
+
+
+class ConnectionStatus(str, Enum):
+    """Provider connection lifecycle states.
+
+    Defines valid states for a provider connection and the transitions
+    between them. Used to track connection health and determine if
+    credentials need refresh or re-authentication.
+
+    String Enum:
+        Inherits from str for easy serialization and database storage.
+        Values are lowercase for consistency.
+
+    State Transitions:
+        PENDING → ACTIVE: Successful authentication
+        PENDING → FAILED: Authentication failed or timed out
+        ACTIVE → EXPIRED: Credentials past expiration
+        ACTIVE → REVOKED: User or provider revoked access
+        EXPIRED → ACTIVE: Successful re-authentication
+        REVOKED → ACTIVE: Successful re-authentication
+        Any → DISCONNECTED: User explicitly disconnects (terminal)
+    """
+
+    PENDING = "pending"
+    """Authentication initiated, awaiting completion.
+
+    Initial state when user starts provider connection flow.
+    Transitions to ACTIVE on success, FAILED on error.
+    """
+
+    ACTIVE = "active"
+    """Connected with valid credentials.
+
+    Connection is healthy and can be used for data sync.
+    Credentials are valid and not expired.
+    """
+
+    EXPIRED = "expired"
+    """Credentials expired, needs re-authentication.
+
+    Connection was previously active but credentials have expired.
+    User must re-authenticate to restore connection.
+    """
+
+    REVOKED = "revoked"
+    """Access revoked by user or provider.
+
+    Provider or user explicitly revoked access.
+    Differs from EXPIRED in that credentials are invalid
+    regardless of expiration time.
+    """
+
+    FAILED = "failed"
+    """Authentication failed.
+
+    Initial authentication attempt failed.
+    User may retry the connection flow.
+    """
+
+    DISCONNECTED = "disconnected"
+    """User explicitly disconnected.
+
+    Terminal state - user has removed this connection.
+    Credentials are cleared and connection is inactive.
+    """
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """Get all status values as strings.
+
+        Returns:
+            list[str]: List of status values.
+        """
+        return [status.value for status in cls]
+
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        """Check if a string is a valid status.
+
+        Args:
+            value: String to check.
+
+        Returns:
+            bool: True if value is a valid status.
+        """
+        return value in cls.values()
+
+    @classmethod
+    def active_states(cls) -> list["ConnectionStatus"]:
+        """Get states where connection is usable.
+
+        Returns:
+            list[ConnectionStatus]: States where sync is possible.
+        """
+        return [cls.ACTIVE]
+
+    @classmethod
+    def needs_reauth_states(cls) -> list["ConnectionStatus"]:
+        """Get states requiring re-authentication.
+
+        Returns:
+            list[ConnectionStatus]: States needing user action.
+        """
+        return [cls.EXPIRED, cls.REVOKED, cls.FAILED]
+
+    @classmethod
+    def terminal_states(cls) -> list["ConnectionStatus"]:
+        """Get terminal states (no recovery).
+
+        Returns:
+            list[ConnectionStatus]: Terminal states.
+        """
+        return [cls.DISCONNECTED]

--- a/src/domain/enums/credential_type.py
+++ b/src/domain/enums/credential_type.py
@@ -1,0 +1,131 @@
+"""Authentication mechanism types for provider credentials.
+
+Defines the type of credential stored, used by infrastructure layer
+to route to the correct credential handler for encryption/decryption
+and token refresh operations.
+
+The domain layer treats credentials as opaque blobs - this enum
+provides a hint to infrastructure about how to process them.
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+
+Usage:
+    from src.domain.enums import CredentialType
+
+    credentials = ProviderCredentials(
+        encrypted_data=encrypted_blob,
+        credential_type=CredentialType.OAUTH2,
+        expires_at=expires_at,
+    )
+"""
+
+from enum import Enum
+
+
+class CredentialType(str, Enum):
+    """Authentication mechanism type for provider credentials.
+
+    Used by infrastructure layer to determine how to:
+    - Encrypt/decrypt credential data
+    - Refresh expiring credentials
+    - Validate credential format
+
+    The domain layer is authentication-agnostic - it only stores
+    this type as a routing hint for infrastructure.
+
+    String Enum:
+        Inherits from str for easy serialization and database storage.
+        Values are lowercase for consistency.
+    """
+
+    OAUTH2 = "oauth2"
+    """OAuth 2.0 authentication.
+
+    Used by most brokerages (Schwab, Fidelity, etc.).
+
+    Credential data typically includes:
+        - access_token
+        - refresh_token
+        - token_type
+        - expires_in
+        - scope
+    """
+
+    API_KEY = "api_key"
+    """Simple API key authentication.
+
+    Used by some data providers with static credentials.
+
+    Credential data typically includes:
+        - api_key
+        - api_secret (optional)
+    """
+
+    LINK_TOKEN = "link_token"
+    """Plaid-style link tokens.
+
+    Used by aggregators like Plaid that use a linking flow.
+
+    Credential data typically includes:
+        - access_token
+        - item_id
+        - institution_id
+    """
+
+    CERTIFICATE = "certificate"
+    """mTLS certificate-based authentication.
+
+    Used by providers requiring mutual TLS.
+
+    Credential data typically includes:
+        - client_certificate
+        - private_key
+        - certificate_chain
+    """
+
+    CUSTOM = "custom"
+    """Provider-specific custom authentication.
+
+    Fallback for providers with unique auth mechanisms.
+    Infrastructure must handle on a per-provider basis.
+    """
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """Get all credential type values as strings.
+
+        Returns:
+            list[str]: List of credential type values.
+        """
+        return [cred_type.value for cred_type in cls]
+
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        """Check if a string is a valid credential type.
+
+        Args:
+            value: String to check.
+
+        Returns:
+            bool: True if value is a valid credential type.
+        """
+        return value in cls.values()
+
+    @classmethod
+    def supports_refresh(cls) -> list["CredentialType"]:
+        """Get credential types that support automatic refresh.
+
+        Returns:
+            list[CredentialType]: Types with refresh capability.
+        """
+        return [cls.OAUTH2, cls.LINK_TOKEN]
+
+    @classmethod
+    def never_expires(cls) -> list["CredentialType"]:
+        """Get credential types that typically don't expire.
+
+        Returns:
+            list[CredentialType]: Types without expiration.
+        """
+        return [cls.API_KEY, cls.CERTIFICATE]

--- a/src/domain/errors/__init__.py
+++ b/src/domain/errors/__init__.py
@@ -8,7 +8,14 @@ Usage:
 
 from src.domain.errors.audit_error import AuditError
 from src.domain.errors.authentication_error import AuthenticationError
+from src.domain.errors.provider_connection_error import ProviderConnectionError
 from src.domain.errors.rate_limit_error import RateLimitError
 from src.domain.errors.secrets_error import SecretsError
 
-__all__ = ["AuditError", "AuthenticationError", "RateLimitError", "SecretsError"]
+__all__ = [
+    "AuditError",
+    "AuthenticationError",
+    "ProviderConnectionError",
+    "RateLimitError",
+    "SecretsError",
+]

--- a/src/domain/errors/provider_connection_error.py
+++ b/src/domain/errors/provider_connection_error.py
@@ -1,0 +1,61 @@
+"""Provider connection domain errors.
+
+Defines provider connection-specific error constants for state transitions,
+validation, and connection management.
+
+Architecture:
+    - Domain layer errors (no infrastructure dependencies)
+    - Used in Result types (railway-oriented programming)
+    - Never raised as exceptions (return Failure(error) instead)
+
+Usage:
+    from src.domain.errors import ProviderConnectionError
+    from src.core.result import Failure
+
+    result = connection.mark_connected(credentials)
+    match result:
+        case Success(_):
+            # Connection activated
+            ...
+        case Failure(ProviderConnectionError.INVALID_STATE_TRANSITION):
+            # Handle invalid transition
+            ...
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+"""
+
+
+class ProviderConnectionError:
+    """Provider connection error constants.
+
+    Used in Result types for connection operation failures.
+    These are NOT exceptions - they are error value constants
+    used in railway-oriented programming pattern.
+
+    Error Categories:
+        - State transition errors: INVALID_STATE_TRANSITION
+        - Validation errors: INVALID_CREDENTIALS, INVALID_PROVIDER_SLUG
+        - Status errors: NOT_CONNECTED, CREDENTIALS_EXPIRED
+    """
+
+    # State transition errors
+    INVALID_STATE_TRANSITION = "Invalid state transition"
+    CANNOT_TRANSITION_TO_ACTIVE = "Cannot transition to ACTIVE from current state"
+    CANNOT_TRANSITION_TO_EXPIRED = "Cannot transition to EXPIRED, must be ACTIVE"
+    CANNOT_TRANSITION_TO_REVOKED = "Cannot transition to REVOKED, must be ACTIVE"
+    CANNOT_TRANSITION_TO_FAILED = "Cannot transition to FAILED, must be PENDING"
+
+    # Validation errors
+    CREDENTIALS_REQUIRED = "Credentials are required"
+    INVALID_CREDENTIALS = "Invalid credentials"
+    INVALID_PROVIDER_SLUG = "Invalid provider slug"
+    INVALID_ALIAS = "Alias exceeds maximum length"
+
+    # Status errors
+    NOT_CONNECTED = "Connection is not active"
+    CREDENTIALS_EXPIRED = "Credentials have expired"
+    CONNECTION_DISCONNECTED = "Connection has been disconnected"
+
+    # Consistency errors
+    ACTIVE_WITHOUT_CREDENTIALS = "ACTIVE connection must have credentials"

--- a/src/domain/events/__init__.py
+++ b/src/domain/events/__init__.py
@@ -45,14 +45,6 @@ from src.domain.events.auth_events import (
     PasswordResetRequestAttempted,
     PasswordResetRequestFailed,
     PasswordResetRequestSucceeded,
-    # Provider Connection Events
-    ProviderConnectionAttempted,
-    ProviderConnectionFailed,
-    ProviderConnectionSucceeded,
-    # Provider Token Refresh Events (OAuth)
-    ProviderTokenRefreshAttempted,
-    ProviderTokenRefreshFailed,
-    ProviderTokenRefreshSucceeded,
     # Token Rejection Event (Security Monitoring)
     TokenRejectedDueToRotation,
     # User Login Events
@@ -87,6 +79,20 @@ from src.domain.events.authorization_events import (
     RoleRevocationSucceeded,
 )
 from src.domain.events.base_event import DomainEvent
+from src.domain.events.provider_events import (
+    # Provider Connection Events (3-state)
+    ProviderConnectionAttempted,
+    ProviderConnectionFailed,
+    ProviderConnectionSucceeded,
+    # Provider Disconnection Events (3-state)
+    ProviderDisconnectionAttempted,
+    ProviderDisconnectionFailed,
+    ProviderDisconnectionSucceeded,
+    # Provider Token Refresh Events (3-state)
+    ProviderTokenRefreshAttempted,
+    ProviderTokenRefreshFailed,
+    ProviderTokenRefreshSucceeded,
+)
 from src.domain.events.rate_limit_events import (
     RateLimitCheckAllowed,
     RateLimitCheckAttempted,
@@ -142,6 +148,10 @@ __all__ = [
     "ProviderConnectionAttempted",
     "ProviderConnectionSucceeded",
     "ProviderConnectionFailed",
+    # Provider Disconnection Events (3-state)
+    "ProviderDisconnectionAttempted",
+    "ProviderDisconnectionSucceeded",
+    "ProviderDisconnectionFailed",
     # Provider Token Refresh Events (3-state)
     "ProviderTokenRefreshAttempted",
     "ProviderTokenRefreshSucceeded",

--- a/src/domain/events/auth_events.py
+++ b/src/domain/events/auth_events.py
@@ -246,38 +246,7 @@ class UserPasswordChangeFailed(DomainEvent):
 
 
 # ═══════════════════════════════════════════════════════════════
-# Provider Connection (Workflow 5) - Placeholder for Phase 2
-# ═══════════════════════════════════════════════════════════════
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderConnectionAttempted(DomainEvent):
-    """Provider connection attempt initiated (OAuth flow started)."""
-
-    user_id: UUID
-    provider_name: str
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderConnectionSucceeded(DomainEvent):
-    """Provider connected successfully (OAuth completed, tokens saved)."""
-
-    user_id: UUID
-    provider_id: UUID
-    provider_name: str
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderConnectionFailed(DomainEvent):
-    """Provider connection failed (OAuth failed, API error)."""
-
-    user_id: UUID
-    provider_name: str
-    reason: str
-
-
-# ═══════════════════════════════════════════════════════════════
-# Auth Token Refresh (Workflow 6) - JWT/Refresh Token Rotation
+# Auth Token Refresh (Workflow 5) - JWT/Refresh Token Rotation
 # ═══════════════════════════════════════════════════════════════
 
 
@@ -497,40 +466,7 @@ class PasswordResetConfirmFailed(DomainEvent):
 
 
 # ═══════════════════════════════════════════════════════════════
-# Provider Token Refresh (Workflow 9) - Placeholder for Phase 2
-# ═══════════════════════════════════════════════════════════════
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderTokenRefreshAttempted(DomainEvent):
-    """Provider token refresh attempt initiated."""
-
-    user_id: UUID
-    provider_id: UUID
-    provider_name: str
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderTokenRefreshSucceeded(DomainEvent):
-    """Provider token refresh completed successfully."""
-
-    user_id: UUID
-    provider_id: UUID
-    provider_name: str
-
-
-@dataclass(frozen=True, kw_only=True)
-class ProviderTokenRefreshFailed(DomainEvent):
-    """Provider token refresh failed (user action required - reconnect provider)."""
-
-    user_id: UUID
-    provider_id: UUID
-    provider_name: str
-    error_code: str
-
-
-# ═══════════════════════════════════════════════════════════════
-# Global Token Rotation (Workflow 10)
+# Global Token Rotation (Workflow 8)
 # ═══════════════════════════════════════════════════════════════
 
 

--- a/src/domain/events/provider_events.py
+++ b/src/domain/events/provider_events.py
@@ -1,0 +1,264 @@
+"""Provider domain events (Phase 2 - Domain Layer).
+
+Pattern: 3 events per workflow (ATTEMPTED → SUCCEEDED/FAILED)
+- *Attempted: Action initiated (before business logic)
+- *Succeeded: Operation completed successfully (after commit)
+- *Failed: Operation failed (after rollback)
+
+Workflows:
+1. Provider Connection (user connects to provider)
+2. Provider Disconnection (user disconnects from provider)
+3. Provider Token Refresh (system refreshes credentials)
+
+Handlers:
+- LoggingEventHandler: ALL events
+- AuditEventHandler: ALL events
+- EmailEventHandler: SUCCEEDED only (connection/disconnection notifications)
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from src.domain.events.base_event import DomainEvent
+
+
+# ═══════════════════════════════════════════════════════════════
+# Provider Connection (Workflow 1)
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderConnectionAttempted(DomainEvent):
+    """Provider connection attempt initiated.
+
+    Emitted when user starts the provider connection flow
+    (e.g., OAuth redirect initiated).
+
+    Triggers:
+    - LoggingEventHandler: Log attempt
+    - AuditEventHandler: Record PROVIDER_CONNECTION_ATTEMPTED
+
+    Attributes:
+        user_id: User initiating connection.
+        provider_id: Provider being connected to.
+        provider_slug: Provider identifier for logging.
+    """
+
+    user_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderConnectionSucceeded(DomainEvent):
+    """Provider connection completed successfully.
+
+    Emitted after successful authentication and credential storage.
+
+    Triggers:
+    - LoggingEventHandler: Log success
+    - AuditEventHandler: Record PROVIDER_CONNECTED
+    - EmailEventHandler: Send provider connected notification
+
+    Attributes:
+        user_id: User who connected.
+        connection_id: New connection ID.
+        provider_id: Provider connected to.
+        provider_slug: Provider identifier for logging.
+
+    Note:
+        NEVER include credentials in events.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderConnectionFailed(DomainEvent):
+    """Provider connection failed.
+
+    Emitted when authentication fails, user cancels, or other error.
+
+    Triggers:
+    - LoggingEventHandler: Log failure
+    - AuditEventHandler: Record PROVIDER_CONNECTION_FAILED
+
+    Attributes:
+        user_id: User who attempted connection.
+        provider_id: Provider that failed to connect.
+        provider_slug: Provider identifier for logging.
+        reason: Failure reason (e.g., "user_cancelled", "oauth_error",
+            "invalid_credentials", "provider_unavailable").
+    """
+
+    user_id: UUID
+    provider_id: UUID
+    provider_slug: str
+    reason: str
+
+
+# ═══════════════════════════════════════════════════════════════
+# Provider Disconnection (Workflow 2)
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderDisconnectionAttempted(DomainEvent):
+    """Provider disconnection attempt initiated.
+
+    Emitted when user requests to disconnect a provider.
+
+    Triggers:
+    - LoggingEventHandler: Log attempt
+    - AuditEventHandler: Record PROVIDER_DISCONNECTION_ATTEMPTED
+
+    Attributes:
+        user_id: User initiating disconnection.
+        connection_id: Connection being disconnected.
+        provider_id: Provider being disconnected.
+        provider_slug: Provider identifier for logging.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderDisconnectionSucceeded(DomainEvent):
+    """Provider disconnection completed successfully.
+
+    Emitted after credentials are cleared and connection is removed.
+
+    Triggers:
+    - LoggingEventHandler: Log success
+    - AuditEventHandler: Record PROVIDER_DISCONNECTED
+    - EmailEventHandler: Send provider disconnected notification
+
+    Attributes:
+        user_id: User who disconnected.
+        connection_id: Connection that was disconnected.
+        provider_id: Provider that was disconnected.
+        provider_slug: Provider identifier for logging.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderDisconnectionFailed(DomainEvent):
+    """Provider disconnection failed.
+
+    Emitted when disconnection fails (rare - usually database error).
+
+    Triggers:
+    - LoggingEventHandler: Log failure
+    - AuditEventHandler: Record PROVIDER_DISCONNECTION_FAILED
+
+    Attributes:
+        user_id: User who attempted disconnection.
+        connection_id: Connection that failed to disconnect.
+        provider_id: Provider that failed to disconnect.
+        provider_slug: Provider identifier for logging.
+        reason: Failure reason (e.g., "database_error", "connection_not_found").
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+    reason: str
+
+
+# ═══════════════════════════════════════════════════════════════
+# Provider Token Refresh (Workflow 3)
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderTokenRefreshAttempted(DomainEvent):
+    """Provider token refresh attempt initiated.
+
+    Emitted when system attempts to refresh expiring credentials.
+    Typically triggered by background job or proactive refresh.
+
+    Triggers:
+    - LoggingEventHandler: Log attempt
+    - AuditEventHandler: Record PROVIDER_TOKEN_REFRESH_ATTEMPTED
+
+    Attributes:
+        user_id: User whose credentials are being refreshed.
+        connection_id: Connection being refreshed.
+        provider_id: Provider whose tokens are refreshing.
+        provider_slug: Provider identifier for logging.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderTokenRefreshSucceeded(DomainEvent):
+    """Provider token refresh completed successfully.
+
+    Emitted after new credentials are stored.
+
+    Triggers:
+    - LoggingEventHandler: Log success
+    - AuditEventHandler: Record PROVIDER_TOKEN_REFRESHED
+
+    Attributes:
+        user_id: User whose credentials were refreshed.
+        connection_id: Connection that was refreshed.
+        provider_id: Provider whose tokens were refreshed.
+        provider_slug: Provider identifier for logging.
+
+    Note:
+        NEVER include credentials in events.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderTokenRefreshFailed(DomainEvent):
+    """Provider token refresh failed.
+
+    Emitted when refresh fails - user may need to re-authenticate.
+
+    Triggers:
+    - LoggingEventHandler: Log failure
+    - AuditEventHandler: Record PROVIDER_TOKEN_REFRESH_FAILED
+    - EmailEventHandler: Notify user of required action (if needs_reauth)
+
+    Attributes:
+        user_id: User whose credentials failed to refresh.
+        connection_id: Connection that failed to refresh.
+        provider_id: Provider whose tokens failed to refresh.
+        provider_slug: Provider identifier for logging.
+        reason: Failure reason (e.g., "refresh_token_expired",
+            "provider_revoked", "network_error").
+        needs_user_action: Whether user must re-authenticate.
+    """
+
+    user_id: UUID
+    connection_id: UUID
+    provider_id: UUID
+    provider_slug: str
+    reason: str
+    needs_user_action: bool = False

--- a/src/domain/protocols/__init__.py
+++ b/src/domain/protocols/__init__.py
@@ -51,6 +51,9 @@ from src.domain.protocols.session_enricher import (
     LocationEnrichmentResult,
 )
 from src.domain.protocols.session_repository import SessionData, SessionRepository
+from src.domain.protocols.provider_connection_repository import (
+    ProviderConnectionRepository,
+)
 from src.domain.protocols.rate_limit_protocol import RateLimitProtocol
 from src.domain.protocols.user_repository import UserRepository
 
@@ -84,4 +87,6 @@ __all__ = [
     "SessionRepository",
     # Rate Limit protocol
     "RateLimitProtocol",
+    # Provider Connection Repository
+    "ProviderConnectionRepository",
 ]

--- a/src/domain/protocols/provider_connection_repository.py
+++ b/src/domain/protocols/provider_connection_repository.py
@@ -1,0 +1,174 @@
+"""ProviderConnectionRepository protocol for provider connection persistence.
+
+Port (interface) for hexagonal architecture.
+Infrastructure layer implements this protocol.
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+"""
+
+from typing import Protocol
+from uuid import UUID
+
+from src.domain.entities.provider_connection import ProviderConnection
+
+
+class ProviderConnectionRepository(Protocol):
+    """Provider connection repository protocol (port).
+
+    Defines the interface for provider connection persistence operations.
+    Infrastructure layer provides concrete implementation.
+
+    This is a Protocol (not ABC) for structural typing.
+    Implementations don't need to inherit from this.
+
+    Methods:
+        find_by_id: Retrieve connection by ID
+        find_by_user_id: Retrieve all connections for user
+        find_by_user_and_provider: Retrieve connections for user + provider
+        find_active_by_user: Retrieve active connections for user
+        save: Create or update connection
+        delete: Remove connection
+
+    Example Implementation:
+        >>> class PostgresProviderConnectionRepository:
+        ...     async def find_by_id(self, id: UUID) -> ProviderConnection | None:
+        ...         # Database logic here
+        ...         pass
+    """
+
+    async def find_by_id(self, connection_id: UUID) -> ProviderConnection | None:
+        """Find connection by ID.
+
+        Args:
+            connection_id: Connection's unique identifier.
+
+        Returns:
+            ProviderConnection if found, None otherwise.
+
+        Example:
+            >>> conn = await repo.find_by_id(connection_id)
+            >>> if conn:
+            ...     print(conn.provider_slug)
+        """
+        ...
+
+    async def find_by_user_id(self, user_id: UUID) -> list[ProviderConnection]:
+        """Find all connections for a user.
+
+        Returns connections in all statuses (including disconnected).
+
+        Args:
+            user_id: User's unique identifier.
+
+        Returns:
+            List of connections (empty if none found).
+
+        Example:
+            >>> connections = await repo.find_by_user_id(user_id)
+            >>> for conn in connections:
+            ...     print(f"{conn.provider_slug}: {conn.status.value}")
+        """
+        ...
+
+    async def find_by_user_and_provider(
+        self,
+        user_id: UUID,
+        provider_id: UUID,
+    ) -> list[ProviderConnection]:
+        """Find all connections for user + provider combination.
+
+        User may have multiple connections to same provider (different accounts).
+
+        Args:
+            user_id: User's unique identifier.
+            provider_id: Provider's unique identifier.
+
+        Returns:
+            List of connections (empty if none found).
+
+        Example:
+            >>> connections = await repo.find_by_user_and_provider(user_id, schwab_id)
+            >>> # User might have multiple Schwab accounts
+            >>> for conn in connections:
+            ...     print(conn.alias)
+        """
+        ...
+
+    async def find_active_by_user(self, user_id: UUID) -> list[ProviderConnection]:
+        """Find all active connections for a user.
+
+        Only returns connections with status=ACTIVE.
+
+        Args:
+            user_id: User's unique identifier.
+
+        Returns:
+            List of active connections (empty if none found).
+
+        Example:
+            >>> active = await repo.find_active_by_user(user_id)
+            >>> for conn in active:
+            ...     if conn.can_sync():
+            ...         # Perform sync
+        """
+        ...
+
+    async def save(self, connection: ProviderConnection) -> None:
+        """Create or update connection in database.
+
+        Uses upsert semantics - creates if not exists, updates if exists.
+
+        Args:
+            connection: ProviderConnection entity to persist.
+
+        Raises:
+            DatabaseError: If database operation fails.
+
+        Example:
+            >>> conn = ProviderConnection(...)
+            >>> await repo.save(conn)
+        """
+        ...
+
+    async def delete(self, connection_id: UUID) -> None:
+        """Remove connection from database.
+
+        Hard delete - permanently removes the record.
+        For soft delete, use mark_disconnected() on the entity instead.
+
+        Args:
+            connection_id: Connection's unique identifier.
+
+        Raises:
+            NotFoundError: If connection doesn't exist.
+            DatabaseError: If database operation fails.
+
+        Note:
+            Consider using mark_disconnected() for audit trail instead of delete.
+
+        Example:
+            >>> await repo.delete(connection_id)
+        """
+        ...
+
+    async def find_expiring_soon(
+        self,
+        minutes: int = 30,
+    ) -> list[ProviderConnection]:
+        """Find connections with credentials expiring soon.
+
+        Used by background job to proactively refresh credentials.
+
+        Args:
+            minutes: Time threshold in minutes (default 30).
+
+        Returns:
+            List of active connections with credentials expiring within threshold.
+
+        Example:
+            >>> expiring = await repo.find_expiring_soon(minutes=15)
+            >>> for conn in expiring:
+            ...     # Trigger refresh
+        """
+        ...

--- a/src/domain/value_objects/__init__.py
+++ b/src/domain/value_objects/__init__.py
@@ -5,6 +5,13 @@ Immutable value objects that enforce business constraints.
 
 from src.domain.value_objects.email import Email
 from src.domain.value_objects.password import Password
+from src.domain.value_objects.provider_credentials import ProviderCredentials
 from src.domain.value_objects.rate_limit_rule import RateLimitResult, RateLimitRule
 
-__all__ = ["Email", "Password", "RateLimitResult", "RateLimitRule"]
+__all__ = [
+    "Email",
+    "Password",
+    "ProviderCredentials",
+    "RateLimitResult",
+    "RateLimitRule",
+]

--- a/src/domain/value_objects/provider_credentials.py
+++ b/src/domain/value_objects/provider_credentials.py
@@ -1,0 +1,166 @@
+"""Authentication-agnostic encrypted credentials value object.
+
+Immutable value object that stores encrypted credential data as an
+opaque blob. The domain layer has no knowledge of the credential
+format - infrastructure layer handles encryption/decryption based
+on the credential_type hint.
+
+Reference:
+    - docs/architecture/provider-domain-model.md
+
+Usage:
+    from src.domain.value_objects import ProviderCredentials
+    from src.domain.enums import CredentialType
+
+    credentials = ProviderCredentials(
+        encrypted_data=encrypted_blob,
+        credential_type=CredentialType.OAUTH2,
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    if credentials.is_expired():
+        # Need to refresh or re-authenticate
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from src.domain.enums.credential_type import CredentialType
+
+
+@dataclass(frozen=True)
+class ProviderCredentials:
+    """Authentication-agnostic encrypted credentials.
+
+    Stores encrypted credential data as an opaque blob. The domain layer
+    treats this as a black box - only the infrastructure layer understands
+    the internal format based on credential_type.
+
+    This design supports multiple authentication mechanisms (OAuth2, API keys,
+    link tokens, certificates) without domain layer changes.
+
+    Attributes:
+        encrypted_data: Encrypted credential blob (opaque to domain).
+        credential_type: Type hint for infrastructure to route handling.
+        expires_at: When credentials expire (None = never expires).
+
+    Immutability:
+        Frozen dataclass ensures credentials cannot be modified after creation.
+        To update credentials, create a new ProviderCredentials instance.
+
+    Security:
+        - Domain never sees raw credentials
+        - Encryption/decryption happens at infrastructure layer
+        - Credentials excluded from logging and events
+
+    Example:
+        >>> from datetime import UTC, datetime, timedelta
+        >>> creds = ProviderCredentials(
+        ...     encrypted_data=b"encrypted_oauth_tokens",
+        ...     credential_type=CredentialType.OAUTH2,
+        ...     expires_at=datetime.now(UTC) + timedelta(hours=1),
+        ... )
+        >>> creds.is_expired()
+        False
+    """
+
+    encrypted_data: bytes
+    credential_type: CredentialType
+    expires_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        """Validate credentials after initialization.
+
+        Raises:
+            ValueError: If encrypted_data is empty or invalid.
+        """
+        if not self.encrypted_data:
+            raise ValueError("encrypted_data cannot be empty")
+
+        if not isinstance(self.encrypted_data, bytes):
+            raise ValueError("encrypted_data must be bytes")
+
+        if not isinstance(self.credential_type, CredentialType):
+            raise ValueError("credential_type must be a CredentialType enum")
+
+        # Ensure expires_at is timezone-aware if provided
+        if self.expires_at is not None:
+            if self.expires_at.tzinfo is None:
+                raise ValueError("expires_at must be timezone-aware")
+
+    def is_expired(self) -> bool:
+        """Check if credentials have expired.
+
+        Returns:
+            bool: True if credentials are past expiration time.
+                  False if no expiration set or not yet expired.
+        """
+        if self.expires_at is None:
+            return False
+        return datetime.now(UTC) >= self.expires_at
+
+    def is_expiring_soon(self, threshold: timedelta = timedelta(minutes=5)) -> bool:
+        """Check if credentials will expire within threshold.
+
+        Useful for proactive refresh before expiration.
+
+        Args:
+            threshold: Time window to check. Defaults to 5 minutes.
+
+        Returns:
+            bool: True if credentials will expire within threshold.
+                  False if no expiration set or expiration is further out.
+        """
+        if self.expires_at is None:
+            return False
+        return datetime.now(UTC) >= (self.expires_at - threshold)
+
+    def time_until_expiry(self) -> timedelta | None:
+        """Get time remaining until credentials expire.
+
+        Returns:
+            timedelta | None: Time until expiration, or None if no expiration.
+                              Returns zero timedelta if already expired.
+        """
+        if self.expires_at is None:
+            return None
+
+        remaining = self.expires_at - datetime.now(UTC)
+        if remaining.total_seconds() < 0:
+            return timedelta(seconds=0)
+        return remaining
+
+    def supports_refresh(self) -> bool:
+        """Check if credential type supports automatic refresh.
+
+        Returns:
+            bool: True if credentials can be refreshed without user action.
+        """
+        return self.credential_type in CredentialType.supports_refresh()
+
+    def __repr__(self) -> str:
+        """Return repr for debugging.
+
+        Note: Does NOT include encrypted_data for security.
+
+        Returns:
+            str: String representation without sensitive data.
+        """
+        expires_str = self.expires_at.isoformat() if self.expires_at else "None"
+        return (
+            f"ProviderCredentials("
+            f"credential_type={self.credential_type.value}, "
+            f"expires_at={expires_str}, "
+            f"encrypted_data=<{len(self.encrypted_data)} bytes>)"
+        )
+
+    def __str__(self) -> str:
+        """Return string representation.
+
+        Note: Does NOT include encrypted_data for security.
+
+        Returns:
+            str: Human-readable string without sensitive data.
+        """
+        status = "expired" if self.is_expired() else "valid"
+        return f"ProviderCredentials({self.credential_type.value}, {status})"

--- a/tests/unit/test_domain_provider_connection.py
+++ b/tests/unit/test_domain_provider_connection.py
@@ -1,0 +1,923 @@
+"""Unit tests for ProviderConnection domain entity.
+
+Tests cover:
+- Entity creation with all fields
+- Query methods (is_connected, needs_reauthentication, can_sync, etc.)
+- State transition methods with Result types
+- Validation and error handling
+
+Architecture:
+- Unit tests for domain entity (no dependencies)
+- Tests pure business logic and state machine
+- Validates entity invariants and business rules
+- All state transitions return Result types (ROP)
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.core.result import Failure, Success
+from src.domain.entities.provider_connection import ProviderConnection
+from src.domain.enums.connection_status import ConnectionStatus
+from src.domain.errors.provider_connection_error import ProviderConnectionError
+from src.domain.value_objects.provider_credentials import ProviderCredentials
+from tests.conftest import create_credentials
+
+
+@pytest.mark.unit
+class TestConnectionStatusEnumMethods:
+    """Test ConnectionStatus enum helper methods."""
+
+    def test_values_returns_all_statuses(self):
+        """Test ConnectionStatus.values() returns all status strings."""
+        # Act
+        values = ConnectionStatus.values()
+
+        # Assert
+        assert len(values) == 6
+        assert "pending" in values
+        assert "active" in values
+        assert "expired" in values
+        assert "revoked" in values
+        assert "failed" in values
+        assert "disconnected" in values
+
+    def test_is_valid_true_for_valid_status(self):
+        """Test is_valid returns True for valid status string."""
+        # Assert
+        assert ConnectionStatus.is_valid("pending") is True
+        assert ConnectionStatus.is_valid("active") is True
+        assert ConnectionStatus.is_valid("disconnected") is True
+
+    def test_is_valid_false_for_invalid_status(self):
+        """Test is_valid returns False for invalid status string."""
+        # Assert
+        assert ConnectionStatus.is_valid("invalid") is False
+        assert ConnectionStatus.is_valid("ACTIVE") is False  # Case sensitive
+        assert ConnectionStatus.is_valid("") is False
+
+    def test_active_states_returns_only_active(self):
+        """Test active_states returns only ACTIVE status."""
+        # Act
+        active = ConnectionStatus.active_states()
+
+        # Assert
+        assert len(active) == 1
+        assert ConnectionStatus.ACTIVE in active
+        assert ConnectionStatus.PENDING not in active
+
+    def test_terminal_states_returns_only_disconnected(self):
+        """Test terminal_states returns only DISCONNECTED status."""
+        # Act
+        terminal = ConnectionStatus.terminal_states()
+
+        # Assert
+        assert len(terminal) == 1
+        assert ConnectionStatus.DISCONNECTED in terminal
+        assert ConnectionStatus.FAILED not in terminal
+
+    def test_needs_reauth_states_returns_correct_statuses(self):
+        """Test needs_reauth_states returns expired, revoked, and failed."""
+        # Act
+        needs_reauth = ConnectionStatus.needs_reauth_states()
+
+        # Assert
+        assert len(needs_reauth) == 3
+        assert ConnectionStatus.EXPIRED in needs_reauth
+        assert ConnectionStatus.REVOKED in needs_reauth
+        assert ConnectionStatus.FAILED in needs_reauth
+        assert ConnectionStatus.ACTIVE not in needs_reauth
+
+
+def create_connection(
+    connection_id: UUID | None = None,
+    user_id: UUID | None = None,
+    provider_id: UUID | None = None,
+    provider_slug: str = "schwab",
+    alias: str | None = None,
+    status: ConnectionStatus = ConnectionStatus.PENDING,
+    credentials: ProviderCredentials | None = None,
+    connected_at: datetime | None = None,
+    last_sync_at: datetime | None = None,
+) -> ProviderConnection:
+    """Helper to create ProviderConnection entities for testing."""
+    return ProviderConnection(
+        id=connection_id or uuid4(),
+        user_id=user_id or uuid4(),
+        provider_id=provider_id or uuid4(),
+        provider_slug=provider_slug,
+        alias=alias,
+        status=status,
+        credentials=credentials,
+        connected_at=connected_at,
+        last_sync_at=last_sync_at,
+    )
+
+
+@pytest.mark.unit
+class TestProviderConnectionCreation:
+    """Test ProviderConnection entity creation."""
+
+    def test_connection_created_with_all_required_fields(self):
+        """Test connection can be created with all required fields."""
+        # Arrange
+        connection_id = uuid4()
+        user_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        connection = ProviderConnection(
+            id=connection_id,
+            user_id=user_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            status=ConnectionStatus.PENDING,
+        )
+
+        # Assert
+        assert connection.id == connection_id
+        assert isinstance(connection.id, UUID)
+        assert connection.user_id == user_id
+        assert connection.provider_id == provider_id
+        assert connection.provider_slug == "schwab"
+        assert connection.status == ConnectionStatus.PENDING
+        assert connection.alias is None
+        assert connection.credentials is None
+        assert connection.connected_at is None
+        assert connection.last_sync_at is None
+        assert connection.created_at is not None
+        assert connection.updated_at is not None
+
+    def test_connection_created_with_optional_alias(self):
+        """Test connection can be created with alias."""
+        # Act
+        connection = create_connection(alias="My Schwab IRA")
+
+        # Assert
+        assert connection.alias == "My Schwab IRA"
+
+    def test_connection_created_with_active_status_and_credentials(self):
+        """Test active connection requires credentials."""
+        # Arrange
+        credentials = create_credentials()
+
+        # Act
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.status == ConnectionStatus.ACTIVE
+        assert connection.credentials is not None
+
+    def test_connection_raises_error_for_empty_provider_slug(self):
+        """Test creation fails with empty provider_slug."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_connection(provider_slug="")
+
+        assert ProviderConnectionError.INVALID_PROVIDER_SLUG in str(exc_info.value)
+
+    def test_connection_raises_error_for_long_provider_slug(self):
+        """Test creation fails with provider_slug > 50 chars."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_connection(provider_slug="x" * 51)
+
+        assert ProviderConnectionError.INVALID_PROVIDER_SLUG in str(exc_info.value)
+
+    def test_connection_raises_error_for_long_alias(self):
+        """Test creation fails with alias > 100 chars."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_connection(alias="x" * 101)
+
+        assert ProviderConnectionError.INVALID_ALIAS in str(exc_info.value)
+
+    def test_connection_raises_error_for_active_without_credentials(self):
+        """Test creation fails for ACTIVE status without credentials."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_connection(status=ConnectionStatus.ACTIVE, credentials=None)
+
+        assert ProviderConnectionError.ACTIVE_WITHOUT_CREDENTIALS in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestProviderConnectionIsConnected:
+    """Test ProviderConnection.is_connected() query method."""
+
+    def test_is_connected_true_when_active_with_credentials(self):
+        """Test is_connected returns True for ACTIVE with credentials."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.is_connected() is True
+
+    def test_is_connected_false_when_pending(self):
+        """Test is_connected returns False for PENDING status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Assert
+        assert connection.is_connected() is False
+
+    def test_is_connected_false_when_expired(self):
+        """Test is_connected returns False for EXPIRED status."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        # Manually set to expired (simulating state after mark_expired)
+        connection.status = ConnectionStatus.EXPIRED
+
+        # Assert
+        assert connection.is_connected() is False
+
+    def test_is_connected_false_when_disconnected(self):
+        """Test is_connected returns False for DISCONNECTED status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.DISCONNECTED)
+
+        # Assert
+        assert connection.is_connected() is False
+
+
+@pytest.mark.unit
+class TestProviderConnectionNeedsReauthentication:
+    """Test ProviderConnection.needs_reauthentication() query method."""
+
+    def test_needs_reauthentication_false_when_active(self):
+        """Test needs_reauthentication returns False for ACTIVE."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.needs_reauthentication() is False
+
+    def test_needs_reauthentication_true_when_expired(self):
+        """Test needs_reauthentication returns True for EXPIRED."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        connection.status = ConnectionStatus.EXPIRED
+
+        # Assert
+        assert connection.needs_reauthentication() is True
+
+    def test_needs_reauthentication_true_when_revoked(self):
+        """Test needs_reauthentication returns True for REVOKED."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        connection.status = ConnectionStatus.REVOKED
+
+        # Assert
+        assert connection.needs_reauthentication() is True
+
+    def test_needs_reauthentication_true_when_failed(self):
+        """Test needs_reauthentication returns True for FAILED."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.FAILED)
+
+        # Assert
+        assert connection.needs_reauthentication() is True
+
+    def test_needs_reauthentication_false_when_pending(self):
+        """Test needs_reauthentication returns False for PENDING."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Assert
+        assert connection.needs_reauthentication() is False
+
+
+@pytest.mark.unit
+class TestProviderConnectionCredentialsExpiry:
+    """Test credential expiry query methods."""
+
+    def test_is_credentials_expired_false_when_no_credentials(self):
+        """Test is_credentials_expired returns False when no credentials."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Assert
+        assert connection.is_credentials_expired() is False
+
+    def test_is_credentials_expired_false_when_not_expired(self):
+        """Test is_credentials_expired returns False for valid credentials."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.is_credentials_expired() is False
+
+    def test_is_credentials_expired_true_when_expired(self):
+        """Test is_credentials_expired returns True for expired credentials."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(hours=1)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.is_credentials_expired() is True
+
+    def test_is_credentials_expiring_soon_false_when_no_credentials(self):
+        """Test is_credentials_expiring_soon returns False when no credentials."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Assert
+        assert connection.is_credentials_expiring_soon() is False
+
+    def test_is_credentials_expiring_soon_false_when_not_expiring(self):
+        """Test is_credentials_expiring_soon returns False when far from expiry."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.is_credentials_expiring_soon() is False
+
+    def test_is_credentials_expiring_soon_true_when_near_expiry(self):
+        """Test is_credentials_expiring_soon returns True within threshold."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(minutes=3)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.is_credentials_expiring_soon() is True
+
+
+@pytest.mark.unit
+class TestProviderConnectionCanSync:
+    """Test ProviderConnection.can_sync() query method."""
+
+    def test_can_sync_true_when_connected_and_not_expired(self):
+        """Test can_sync returns True for active connection with valid credentials."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.can_sync() is True
+
+    def test_can_sync_false_when_not_connected(self):
+        """Test can_sync returns False when not connected."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Assert
+        assert connection.can_sync() is False
+
+    def test_can_sync_false_when_credentials_expired(self):
+        """Test can_sync returns False when credentials expired."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(hours=1)
+        )
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Assert
+        assert connection.can_sync() is False
+
+
+@pytest.mark.unit
+class TestProviderConnectionMarkConnected:
+    """Test ProviderConnection.mark_connected() state transition."""
+
+    def test_mark_connected_success_from_pending(self):
+        """Test mark_connected succeeds from PENDING status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+        credentials = create_credentials()
+        original_updated_at = connection.updated_at
+
+        # Act
+        result = connection.mark_connected(credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.ACTIVE
+        assert connection.credentials == credentials
+        assert connection.connected_at is not None
+        assert connection.updated_at > original_updated_at
+
+    def test_mark_connected_success_from_expired(self):
+        """Test mark_connected succeeds from EXPIRED status."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+        connection.status = ConnectionStatus.EXPIRED
+        new_credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(new_credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.ACTIVE
+        assert connection.credentials == new_credentials
+
+    def test_mark_connected_success_from_revoked(self):
+        """Test mark_connected succeeds from REVOKED status."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+        connection.status = ConnectionStatus.REVOKED
+        new_credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(new_credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.ACTIVE
+
+    def test_mark_connected_success_from_failed(self):
+        """Test mark_connected succeeds from FAILED status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.FAILED)
+        credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.ACTIVE
+
+    def test_mark_connected_fails_from_active(self):
+        """Test mark_connected fails from ACTIVE status."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+        new_credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(new_credentials)
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_ACTIVE
+
+    def test_mark_connected_fails_from_disconnected(self):
+        """Test mark_connected fails from DISCONNECTED status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.DISCONNECTED)
+        credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(credentials)
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_ACTIVE
+
+    def test_mark_connected_fails_with_none_credentials(self):
+        """Test mark_connected fails when credentials is None."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.mark_connected(None)  # type: ignore[arg-type]
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CREDENTIALS_REQUIRED
+
+    def test_mark_connected_preserves_connected_at_on_reconnect(self):
+        """Test mark_connected preserves connected_at on re-authentication."""
+        # Arrange
+        original_connected_at = datetime.now(UTC) - timedelta(days=30)
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+            connected_at=original_connected_at,
+        )
+        connection.status = ConnectionStatus.EXPIRED
+        new_credentials = create_credentials()
+
+        # Act
+        result = connection.mark_connected(new_credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.connected_at == original_connected_at
+
+
+@pytest.mark.unit
+class TestProviderConnectionMarkDisconnected:
+    """Test ProviderConnection.mark_disconnected() state transition."""
+
+    def test_mark_disconnected_success_from_active(self):
+        """Test mark_disconnected succeeds from ACTIVE status."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        result = connection.mark_disconnected()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.DISCONNECTED
+        assert connection.credentials is None
+
+    def test_mark_disconnected_success_from_pending(self):
+        """Test mark_disconnected succeeds from any status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.mark_disconnected()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.DISCONNECTED
+
+    def test_mark_disconnected_clears_credentials(self):
+        """Test mark_disconnected clears credentials."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        assert connection.credentials is not None
+
+        # Act
+        connection.mark_disconnected()
+
+        # Assert
+        assert connection.credentials is None
+
+    def test_mark_disconnected_updates_timestamp(self):
+        """Test mark_disconnected updates updated_at."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        original_updated_at = connection.updated_at
+
+        # Act
+        connection.mark_disconnected()
+
+        # Assert
+        assert connection.updated_at > original_updated_at
+
+
+@pytest.mark.unit
+class TestProviderConnectionMarkExpired:
+    """Test ProviderConnection.mark_expired() state transition."""
+
+    def test_mark_expired_success_from_active(self):
+        """Test mark_expired succeeds from ACTIVE status."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        result = connection.mark_expired()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.EXPIRED
+
+    def test_mark_expired_preserves_credentials(self):
+        """Test mark_expired does NOT clear credentials (may have refresh token)."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        connection.mark_expired()
+
+        # Assert
+        assert connection.credentials is not None
+        assert connection.credentials == credentials
+
+    def test_mark_expired_fails_from_pending(self):
+        """Test mark_expired fails from PENDING status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.mark_expired()
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_EXPIRED
+
+    def test_mark_expired_fails_from_disconnected(self):
+        """Test mark_expired fails from DISCONNECTED status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.DISCONNECTED)
+
+        # Act
+        result = connection.mark_expired()
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_EXPIRED
+
+
+@pytest.mark.unit
+class TestProviderConnectionMarkRevoked:
+    """Test ProviderConnection.mark_revoked() state transition."""
+
+    def test_mark_revoked_success_from_active(self):
+        """Test mark_revoked succeeds from ACTIVE status."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        result = connection.mark_revoked()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.REVOKED
+
+    def test_mark_revoked_preserves_credentials(self):
+        """Test mark_revoked does NOT clear credentials (audit trail)."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        connection.mark_revoked()
+
+        # Assert
+        assert connection.credentials is not None
+
+    def test_mark_revoked_fails_from_pending(self):
+        """Test mark_revoked fails from PENDING status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.mark_revoked()
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_REVOKED
+
+
+@pytest.mark.unit
+class TestProviderConnectionMarkFailed:
+    """Test ProviderConnection.mark_failed() state transition."""
+
+    def test_mark_failed_success_from_pending(self):
+        """Test mark_failed succeeds from PENDING status."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.mark_failed()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.status == ConnectionStatus.FAILED
+
+    def test_mark_failed_fails_from_active(self):
+        """Test mark_failed fails from ACTIVE status."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+
+        # Act
+        result = connection.mark_failed()
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CANNOT_TRANSITION_TO_FAILED
+
+    def test_mark_failed_updates_timestamp(self):
+        """Test mark_failed updates updated_at."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+        original_updated_at = connection.updated_at
+
+        # Act
+        connection.mark_failed()
+
+        # Assert
+        assert connection.updated_at > original_updated_at
+
+
+@pytest.mark.unit
+class TestProviderConnectionUpdateCredentials:
+    """Test ProviderConnection.update_credentials() method."""
+
+    def test_update_credentials_success_when_active(self):
+        """Test update_credentials succeeds for ACTIVE connection."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+        new_credentials = create_credentials(
+            encrypted_data=b"new_encrypted_data",
+            expires_at=datetime.now(UTC) + timedelta(hours=2),
+        )
+
+        # Act
+        result = connection.update_credentials(new_credentials)
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.credentials == new_credentials
+
+    def test_update_credentials_fails_when_not_active(self):
+        """Test update_credentials fails for non-ACTIVE connection."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+        credentials = create_credentials()
+
+        # Act
+        result = connection.update_credentials(credentials)
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.NOT_CONNECTED
+
+    def test_update_credentials_fails_with_none(self):
+        """Test update_credentials fails when credentials is None."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+
+        # Act
+        result = connection.update_credentials(None)  # type: ignore[arg-type]
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.CREDENTIALS_REQUIRED
+
+    def test_update_credentials_updates_timestamp(self):
+        """Test update_credentials updates updated_at."""
+        # Arrange
+        old_credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=old_credentials,
+        )
+        original_updated_at = connection.updated_at
+        new_credentials = create_credentials()
+
+        # Act
+        connection.update_credentials(new_credentials)
+
+        # Assert
+        assert connection.updated_at > original_updated_at
+
+
+@pytest.mark.unit
+class TestProviderConnectionRecordSync:
+    """Test ProviderConnection.record_sync() method."""
+
+    def test_record_sync_success_when_active(self):
+        """Test record_sync succeeds for ACTIVE connection."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        assert connection.last_sync_at is None
+
+        # Act
+        result = connection.record_sync()
+
+        # Assert
+        assert isinstance(result, Success)
+        assert connection.last_sync_at is not None
+
+    def test_record_sync_fails_when_not_active(self):
+        """Test record_sync fails for non-ACTIVE connection."""
+        # Arrange
+        connection = create_connection(status=ConnectionStatus.PENDING)
+
+        # Act
+        result = connection.record_sync()
+
+        # Assert
+        assert isinstance(result, Failure)
+        assert result.error == ProviderConnectionError.NOT_CONNECTED
+
+    def test_record_sync_updates_last_sync_at(self):
+        """Test record_sync updates last_sync_at timestamp."""
+        # Arrange
+        credentials = create_credentials()
+        old_sync_time = datetime.now(UTC) - timedelta(hours=1)
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+            last_sync_at=old_sync_time,
+        )
+
+        # Act
+        connection.record_sync()
+
+        # Assert
+        assert connection.last_sync_at is not None
+        assert connection.last_sync_at > old_sync_time
+
+    def test_record_sync_updates_updated_at(self):
+        """Test record_sync updates updated_at timestamp."""
+        # Arrange
+        credentials = create_credentials()
+        connection = create_connection(
+            status=ConnectionStatus.ACTIVE,
+            credentials=credentials,
+        )
+        original_updated_at = connection.updated_at
+
+        # Act
+        connection.record_sync()
+
+        # Assert
+        assert connection.updated_at > original_updated_at

--- a/tests/unit/test_domain_provider_credentials.py
+++ b/tests/unit/test_domain_provider_credentials.py
@@ -1,0 +1,554 @@
+"""Unit tests for ProviderCredentials value object.
+
+Tests cover:
+- Value object creation and validation
+- Immutability (frozen dataclass)
+- Expiry checking methods (is_expired, is_expiring_soon, time_until_expiry)
+- Refresh support checking
+- String representations (security: no encrypted data)
+
+Architecture:
+- Unit tests for domain value object (no dependencies)
+- Tests pure validation logic
+- Validates immutability constraints
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.domain.enums.credential_type import CredentialType
+from src.domain.value_objects.provider_credentials import ProviderCredentials
+from tests.conftest import create_credentials
+
+
+@pytest.mark.unit
+class TestProviderCredentialsCreation:
+    """Test ProviderCredentials value object creation."""
+
+    def test_credentials_created_with_all_fields(self):
+        """Test credentials can be created with all fields."""
+        # Arrange
+        encrypted_data = b"encrypted_oauth_tokens"
+        credential_type = CredentialType.OAUTH2
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+        # Act
+        credentials = ProviderCredentials(
+            encrypted_data=encrypted_data,
+            credential_type=credential_type,
+            expires_at=expires_at,
+        )
+
+        # Assert
+        assert credentials.encrypted_data == encrypted_data
+        assert credentials.credential_type == credential_type
+        assert credentials.expires_at == expires_at
+
+    def test_credentials_created_without_expiration(self):
+        """Test credentials can be created without expiration (never expires)."""
+        # Act
+        credentials = create_credentials(
+            credential_type=CredentialType.API_KEY,
+            expires_at=None,
+        )
+
+        # Assert
+        assert credentials.expires_at is None
+
+    def test_credentials_created_with_each_credential_type(self):
+        """Test credentials can be created with each CredentialType."""
+        for cred_type in CredentialType:
+            # Act
+            credentials = create_credentials(credential_type=cred_type)
+
+            # Assert
+            assert credentials.credential_type == cred_type
+
+    def test_credentials_raises_error_for_empty_encrypted_data(self):
+        """Test creation fails with empty encrypted_data."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_credentials(encrypted_data=b"")
+
+        assert "encrypted_data cannot be empty" in str(exc_info.value)
+
+    def test_credentials_raises_error_for_non_bytes_encrypted_data(self):
+        """Test creation fails with non-bytes encrypted_data."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            ProviderCredentials(
+                encrypted_data="not bytes",  # type: ignore[arg-type]
+                credential_type=CredentialType.OAUTH2,
+            )
+
+        assert "encrypted_data must be bytes" in str(exc_info.value)
+
+    def test_credentials_raises_error_for_invalid_credential_type(self):
+        """Test creation fails with invalid credential_type."""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            ProviderCredentials(
+                encrypted_data=b"data",
+                credential_type="oauth2",  # type: ignore[arg-type]
+            )
+
+        assert "credential_type must be a CredentialType enum" in str(exc_info.value)
+
+    def test_credentials_raises_error_for_naive_datetime(self):
+        """Test creation fails with naive (non-timezone-aware) datetime."""
+        # Arrange
+        naive_datetime = datetime.now()  # No timezone  # noqa: DTZ005
+
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            create_credentials(expires_at=naive_datetime)
+
+        assert "expires_at must be timezone-aware" in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestProviderCredentialsImmutability:
+    """Test ProviderCredentials immutability (frozen dataclass)."""
+
+    def test_credentials_are_frozen(self):
+        """Test credentials cannot be modified after creation."""
+        # Arrange
+        credentials = create_credentials()
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            credentials.encrypted_data = b"new_data"  # type: ignore[misc]
+
+    def test_credentials_credential_type_is_frozen(self):
+        """Test credential_type cannot be modified."""
+        # Arrange
+        credentials = create_credentials()
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            credentials.credential_type = CredentialType.API_KEY  # type: ignore[misc]
+
+    def test_credentials_expires_at_is_frozen(self):
+        """Test expires_at cannot be modified."""
+        # Arrange
+        credentials = create_credentials(expires_at=datetime.now(UTC))
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            credentials.expires_at = datetime.now(UTC) + timedelta(hours=1)  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestProviderCredentialsIsExpired:
+    """Test ProviderCredentials.is_expired() method."""
+
+    def test_is_expired_false_when_no_expiration(self):
+        """Test is_expired returns False when no expiration set."""
+        # Arrange
+        credentials = create_credentials(expires_at=None)
+
+        # Assert
+        assert credentials.is_expired() is False
+
+    def test_is_expired_false_when_future_expiration(self):
+        """Test is_expired returns False when expiration is in future."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+
+        # Assert
+        assert credentials.is_expired() is False
+
+    def test_is_expired_true_when_past_expiration(self):
+        """Test is_expired returns True when expiration is in past."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(hours=1)
+        )
+
+        # Assert
+        assert credentials.is_expired() is True
+
+    def test_is_expired_true_at_exact_expiration(self):
+        """Test is_expired returns True at exact expiration time."""
+        # Arrange - expires exactly now (or just slightly in past)
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(milliseconds=1)
+        )
+
+        # Assert
+        assert credentials.is_expired() is True
+
+
+@pytest.mark.unit
+class TestProviderCredentialsIsExpiringSoon:
+    """Test ProviderCredentials.is_expiring_soon() method."""
+
+    def test_is_expiring_soon_false_when_no_expiration(self):
+        """Test is_expiring_soon returns False when no expiration set."""
+        # Arrange
+        credentials = create_credentials(expires_at=None)
+
+        # Assert
+        assert credentials.is_expiring_soon() is False
+
+    def test_is_expiring_soon_false_when_far_from_expiry(self):
+        """Test is_expiring_soon returns False when expiration is far away."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+
+        # Assert
+        assert credentials.is_expiring_soon() is False
+
+    def test_is_expiring_soon_true_within_default_threshold(self):
+        """Test is_expiring_soon returns True within 5 minute threshold."""
+        # Arrange - 3 minutes from now (within default 5 min threshold)
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(minutes=3)
+        )
+
+        # Assert
+        assert credentials.is_expiring_soon() is True
+
+    def test_is_expiring_soon_false_outside_default_threshold(self):
+        """Test is_expiring_soon returns False just outside threshold."""
+        # Arrange - 6 minutes from now (outside default 5 min threshold)
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(minutes=6)
+        )
+
+        # Assert
+        assert credentials.is_expiring_soon() is False
+
+    def test_is_expiring_soon_with_custom_threshold(self):
+        """Test is_expiring_soon with custom threshold."""
+        # Arrange - 8 minutes from now
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(minutes=8)
+        )
+
+        # Assert - 10 minute threshold should capture it
+        assert credentials.is_expiring_soon(threshold=timedelta(minutes=10)) is True
+
+    def test_is_expiring_soon_true_when_already_expired(self):
+        """Test is_expiring_soon returns True when already expired."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(minutes=5)
+        )
+
+        # Assert
+        assert credentials.is_expiring_soon() is True
+
+
+@pytest.mark.unit
+class TestProviderCredentialsTimeUntilExpiry:
+    """Test ProviderCredentials.time_until_expiry() method."""
+
+    def test_time_until_expiry_none_when_no_expiration(self):
+        """Test time_until_expiry returns None when no expiration set."""
+        # Arrange
+        credentials = create_credentials(expires_at=None)
+
+        # Assert
+        assert credentials.time_until_expiry() is None
+
+    def test_time_until_expiry_positive_when_not_expired(self):
+        """Test time_until_expiry returns positive timedelta when valid."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+
+        # Act
+        remaining = credentials.time_until_expiry()
+
+        # Assert
+        assert remaining is not None
+        assert remaining.total_seconds() > 0
+        # Should be roughly 1 hour (with small tolerance for test execution)
+        assert 3500 < remaining.total_seconds() < 3700
+
+    def test_time_until_expiry_zero_when_expired(self):
+        """Test time_until_expiry returns zero timedelta when expired."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(hours=1)
+        )
+
+        # Act
+        remaining = credentials.time_until_expiry()
+
+        # Assert
+        assert remaining is not None
+        assert remaining.total_seconds() == 0
+
+
+@pytest.mark.unit
+class TestProviderCredentialsSupportsRefresh:
+    """Test ProviderCredentials.supports_refresh() method."""
+
+    def test_supports_refresh_true_for_oauth2(self):
+        """Test supports_refresh returns True for OAuth2."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.OAUTH2)
+
+        # Assert
+        assert credentials.supports_refresh() is True
+
+    def test_supports_refresh_true_for_link_token(self):
+        """Test supports_refresh returns True for Plaid link tokens."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.LINK_TOKEN)
+
+        # Assert
+        assert credentials.supports_refresh() is True
+
+    def test_supports_refresh_false_for_api_key(self):
+        """Test supports_refresh returns False for API keys."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.API_KEY)
+
+        # Assert
+        assert credentials.supports_refresh() is False
+
+    def test_supports_refresh_false_for_certificate(self):
+        """Test supports_refresh returns False for certificates."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.CERTIFICATE)
+
+        # Assert
+        assert credentials.supports_refresh() is False
+
+    def test_supports_refresh_false_for_custom(self):
+        """Test supports_refresh returns False for custom credentials."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.CUSTOM)
+
+        # Assert
+        assert credentials.supports_refresh() is False
+
+
+@pytest.mark.unit
+class TestProviderCredentialsStringRepresentations:
+    """Test ProviderCredentials __repr__ and __str__ methods."""
+
+    def test_repr_does_not_include_encrypted_data(self):
+        """Test __repr__ does not expose encrypted data."""
+        # Arrange
+        credentials = create_credentials(
+            encrypted_data=b"super_secret_oauth_tokens",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        # Act
+        repr_str = repr(credentials)
+
+        # Assert
+        assert "super_secret_oauth_tokens" not in repr_str
+        assert "<25 bytes>" in repr_str  # Shows length instead
+
+    def test_repr_includes_credential_type(self):
+        """Test __repr__ includes credential type."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.API_KEY)
+
+        # Act
+        repr_str = repr(credentials)
+
+        # Assert
+        assert "api_key" in repr_str
+
+    def test_repr_includes_expiration(self):
+        """Test __repr__ includes expiration time."""
+        # Arrange
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        credentials = create_credentials(expires_at=expires_at)
+
+        # Act
+        repr_str = repr(credentials)
+
+        # Assert
+        assert expires_at.isoformat() in repr_str
+
+    def test_repr_handles_none_expiration(self):
+        """Test __repr__ handles None expiration."""
+        # Arrange
+        credentials = create_credentials(expires_at=None)
+
+        # Act
+        repr_str = repr(credentials)
+
+        # Assert
+        assert "expires_at=None" in repr_str
+
+    def test_str_does_not_include_encrypted_data(self):
+        """Test __str__ does not expose encrypted data."""
+        # Arrange
+        credentials = create_credentials(encrypted_data=b"super_secret_oauth_tokens")
+
+        # Act
+        str_result = str(credentials)
+
+        # Assert
+        assert "super_secret_oauth_tokens" not in str_result
+
+    def test_str_shows_valid_status_when_not_expired(self):
+        """Test __str__ shows 'valid' for non-expired credentials."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+
+        # Act
+        str_result = str(credentials)
+
+        # Assert
+        assert "valid" in str_result
+
+    def test_str_shows_expired_status_when_expired(self):
+        """Test __str__ shows 'expired' for expired credentials."""
+        # Arrange
+        credentials = create_credentials(
+            expires_at=datetime.now(UTC) - timedelta(hours=1)
+        )
+
+        # Act
+        str_result = str(credentials)
+
+        # Assert
+        assert "expired" in str_result
+
+    def test_str_includes_credential_type(self):
+        """Test __str__ includes credential type."""
+        # Arrange
+        credentials = create_credentials(credential_type=CredentialType.CERTIFICATE)
+
+        # Act
+        str_result = str(credentials)
+
+        # Assert
+        assert "certificate" in str_result
+
+
+@pytest.mark.unit
+class TestProviderCredentialsEquality:
+    """Test ProviderCredentials equality (frozen dataclass behavior)."""
+
+    def test_equal_credentials_are_equal(self):
+        """Test identical credentials are equal."""
+        # Arrange
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        cred1 = ProviderCredentials(
+            encrypted_data=b"same_data",
+            credential_type=CredentialType.OAUTH2,
+            expires_at=expires_at,
+        )
+        cred2 = ProviderCredentials(
+            encrypted_data=b"same_data",
+            credential_type=CredentialType.OAUTH2,
+            expires_at=expires_at,
+        )
+
+        # Assert
+        assert cred1 == cred2
+
+    def test_different_encrypted_data_not_equal(self):
+        """Test credentials with different data are not equal."""
+        # Arrange
+        cred1 = create_credentials(encrypted_data=b"data1")
+        cred2 = create_credentials(encrypted_data=b"data2")
+
+        # Assert
+        assert cred1 != cred2
+
+    def test_different_credential_type_not_equal(self):
+        """Test credentials with different types are not equal."""
+        # Arrange
+        cred1 = create_credentials(credential_type=CredentialType.OAUTH2)
+        cred2 = create_credentials(credential_type=CredentialType.API_KEY)
+
+        # Assert
+        assert cred1 != cred2
+
+    def test_different_expiration_not_equal(self):
+        """Test credentials with different expiration are not equal."""
+        # Arrange
+        now = datetime.now(UTC)
+        cred1 = create_credentials(expires_at=now + timedelta(hours=1))
+        cred2 = create_credentials(expires_at=now + timedelta(hours=2))
+
+        # Assert
+        assert cred1 != cred2
+
+    def test_credentials_hashable(self):
+        """Test credentials can be used in sets and as dict keys."""
+        # Arrange
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        cred1 = create_credentials(encrypted_data=b"data1", expires_at=expires_at)
+        cred2 = create_credentials(encrypted_data=b"data2", expires_at=expires_at)
+        cred3 = create_credentials(
+            encrypted_data=b"data1", expires_at=expires_at
+        )  # Same as cred1
+
+        # Act
+        cred_set = {cred1, cred2, cred3}
+
+        # Assert
+        assert len(cred_set) == 2  # cred1 and cred3 are equal
+
+
+@pytest.mark.unit
+class TestCredentialTypeEnumMethods:
+    """Test CredentialType enum helper methods."""
+
+    def test_values_returns_all_types(self):
+        """Test CredentialType.values() returns all type strings."""
+        # Act
+        values = CredentialType.values()
+
+        # Assert
+        assert len(values) == 5
+        assert "oauth2" in values
+        assert "api_key" in values
+        assert "link_token" in values
+        assert "certificate" in values
+        assert "custom" in values
+
+    def test_is_valid_true_for_valid_type(self):
+        """Test is_valid returns True for valid type string."""
+        # Assert
+        assert CredentialType.is_valid("oauth2") is True
+        assert CredentialType.is_valid("api_key") is True
+
+    def test_is_valid_false_for_invalid_type(self):
+        """Test is_valid returns False for invalid type string."""
+        # Assert
+        assert CredentialType.is_valid("invalid") is False
+        assert CredentialType.is_valid("OAUTH2") is False  # Case sensitive
+
+    def test_supports_refresh_returns_correct_types(self):
+        """Test supports_refresh returns types that support auto-refresh."""
+        # Act
+        refresh_types = CredentialType.supports_refresh()
+
+        # Assert
+        assert len(refresh_types) == 2
+        assert CredentialType.OAUTH2 in refresh_types
+        assert CredentialType.LINK_TOKEN in refresh_types
+        assert CredentialType.API_KEY not in refresh_types
+
+    def test_never_expires_returns_correct_types(self):
+        """Test never_expires returns types without expiration."""
+        # Act
+        no_expire_types = CredentialType.never_expires()
+
+        # Assert
+        assert len(no_expire_types) == 2
+        assert CredentialType.API_KEY in no_expire_types
+        assert CredentialType.CERTIFICATE in no_expire_types
+        assert CredentialType.OAUTH2 not in no_expire_types

--- a/tests/unit/test_domain_provider_events.py
+++ b/tests/unit/test_domain_provider_events.py
@@ -1,0 +1,359 @@
+"""Unit tests for Provider domain events.
+
+Tests cover:
+- Event creation with all required fields
+- Event immutability (frozen dataclasses)
+- Event inheritance from DomainEvent
+- Field validation (no missing attributes)
+- All 9 provider events (3 workflows × 3 states)
+
+Architecture:
+- Unit tests for domain events (no dependencies)
+- Tests pure event structure
+- Validates all events follow 3-state pattern
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.domain.events.provider_events import (
+    ProviderConnectionAttempted,
+    ProviderConnectionFailed,
+    ProviderConnectionSucceeded,
+    ProviderDisconnectionAttempted,
+    ProviderDisconnectionFailed,
+    ProviderDisconnectionSucceeded,
+    ProviderTokenRefreshAttempted,
+    ProviderTokenRefreshFailed,
+    ProviderTokenRefreshSucceeded,
+)
+
+
+@pytest.mark.unit
+class TestProviderConnectionAttempted:
+    """Test ProviderConnectionAttempted event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderConnectionAttempted(
+            user_id=user_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+        assert event.event_id is not None
+
+    def test_event_is_frozen(self):
+        """Test event is immutable (frozen dataclass)."""
+        # Arrange
+        event = ProviderConnectionAttempted(
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            provider_slug="schwab",
+        )
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            event.user_id = uuid4()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestProviderConnectionSucceeded:
+    """Test ProviderConnectionSucceeded event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderConnectionSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+
+    def test_event_is_frozen(self):
+        """Test event is immutable (frozen dataclass)."""
+        # Arrange
+        event = ProviderConnectionSucceeded(
+            user_id=uuid4(),
+            connection_id=uuid4(),
+            provider_id=uuid4(),
+            provider_slug="schwab",
+        )
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            event.connection_id = uuid4()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestProviderConnectionFailed:
+    """Test ProviderConnectionFailed event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderConnectionFailed(
+            user_id=user_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            reason="oauth_error",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.reason == "oauth_error"
+        assert event.occurred_at is not None
+
+    def test_event_created_with_different_failure_reasons(self):
+        """Test event supports various failure reasons."""
+        # Arrange
+        reasons = [
+            "user_cancelled",
+            "oauth_error",
+            "invalid_credentials",
+            "provider_unavailable",
+        ]
+
+        for reason in reasons:
+            # Act
+            event = ProviderConnectionFailed(
+                user_id=uuid4(),
+                provider_id=uuid4(),
+                provider_slug="schwab",
+                reason=reason,
+            )
+
+            # Assert
+            assert event.reason == reason
+
+
+@pytest.mark.unit
+class TestProviderDisconnectionAttempted:
+    """Test ProviderDisconnectionAttempted event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderDisconnectionAttempted(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+
+
+@pytest.mark.unit
+class TestProviderDisconnectionSucceeded:
+    """Test ProviderDisconnectionSucceeded event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderDisconnectionSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+
+
+@pytest.mark.unit
+class TestProviderDisconnectionFailed:
+    """Test ProviderDisconnectionFailed event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderDisconnectionFailed(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            reason="database_error",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.reason == "database_error"
+
+
+@pytest.mark.unit
+class TestProviderTokenRefreshAttempted:
+    """Test ProviderTokenRefreshAttempted event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderTokenRefreshAttempted(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+
+
+@pytest.mark.unit
+class TestProviderTokenRefreshSucceeded:
+    """Test ProviderTokenRefreshSucceeded event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderTokenRefreshSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.occurred_at is not None
+
+
+@pytest.mark.unit
+class TestProviderTokenRefreshFailed:
+    """Test ProviderTokenRefreshFailed event."""
+
+    def test_event_created_with_all_required_fields(self):
+        """Test event can be created with all required fields."""
+        # Arrange
+        user_id = uuid4()
+        connection_id = uuid4()
+        provider_id = uuid4()
+
+        # Act
+        event = ProviderTokenRefreshFailed(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            reason="refresh_token_expired",
+            needs_user_action=True,
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.connection_id == connection_id
+        assert event.provider_id == provider_id
+        assert event.provider_slug == "schwab"
+        assert event.reason == "refresh_token_expired"
+        assert event.needs_user_action is True
+
+    def test_event_created_with_default_needs_user_action(self):
+        """Test event defaults needs_user_action to False."""
+        # Act
+        event = ProviderTokenRefreshFailed(
+            user_id=uuid4(),
+            connection_id=uuid4(),
+            provider_id=uuid4(),
+            provider_slug="schwab",
+            reason="network_error",
+        )
+
+        # Assert
+        assert event.needs_user_action is False
+
+    def test_event_created_with_different_failure_reasons(self):
+        """Test event supports various failure reasons."""
+        # Arrange
+        reasons = [
+            "refresh_token_expired",
+            "provider_revoked",
+            "network_error",
+        ]
+
+        for reason in reasons:
+            # Act
+            event = ProviderTokenRefreshFailed(
+                user_id=uuid4(),
+                connection_id=uuid4(),
+                provider_id=uuid4(),
+                provider_slug="schwab",
+                reason=reason,
+            )
+
+            # Assert
+            assert event.reason == reason


### PR DESCRIPTION
## Overview
Implements F2.1: Provider Connection Domain Model - pure domain layer for financial provider connections (Schwab, Plaid, etc.).

## Implementation Summary

### Phase 1: Architecture Documentation ✅
- **File**: `docs/architecture/provider-domain-model.md`
- Complete specification with state machine diagrams
- Authentication-agnostic credential design
- Protocol-based repository interface

### Phase 2: Value Objects & Enums ✅
- **ConnectionStatus**: 6 states (pending → active ↔ expired/revoked/failed → disconnected)
- **CredentialType**: 5 types (oauth2, api_key, link_token, certificate, custom)
- **ProviderCredentials**: Encrypted opaque credentials with expiration logic

### Phase 3: Domain Entity ✅
- **ProviderConnection**: Pure domain entity with business logic
- State machine transitions with Result types (ROP)
- Query methods: `is_connected()`, `needs_reauthentication()`, `can_sync()`
- Business methods: `mark_connected()`, `mark_disconnected()`, `mark_expired()`, etc.

### Phase 4: Domain Events ✅
- **9 events**: 3 workflows × 3-state ATTEMPT → OUTCOME pattern
- Connection workflow (attempted/succeeded/failed)
- Disconnection workflow (attempted/succeeded/failed)
- Token refresh workflow (attempted/succeeded/failed)
- Moved from `auth_events.py` to dedicated `provider_events.py`

### Phase 5: Protocol Definition ✅
- **ProviderConnectionRepository**: Protocol-based interface
- 7 methods: find_by_id, find_by_user_id, find_active_by_user, save, delete, etc.
- Infrastructure layer will implement (not in this PR)

### Phase 6: Domain Exports ✅
- Updated all `__init__.py` files with proper exports
- Clean import paths for all domain components

### Phase 7: Unit Tests ✅
- **121 tests** with **100% coverage** (259/259 statements)
- `test_domain_provider_connection.py`: 61 tests (entity + enums)
- `test_domain_provider_credentials.py`: 46 tests (value object)
- `test_domain_provider_events.py`: 14 tests (events)
- All tests pass, fully type-safe

## Key Design Decisions

1. **Authentication-agnostic**: Domain has NO knowledge of OAuth/API keys - only opaque encrypted credentials
2. **Dynamic providers**: No ProviderType enum - providers identified by UUID + slug
3. **Protocol over ABC**: Structural typing for flexibility
4. **Multiple connections per provider**: User can have multiple connections to same provider (distinguished by alias)
5. **Result types**: All state transitions return `Result[T, E]` (Railway-Oriented Programming)
6. **100% domain purity**: Zero infrastructure imports

## Quality Metrics

| Check | Status |
|-------|--------|
| Tests | ✅ 121 passed |
| Coverage | ✅ 100% |
| Type Check | ✅ No issues (18 files) |
| Lint | ✅ All checks passed |
| Format | ✅ All files formatted |

## Files Changed (19 total)

**Domain Layer** (15 files):
- `docs/architecture/provider-domain-model.md` (new)
- `src/domain/entities/provider_connection.py` (new)
- `src/domain/enums/connection_status.py` (new)
- `src/domain/enums/credential_type.py` (new)
- `src/domain/errors/provider_connection_error.py` (new)
- `src/domain/events/provider_events.py` (new)
- `src/domain/events/auth_events.py` (modified - removed provider events)
- `src/domain/protocols/provider_connection_repository.py` (new)
- `src/domain/value_objects/provider_credentials.py` (new)
- `src/domain/entities/__init__.py` (modified)
- `src/domain/enums/__init__.py` (modified)
- `src/domain/errors/__init__.py` (modified)
- `src/domain/events/__init__.py` (modified)
- `src/domain/protocols/__init__.py` (modified)
- `src/domain/value_objects/__init__.py` (modified)

**Tests** (4 files):
- `tests/unit/test_domain_provider_connection.py` (new)
- `tests/unit/test_domain_provider_credentials.py` (new)
- `tests/unit/test_domain_provider_events.py` (new)
- `tests/conftest.py` (modified - added `create_credentials` helper)

## Next Steps

After merge:
- **F2.2**: Account & Transaction domain models
- **F3.x**: Application layer (repositories, commands, queries)
- **F4.x**: Provider integration (Schwab OAuth, APIs)

## Related

- Follows architecture documented in `WARP.md`
- Implements Phase 2 of Dashtam feature roadmap
- Foundation for Phase 3-6 implementation