### PR TITLE
feat(core): migrate from UUID v4 to UUID v7 (RFC 9562)

### DIFF
--- a/docs/architecture/account-domain-model.md
+++ b/docs/architecture/account-domain-model.md
@@ -516,13 +516,13 @@ class TestCurrencyValidation:
 
 ```python
 from decimal import Decimal
-from uuid import uuid4
+from uuid_extensions import uuid7
 from src.domain.entities import Account
 from src.domain.enums import AccountType
 from src.domain.value_objects import Money
 
 account = Account(
-    id=uuid4(),
+    id=uuid7(),
     connection_id=connection.id,
     provider_account_id="ACCT-123456",
     account_number_masked="****1234",

--- a/docs/architecture/audit-trail-architecture.md
+++ b/docs/architecture/audit-trail-architecture.md
@@ -1123,7 +1123,8 @@ CREATE RULE audit_logs_no_delete AS
 
 ```python
 from datetime import datetime, UTC
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1163,7 +1164,7 @@ class PostgresAuditAdapter:
         """Record immutable audit entry in PostgreSQL."""
         try:
             audit_log = AuditLogModel(
-                id=uuid4(),
+                id=uuid7(),
                 action=action.value,
                 user_id=user_id,
                 resource_type=resource_type,

--- a/docs/architecture/authentication-architecture.md
+++ b/docs/architecture/authentication-architecture.md
@@ -747,7 +747,7 @@ All events inherit from `DomainEvent` which provides:
 ```python
 @dataclass(frozen=True, slots=True, kw_only=True)
 class DomainEvent:
-    event_id: UUID = field(default_factory=uuid4)  # Auto-generated
+    event_id: UUID = field(default_factory=uuid7)  # Auto-generated
     occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))  # Auto-generated
 ```
 

--- a/docs/architecture/database-architecture.md
+++ b/docs/architecture/database-architecture.md
@@ -156,7 +156,7 @@ class ChangePasswordHandler:
         
         # Emit domain event (triggers audit, logging, notifications)
         await self.event_bus.publish(UserPasswordChanged(
-            event_id=uuid4(),
+            event_id=uuid7(),
             occurred_at=datetime.now(UTC),
             user_id=user.id,
         ))
@@ -567,7 +567,7 @@ async def create_user(
 ```python
 # src/infrastructure/persistence/base.py
 from datetime import datetime, timezone
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from sqlalchemy import Column, DateTime, func
 from sqlalchemy.dialects.postgresql import UUID
@@ -588,7 +588,7 @@ class Base(DeclarativeBase):
     id: Mapped[UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
-        default=uuid4,
+        default=uuid7,
         nullable=False,
     )
     

--- a/docs/architecture/domain-events-architecture.md
+++ b/docs/architecture/domain-events-architecture.md
@@ -62,7 +62,7 @@ async def change_password(cmd: ChangePassword):
 async def change_password(cmd: ChangePassword):
     # Event 1: ATTEMPT
     await event_bus.publish(PasswordChangeAttempted(
-        event_id=uuid4(),
+        event_id=uuid7(),
         occurred_at=datetime.now(UTC),
         user_id=cmd.user_id,
     ))
@@ -74,7 +74,7 @@ async def change_password(cmd: ChangePassword):
         
         # Event 2: SUCCESS
         await event_bus.publish(PasswordChangeSucceeded(
-            event_id=uuid4(),
+            event_id=uuid7(),
             occurred_at=datetime.now(UTC),
             user_id=user.id,
             initiated_by=cmd.initiated_by,
@@ -83,7 +83,7 @@ async def change_password(cmd: ChangePassword):
     except Exception as e:
         # Event 3: FAILURE
         await event_bus.publish(PasswordChangeFailed(
-            event_id=uuid4(),
+            event_id=uuid7(),
             occurred_at=datetime.now(UTC),
             user_id=cmd.user_id,
             reason=str(e),
@@ -1694,7 +1694,7 @@ def get_event_bus() -> EventBusProtocol:
 
 ```python
 """Change password command handler (example of event-driven pattern)."""
-from uuid import uuid4
+from uuid_extensions import uuid7
 from datetime import datetime, UTC
 from src.application.commands.change_password import ChangePassword
 from src.domain.protocols.user_repository import UserRepository
@@ -1750,7 +1750,7 @@ class ChangePasswordHandler:
         # Event 1: ATTEMPTED
         # ═══════════════════════════════════════════════════════════
         await self.event_bus.publish(UserPasswordChangeAttempted(
-            event_id=uuid4(),
+            event_id=uuid7(),
             occurred_at=datetime.now(UTC),
             user_id=cmd.user_id,
         ))
@@ -1779,7 +1779,7 @@ class ChangePasswordHandler:
                         # Event 2: SUCCEEDED
                         # ═══════════════════════════════════════════
                         await self.event_bus.publish(UserPasswordChangeSucceeded(
-                            event_id=uuid4(),
+                            event_id=uuid7(),
                             occurred_at=datetime.now(UTC),
                             user_id=user.id,
                             initiated_by=cmd.initiated_by,
@@ -1796,7 +1796,7 @@ class ChangePasswordHandler:
                         # Event 3: FAILED (database error)
                         # ═══════════════════════════════════════════
                         await self.event_bus.publish(UserPasswordChangeFailed(
-                            event_id=uuid4(),
+                            event_id=uuid7(),
                             occurred_at=datetime.now(UTC),
                             user_id=cmd.user_id,
                             reason=f"database_error: {error}",
@@ -1811,7 +1811,7 @@ class ChangePasswordHandler:
                 # Event 3: FAILED (user not found)
                 # ═══════════════════════════════════════════════════
                 await self.event_bus.publish(UserPasswordChangeFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=cmd.user_id,
                     reason="user_not_found",

--- a/docs/architecture/error-handling-architecture.md
+++ b/docs/architecture/error-handling-architecture.md
@@ -565,7 +565,7 @@ class UserService:
             ))
         
         # Create user
-        user = User(id=uuid4(), email=email, ...)
+        user = User(id=uuid7(), email=email, ...)
         await self.users.save(user)
         
         return Success(user)

--- a/docs/architecture/session-management-architecture.md
+++ b/docs/architecture/session-management-architecture.md
@@ -858,7 +858,8 @@ class ListUserSessions:
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.core.result import Failure, Result, Success
 from src.domain.entities.session import Session
@@ -929,7 +930,7 @@ class CreateSessionHandler:
         )
         
         # Create session entity
-        session_id = uuid4()
+        session_id = uuid7()
         expires_at = datetime.now(UTC) + timedelta(seconds=command.expires_at_seconds)
         
         session = Session(
@@ -1562,14 +1563,15 @@ class SessionListResponse(BaseModel):
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 
 @dataclass(frozen=True, kw_only=True)
 class SessionCreatedEvent:
     """Published when a new session is created."""
     
-    event_id: UUID = field(default_factory=uuid4)
+    event_id: UUID = field(default_factory=uuid7)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     
     session_id: UUID
@@ -1583,7 +1585,7 @@ class SessionCreatedEvent:
 class SessionRevokedEvent:
     """Published when a session is revoked."""
     
-    event_id: UUID = field(default_factory=uuid4)
+    event_id: UUID = field(default_factory=uuid7)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     
     session_id: UUID
@@ -1595,7 +1597,7 @@ class SessionRevokedEvent:
 class AllSessionsRevokedEvent:
     """Published when all user sessions are revoked."""
     
-    event_id: UUID = field(default_factory=uuid4)
+    event_id: UUID = field(default_factory=uuid7)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     
     user_id: UUID

--- a/docs/architecture/structured-logging-architecture.md
+++ b/docs/architecture/structured-logging-architecture.md
@@ -398,7 +398,7 @@ from src.core.container import get_logger
 
 @app.middleware("http")
 async def bind_request_context(request: Request, call_next):
-    trace_id = request.headers.get("X-Trace-ID") or str(uuid4())
+    trace_id = request.headers.get("X-Trace-ID") or str(uuid7())
     
     # Create request-scoped logger
     request_logger = get_logger().bind(
@@ -992,7 +992,7 @@ class AuthService:
 
 ```python
 # src/presentation/api/middleware/trace_middleware.py
-from uuid import uuid4
+from uuid_extensions import uuid7
 from contextvars import ContextVar
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -1005,7 +1005,7 @@ class TraceMiddleware(BaseHTTPMiddleware):
     
     async def dispatch(self, request, call_next):
         # Generate or extract trace_id
-        trace_id = request.headers.get("X-Trace-Id") or str(uuid4())
+        trace_id = request.headers.get("X-Trace-Id") or str(uuid7())
         
         # Store in context variable
         trace_id_context.set(trace_id)
@@ -1022,7 +1022,7 @@ def get_trace_id() -> str:
     trace_id = trace_id_context.get()
     if not trace_id:
         # Fallback for non-HTTP contexts (background tasks)
-        trace_id = str(uuid4())
+        trace_id = str(uuid7())
         trace_id_context.set(trace_id)
     return trace_id
 
@@ -1540,7 +1540,7 @@ async def start_background_tasks():
     
     async def refresh_tokens():
         # Generate new trace_id for background task
-        trace_id = str(uuid4())
+        trace_id = str(uuid7())
         trace_id_context.set(trace_id)
         
         logger.info(
@@ -1788,7 +1788,7 @@ class MultiAdapter:
 # 1. Middleware injects trace_id
 @app.middleware("http")
 async def trace_middleware(request: Request, call_next):
-    trace_id = str(uuid4())
+    trace_id = str(uuid7())
     trace_id_context.set(trace_id)
     
     logger = get_logger()

--- a/docs/architecture/testing-architecture.md
+++ b/docs/architecture/testing-architecture.md
@@ -1100,7 +1100,7 @@ class TestEventFlowEndToEnd:
         """Test UserRegistrationSucceeded → audit record created."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserRegistrationSucceeded(
             user_id=user_id, email="integration@example.com"
         )

--- a/docs/guides/audit-usage-patterns.md
+++ b/docs/guides/audit-usage-patterns.md
@@ -105,7 +105,7 @@ async def register_user(
     
     # Step 3: Business logic - create user
     try:
-        user_id = uuid4()
+        user_id = uuid7()
         user = User(
             id=user_id,
             email=data.email,

--- a/docs/guides/domain-events-usage.md
+++ b/docs/guides/domain-events-usage.md
@@ -481,7 +481,7 @@ async def test_user_registration_creates_audit_record(test_database):
     # Act
     await event_bus.publish(
         UserRegistrationSucceeded(
-            user_id=uuid4(),
+            user_id=uuid7(),
             email="test@example.com"
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "structlog>=25.5.0",
     "urllib3>=2.5.0",
     "user-agents>=2.2.0",
+    "uuid7>=0.1.0",
     "uvicorn[standard]>=0.37.0",
 ]
 
@@ -116,6 +117,7 @@ module = [
     "casbin_async_sqlalchemy_adapter",
     "user_agents",
     "user_agents.*",
+    "uuid_extensions",
 ]
 ignore_missing_imports = true
 

--- a/src/application/commands/handlers/authenticate_user_handler.py
+++ b/src/application/commands/handlers/authenticate_user_handler.py
@@ -27,7 +27,8 @@ Architecture:
 """
 
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import AuthenticateUser, AuthenticatedUser
 from src.core.result import Failure, Result, Success
@@ -97,7 +98,7 @@ class AuthenticateUserHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             UserLoginAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 email=cmd.email,
             )
@@ -165,7 +166,7 @@ class AuthenticateUserHandler:
         # Note: session_id is no longer emitted here - session creation is separate
         await self._event_bus.publish(
             UserLoginSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user.id,
                 email=user.email,
@@ -196,7 +197,7 @@ class AuthenticateUserHandler:
         """
         await self._event_bus.publish(
             UserLoginFailed(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 email=email,
                 reason=reason,

--- a/src/application/commands/handlers/confirm_password_reset_handler.py
+++ b/src/application/commands/handlers/confirm_password_reset_handler.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import ConfirmPasswordReset
 from src.core.result import Failure, Result, Success
@@ -125,7 +125,7 @@ class ConfirmPasswordResetHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             PasswordResetConfirmAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 token=cmd.token[:8] + "..." if len(cmd.token) > 8 else cmd.token,
             )
@@ -186,7 +186,7 @@ class ConfirmPasswordResetHandler:
         # Step 11: Emit SUCCEEDED event
         await self._event_bus.publish(
             PasswordResetConfirmSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user.id,
                 email=user.email,
@@ -209,7 +209,7 @@ class ConfirmPasswordResetHandler:
         """
         await self._event_bus.publish(
             PasswordResetConfirmFailed(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 token=token[:8] + "..." if len(token) > 8 else token,
                 reason=reason,

--- a/src/application/commands/handlers/create_session_handler.py
+++ b/src/application/commands/handlers/create_session_handler.py
@@ -18,7 +18,8 @@ Architecture:
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.session_commands import CreateSession
 from src.core.result import Failure, Result, Success
@@ -135,7 +136,7 @@ class CreateSessionHandler:
                     return Failure(error=CreateSessionError.EVICTION_FAILED)
 
         # Step 5: Create session
-        session_id = uuid4()
+        session_id = uuid7()
         now = datetime.now(UTC)
         expires_at = cmd.expires_at or (
             now + timedelta(days=DEFAULT_SESSION_LIFETIME_DAYS)
@@ -167,7 +168,7 @@ class CreateSessionHandler:
         # Step 8: Publish event
         await self._event_bus.publish(
             SessionCreatedEvent(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=now,
                 session_id=session_id,
                 user_id=cmd.user_id,
@@ -220,7 +221,7 @@ class CreateSessionHandler:
         # Publish eviction event
         await self._event_bus.publish(
             SessionEvictedEvent(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=now,
                 session_id=oldest.id,
                 user_id=user_id,

--- a/src/application/commands/handlers/logout_user_handler.py
+++ b/src/application/commands/handlers/logout_user_handler.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import LogoutUser
 from src.core.result import Result, Success
@@ -96,7 +97,7 @@ class LogoutUserHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             UserLogoutAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=cmd.user_id,
             )
@@ -115,7 +116,7 @@ class LogoutUserHandler:
             # For security, we still return success but log internally
             await self._event_bus.publish(
                 UserLogoutFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=cmd.user_id,
                     reason=LogoutError.TOKEN_NOT_FOUND,
@@ -130,7 +131,7 @@ class LogoutUserHandler:
             # Token doesn't belong to user - security issue
             await self._event_bus.publish(
                 UserLogoutFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=cmd.user_id,
                     reason="token_user_mismatch",
@@ -143,7 +144,7 @@ class LogoutUserHandler:
         if token_data.revoked_at is not None:
             await self._event_bus.publish(
                 UserLogoutFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=cmd.user_id,
                     reason=LogoutError.TOKEN_ALREADY_REVOKED,
@@ -160,7 +161,7 @@ class LogoutUserHandler:
         # Step 4: Emit SUCCEEDED event
         await self._event_bus.publish(
             UserLogoutSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=cmd.user_id,
                 session_id=session_id,

--- a/src/application/commands/handlers/refresh_access_token_handler.py
+++ b/src/application/commands/handlers/refresh_access_token_handler.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import RefreshAccessToken
 from src.core.result import Failure, Result, Success
@@ -129,7 +130,7 @@ class RefreshAccessTokenHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             AuthTokenRefreshAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=None,  # Unknown until we verify token
             )
@@ -197,7 +198,7 @@ class RefreshAccessTokenHandler:
                 # Emit security monitoring event
                 await self._event_bus.publish(
                     TokenRejectedDueToRotation(
-                        event_id=uuid4(),
+                        event_id=uuid7(),
                         occurred_at=now,
                         user_id=user.id,
                         token_version=token_data.token_version,
@@ -253,7 +254,7 @@ class RefreshAccessTokenHandler:
         # Step 10: Emit SUCCEEDED event
         await self._event_bus.publish(
             AuthTokenRefreshSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user.id,
                 session_id=token_data.session_id,
@@ -328,7 +329,7 @@ class RefreshAccessTokenHandler:
         """
         await self._event_bus.publish(
             AuthTokenRefreshFailed(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user_id,
                 reason=reason,

--- a/src/application/commands/handlers/register_user_handler.py
+++ b/src/application/commands/handlers/register_user_handler.py
@@ -26,7 +26,8 @@ Architecture:
 
 import secrets
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import RegisterUser
 from src.core.result import Failure, Result, Success
@@ -101,7 +102,7 @@ class RegisterUserHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             UserRegistrationAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 email=cmd.email,
             )
@@ -117,7 +118,7 @@ class RegisterUserHandler:
                 # Emit FAILED event
                 await self._event_bus.publish(
                     UserRegistrationFailed(
-                        event_id=uuid4(),
+                        event_id=uuid7(),
                         occurred_at=datetime.now(UTC),
                         email=cmd.email,
                         reason=RegistrationError.EMAIL_ALREADY_EXISTS,
@@ -129,7 +130,7 @@ class RegisterUserHandler:
             password_hash = self._password_service.hash_password(cmd.password)
 
             # Step 5: Create User entity
-            user_id = uuid4()
+            user_id = uuid7()
             now = datetime.now(UTC)
             user = User(
                 id=user_id,
@@ -158,7 +159,7 @@ class RegisterUserHandler:
             # Step 8: Emit SUCCEEDED event (triggers email via EmailEventHandler)
             await self._event_bus.publish(
                 UserRegistrationSucceeded(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=user_id,
                     email=cmd.email,
@@ -173,7 +174,7 @@ class RegisterUserHandler:
             # Catch-all for database errors or unexpected issues
             await self._event_bus.publish(
                 UserRegistrationFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     email=cmd.email,
                     reason=f"{RegistrationError.DATABASE_ERROR}: {str(e)}",

--- a/src/application/commands/handlers/request_password_reset_handler.py
+++ b/src/application/commands/handlers/request_password_reset_handler.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import RequestPasswordReset
 from src.core.result import Result, Success
@@ -127,7 +127,7 @@ class RequestPasswordResetHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             PasswordResetRequestAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 email=cmd.email,
             )
@@ -140,7 +140,7 @@ class RequestPasswordResetHandler:
         if user is None:
             await self._event_bus.publish(
                 PasswordResetRequestFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     email=cmd.email,
                     reason=PasswordResetError.USER_NOT_FOUND,
@@ -153,7 +153,7 @@ class RequestPasswordResetHandler:
         if not user.is_verified:
             await self._event_bus.publish(
                 PasswordResetRequestFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     email=cmd.email,
                     reason=PasswordResetError.USER_NOT_VERIFIED,
@@ -172,7 +172,7 @@ class RequestPasswordResetHandler:
         if request_count >= self.MAX_REQUESTS_PER_HOUR:
             await self._event_bus.publish(
                 PasswordResetRequestFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     email=cmd.email,
                     reason=PasswordResetError.RATE_LIMITED,
@@ -204,7 +204,7 @@ class RequestPasswordResetHandler:
         # Step 8: Emit SUCCEEDED event
         await self._event_bus.publish(
             PasswordResetRequestSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user.id,
                 email=user.email,

--- a/src/application/commands/handlers/revoke_all_sessions_handler.py
+++ b/src/application/commands/handlers/revoke_all_sessions_handler.py
@@ -17,7 +17,7 @@ Architecture:
 """
 
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.application.commands.session_commands import RevokeAllUserSessions
 from src.core.result import Result, Success
@@ -88,7 +88,7 @@ class RevokeAllSessionsHandler:
         now = datetime.now(UTC)
         await self._event_bus.publish(
             AllSessionsRevokedEvent(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=now,
                 user_id=cmd.user_id,
                 reason=cmd.reason,

--- a/src/application/commands/handlers/revoke_session_handler.py
+++ b/src/application/commands/handlers/revoke_session_handler.py
@@ -15,7 +15,8 @@ Architecture:
 """
 
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.session_commands import RevokeSession
 from src.core.result import Failure, Result, Success
@@ -100,7 +101,7 @@ class RevokeSessionHandler:
         # Step 7: Publish event
         await self._event_bus.publish(
             SessionRevokedEvent(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=now,
                 session_id=cmd.session_id,
                 user_id=cmd.user_id,

--- a/src/application/commands/handlers/trigger_global_rotation_handler.py
+++ b/src/application/commands/handlers/trigger_global_rotation_handler.py
@@ -14,7 +14,7 @@ On failure:
 """
 
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.application.commands.rotation_commands import (
     GlobalRotationResult,
@@ -72,7 +72,7 @@ class TriggerGlobalTokenRotationHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             GlobalTokenRotationAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 triggered_by=cmd.triggered_by,
                 reason=cmd.reason,
@@ -97,7 +97,7 @@ class TriggerGlobalTokenRotationHandler:
             # Step 5: Emit SUCCEEDED event
             await self._event_bus.publish(
                 GlobalTokenRotationSucceeded(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     triggered_by=cmd.triggered_by,
                     previous_version=previous_version,
@@ -120,7 +120,7 @@ class TriggerGlobalTokenRotationHandler:
             # Emit FAILED event
             await self._event_bus.publish(
                 GlobalTokenRotationFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     triggered_by=cmd.triggered_by,
                     reason=cmd.reason,

--- a/src/application/commands/handlers/trigger_user_rotation_handler.py
+++ b/src/application/commands/handlers/trigger_user_rotation_handler.py
@@ -15,7 +15,7 @@ On failure:
 """
 
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.application.commands.rotation_commands import (
     TriggerUserTokenRotation,
@@ -79,7 +79,7 @@ class TriggerUserTokenRotationHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             UserTokenRotationAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=cmd.user_id,
                 triggered_by=cmd.triggered_by,
@@ -94,7 +94,7 @@ class TriggerUserTokenRotationHandler:
         if user is None:
             await self._event_bus.publish(
                 UserTokenRotationFailed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     occurred_at=datetime.now(UTC),
                     user_id=cmd.user_id,
                     triggered_by=cmd.triggered_by,
@@ -115,7 +115,7 @@ class TriggerUserTokenRotationHandler:
         # Step 6: Emit SUCCEEDED event
         await self._event_bus.publish(
             UserTokenRotationSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=cmd.user_id,
                 triggered_by=cmd.triggered_by,

--- a/src/application/commands/handlers/verify_email_handler.py
+++ b/src/application/commands/handlers/verify_email_handler.py
@@ -24,7 +24,8 @@ Architecture:
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from src.application.commands.auth_commands import VerifyEmail
 from src.core.result import Failure, Result, Success
@@ -98,7 +99,7 @@ class VerifyEmailHandler:
         # Step 1: Emit ATTEMPTED event
         await self._event_bus.publish(
             EmailVerificationAttempted(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 token=token_preview,
             )
@@ -151,7 +152,7 @@ class VerifyEmailHandler:
         # Step 8: Emit SUCCEEDED event
         await self._event_bus.publish(
             EmailVerificationSucceeded(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 user_id=user.id,
                 email=user.email,
@@ -174,7 +175,7 @@ class VerifyEmailHandler:
         """
         await self._event_bus.publish(
             EmailVerificationFailed(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred_at=datetime.now(UTC),
                 token=token,
                 reason=reason,

--- a/src/domain/entities/account.py
+++ b/src/domain/entities/account.py
@@ -13,13 +13,14 @@ Reference:
     - docs/architecture/account-domain-model.md
 
 Usage:
+    from uuid_extensions import uuid7
     from src.domain.entities import Account
     from src.domain.enums import AccountType
     from src.domain.value_objects import Money
     from decimal import Decimal
 
     account = Account(
-        id=uuid4(),
+        id=uuid7(),
         connection_id=connection.id,
         provider_account_id="SCHWAB-12345",
         account_number_masked="****1234",
@@ -75,7 +76,7 @@ class Account:
 
     Example:
         >>> account = Account(
-        ...     id=uuid4(),
+        ...     id=uuid7(),
         ...     connection_id=connection.id,
         ...     provider_account_id="ACC-12345",
         ...     account_number_masked="****1234",

--- a/src/domain/entities/provider_connection.py
+++ b/src/domain/entities/provider_connection.py
@@ -13,11 +13,12 @@ Reference:
     - docs/architecture/provider-domain-model.md
 
 Usage:
+    from uuid_extensions import uuid7
     from src.domain.entities import ProviderConnection
     from src.domain.enums import ConnectionStatus
 
     connection = ProviderConnection(
-        id=uuid4(),
+        id=uuid7(),
         user_id=user.id,
         provider_id=provider_uuid,
         provider_slug="schwab",
@@ -77,7 +78,7 @@ class ProviderConnection:
 
     Example:
         >>> conn = ProviderConnection(
-        ...     id=uuid4(),
+        ...     id=uuid7(),
         ...     user_id=user_id,
         ...     provider_id=provider_id,
         ...     provider_slug="schwab",

--- a/src/domain/entities/session.py
+++ b/src/domain/entities/session.py
@@ -63,12 +63,12 @@ class Session:
             providers_accessed: List of providers accessed in this session.
 
     Example:
-        >>> from uuid import uuid4
+        >>> from uuid_extensions import uuid7
         >>> from datetime import datetime, UTC, timedelta
         >>>
         >>> session = Session(
-        ...     id=uuid4(),
-        ...     user_id=uuid4(),
+        ...     id=uuid7(),
+        ...     user_id=uuid7(),
         ...     device_info="Chrome on macOS",
         ...     ip_address="192.168.1.1",
         ...     expires_at=datetime.now(UTC) + timedelta(days=30),
@@ -126,7 +126,7 @@ class Session:
             True if session is active, False otherwise.
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4())
+            >>> session = Session(id=uuid7(), user_id=uuid7())
             >>> session.is_active()
             True
             >>> session.revoke("test")
@@ -154,7 +154,7 @@ class Session:
                 - "security_concern": Suspicious activity detected
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4())
+            >>> session = Session(id=uuid7(), user_id=uuid7())
             >>> session.revoke("user_logout")
             >>> session.is_revoked
             True
@@ -177,7 +177,7 @@ class Session:
                 different from stored IP, triggers IP change tracking.
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4(), ip_address="1.1.1.1")
+            >>> session = Session(id=uuid7(), user_id=uuid7(), ip_address="1.1.1.1")
             >>> session.update_activity(ip_address="2.2.2.2")
             >>> session.last_ip_address
             '2.2.2.2'
@@ -200,7 +200,7 @@ class Session:
             provider_name: Provider that was accessed (e.g., "schwab", "fidelity").
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4())
+            >>> session = Session(id=uuid7(), user_id=uuid7())
             >>> session.record_provider_access("schwab")
             >>> session.last_provider_accessed
             'schwab'
@@ -224,7 +224,7 @@ class Session:
         - IP changes from different geolocations
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4())
+            >>> session = Session(id=uuid7(), user_id=uuid7())
             >>> session.suspicious_activity_count
             0
             >>> session.increment_suspicious_activity()
@@ -242,7 +242,7 @@ class Session:
         - Extended session duration
 
         Example:
-            >>> session = Session(id=uuid4(), user_id=uuid4())
+            >>> session = Session(id=uuid7(), user_id=uuid7())
             >>> session.is_trusted
             False
             >>> session.mark_as_trusted()

--- a/src/domain/entities/transaction.py
+++ b/src/domain/entities/transaction.py
@@ -64,10 +64,10 @@ class Transaction:
         updated_at: Timestamp of last sync update.
 
     Example:
-        >>> from uuid import uuid4
+        >>> from uuid_extensions import uuid7
         >>> # Stock purchase
         >>> transaction = Transaction(
-        ...     id=uuid4(),
+        ...     id=uuid7(),
         ...     account_id=account_id,
         ...     provider_transaction_id="schwab-12345",
         ...     transaction_type=TransactionType.TRADE,

--- a/src/domain/entities/user.py
+++ b/src/domain/entities/user.py
@@ -62,8 +62,9 @@ class User:
             min_token_version: Per-user minimum token version (increment to invalidate tokens)
 
     Example:
+        >>> from uuid_extensions import uuid7
         >>> user = User(
-        ...     id=uuid4(),
+        ...     id=uuid7(),
         ...     email="user@example.com",
         ...     password_hash="$2b$12$...",
         ...     is_verified=False,

--- a/src/domain/errors/transaction_error.py
+++ b/src/domain/errors/transaction_error.py
@@ -32,7 +32,6 @@ class TransactionError:
         - Status errors: TRANSACTION_NOT_FOUND, TRANSACTION_ALREADY_SETTLED, DUPLICATE_PROVIDER_TRANSACTION
     """
 
-
     # -------------------------------------------------------------------------
     # Validation Errors
     # -------------------------------------------------------------------------
@@ -63,7 +62,6 @@ class TransactionError:
     - transaction_date is before account creation
     - settlement_date is before transaction_date
     """
-
 
     # -------------------------------------------------------------------------
     # Security/Trade Validation Errors

--- a/src/domain/events/base_event.py
+++ b/src/domain/events/base_event.py
@@ -20,7 +20,7 @@ Usage:
     ...     user_id: UUID
     ...     email: str
     >>>
-    >>> event = UserRegistered(user_id=uuid4(), email="test@example.com")
+    >>> event = UserRegistered(user_id=uuid7(), email="test@example.com")
     >>> print(event.event_id)  # Auto-generated UUID
     >>> print(event.occurred_at)  # Auto-generated timestamp
 
@@ -31,7 +31,8 @@ Reference:
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -66,7 +67,7 @@ class DomainEvent:
         >>>
         >>> # Create event (event_id and occurred_at auto-generated)
         >>> event = UserRegistered(
-        ...     user_id=uuid4(),
+        ...     user_id=uuid7(),
         ...     email="test@example.com",
         ...     ip_address="192.168.1.1"
         ... )
@@ -94,10 +95,10 @@ class DomainEvent:
           RegisterUser or ChangePassword
     """
 
-    event_id: UUID = field(default_factory=uuid4)
+    event_id: UUID = field(default_factory=uuid7)
     """Unique identifier for this event instance.
 
-    Auto-generated UUID v4 if not provided. Used for:
+    Auto-generated UUID v7 if not provided. Used for:
         - Event tracking across systems
         - Deduplication in message queues
         - Correlation in distributed tracing

--- a/src/domain/protocols/event_bus_protocol.py
+++ b/src/domain/protocols/event_bus_protocol.py
@@ -24,7 +24,7 @@ Usage:
     >>> event_bus = get_event_bus()  # Returns EventBusProtocol implementation
     >>>
     >>> # Publish event
-    >>> event = UserRegistered(user_id=uuid4(), email="test@example.com")
+    >>> event = UserRegistered(user_id=uuid7(), email="test@example.com")
     >>> await event_bus.publish(event)
     >>>
     >>> # Subscribe handler

--- a/src/domain/protocols/token_generation_protocol.py
+++ b/src/domain/protocols/token_generation_protocol.py
@@ -73,10 +73,10 @@ class TokenGenerationProtocol(Protocol):
 
         Example:
             >>> token = service.generate_access_token(
-            ...     user_id=uuid4(),
+            ...     user_id=uuid7(),
             ...     email="user@example.com",
             ...     roles=["user"],
-            ...     session_id=uuid4(),
+            ...     session_id=uuid7(),
             ... )
             >>> # eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 

--- a/src/domain/protocols/user_repository.py
+++ b/src/domain/protocols/user_repository.py
@@ -43,7 +43,7 @@ class UserRepository(Protocol):
             User if found, None otherwise.
 
         Example:
-            >>> user = await repo.find_by_id(uuid4())
+            >>> user = await repo.find_by_id(uuid7())
             >>> if user:
             ...     print(user.email)
         """
@@ -78,7 +78,7 @@ class UserRepository(Protocol):
             DatabaseError: If database operation fails.
 
         Example:
-            >>> user = User(id=uuid4(), email="new@example.com", ...)
+            >>> user = User(id=uuid7(), email="new@example.com", ...)
             >>> await repo.save(user)
         """
         ...

--- a/src/infrastructure/events/handlers/audit_event_handler.py
+++ b/src/infrastructure/events/handlers/audit_event_handler.py
@@ -95,7 +95,7 @@ class AuditEventHandler:
         >>> # Events automatically audited when published with session
         >>> async with database.get_session() as session:
         ...     await event_bus.publish(
-        ...         UserRegistrationSucceeded(user_id=uuid4(), email="test@example.com"),
+        ...         UserRegistrationSucceeded(user_id=uuid7(), email="test@example.com"),
         ...         session=session
         ...     )
         >>> # Audit record created using provided session

--- a/src/infrastructure/events/handlers/email_event_handler.py
+++ b/src/infrastructure/events/handlers/email_event_handler.py
@@ -64,7 +64,7 @@ class EmailEventHandler:
         >>>
         >>> # Events automatically trigger email logging
         >>> await event_bus.publish(UserRegistrationSucceeded(
-        ...     user_id=uuid4(),
+        ...     user_id=uuid7(),
         ...     email="test@example.com"
         ... ))
         >>> # Log output: {"event": "email_would_be_sent", "template": "welcome_email", ...}

--- a/src/infrastructure/events/handlers/logging_event_handler.py
+++ b/src/infrastructure/events/handlers/logging_event_handler.py
@@ -97,7 +97,7 @@ class LoggingEventHandler:
         >>>
         >>> # Events automatically logged when published
         >>> await event_bus.publish(UserRegistrationSucceeded(
-        ...     user_id=uuid4(),
+        ...     user_id=uuid7(),
         ...     email="test@example.com"
         ... ))
         >>> # Log output: {"event": "user_registration_succeeded", "user_id": "...", "email": "..."}

--- a/src/infrastructure/events/in_memory_event_bus.py
+++ b/src/infrastructure/events/in_memory_event_bus.py
@@ -20,7 +20,7 @@ Usage:
     >>> # Application layer uses protocol
     >>> event_bus = get_event_bus()
     >>> event_bus.subscribe(UserRegistered, log_user_registered)
-    >>> await event_bus.publish(UserRegistered(user_id=uuid4(), email="test"))
+    >>> await event_bus.publish(UserRegistered(user_id=uuid7(), email="test"))
 
 Reference:
     - docs/architecture/domain-events-architecture.md (Lines 920-1067)
@@ -70,7 +70,7 @@ class InMemoryEventBus:
         >>> bus.subscribe(UserRegistered, send_welcome_email)
         >>>
         >>> # Publish event (all 3 handlers execute concurrently)
-        >>> event = UserRegistered(user_id=uuid4(), email="test@example.com")
+        >>> event = UserRegistered(user_id=uuid7(), email="test@example.com")
         >>> await bus.publish(event)
         >>>
         >>> # If audit handler fails, logging and email handlers still execute

--- a/src/infrastructure/persistence/base.py
+++ b/src/infrastructure/persistence/base.py
@@ -39,7 +39,8 @@ works across different databases.
 
 from datetime import datetime
 from typing import Any
-from uuid import UUID as PythonUUID, uuid4
+from uuid import UUID as PythonUUID
+from uuid_extensions import uuid7
 
 from sqlalchemy import DateTime, Uuid, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
@@ -77,7 +78,7 @@ class BaseModel(DeclarativeBase):
     id: Mapped[PythonUUID] = mapped_column(
         Uuid,  # SQLAlchemy's generic UUID type
         primary_key=True,
-        default=uuid4,
+        default=uuid7,
         nullable=False,
     )
 

--- a/src/infrastructure/rate_limit/token_bucket_adapter.py
+++ b/src/infrastructure/rate_limit/token_bucket_adapter.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from time import perf_counter
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from src.core.result import Failure, Result, Success
 from src.domain.enums import RateLimitScope
@@ -318,7 +318,7 @@ class TokenBucketAdapter:
         try:
             await self._event_bus.publish(
                 RateLimitCheckAttempted(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     endpoint=endpoint,
                     identifier=identifier,
                     scope=scope.value,
@@ -345,7 +345,7 @@ class TokenBucketAdapter:
         try:
             await self._event_bus.publish(
                 RateLimitCheckAllowed(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     endpoint=endpoint,
                     identifier=identifier,
                     scope=scope.value,
@@ -373,7 +373,7 @@ class TokenBucketAdapter:
         try:
             await self._event_bus.publish(
                 RateLimitCheckDenied(
-                    event_id=uuid4(),
+                    event_id=uuid7(),
                     endpoint=endpoint,
                     identifier=identifier,
                     scope=scope.value,

--- a/src/infrastructure/security/jwt_service.py
+++ b/src/infrastructure/security/jwt_service.py
@@ -23,7 +23,8 @@ Reference:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 from jose import JWTError, jwt
 
@@ -99,7 +100,7 @@ class JWTService:
         Example:
             >>> service = JWTService(secret_key="x" * 32)
             >>> token = service.generate_access_token(
-            ...     user_id=uuid4(),
+            ...     user_id=uuid7(),
             ...     email="user@example.com",
             ...     roles=["user"],
             ... )
@@ -120,7 +121,7 @@ class JWTService:
             "roles": roles,
             "iat": int(now.timestamp()),  # Issued at
             "exp": int(expires_at.timestamp()),  # Expires at
-            "jti": str(uuid4()),  # JWT ID (unique identifier)
+            "jti": str(uuid7()),  # JWT ID (unique identifier)
         }
 
         # Add optional session_id if provided
@@ -146,7 +147,7 @@ class JWTService:
         Example:
             >>> service = JWTService(secret_key="x" * 32)
             >>> token = service.generate_access_token(
-            ...     user_id=uuid4(),
+            ...     user_id=uuid7(),
             ...     email="user@example.com",
             ...     roles=["user"],
             ... )

--- a/src/presentation/api/middleware/trace_middleware.py
+++ b/src/presentation/api/middleware/trace_middleware.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from typing import Awaitable, Callable
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -44,7 +44,7 @@ class TraceMiddleware(BaseHTTPMiddleware):
         Returns:
             Response: Response with X-Trace-Id header added.
         """
-        trace_id = request.headers.get("X-Trace-Id") or str(uuid4())
+        trace_id = request.headers.get("X-Trace-Id") or str(uuid7())
         trace_id_context.set(trace_id)
         try:
             response = await call_next(request)

--- a/tests/api/test_admin_rotation_api.py
+++ b/tests/api/test_admin_rotation_api.py
@@ -16,7 +16,7 @@ Note:
 """
 
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from fastapi import FastAPI, Request, status
@@ -231,7 +231,7 @@ class TestUserRotationEndpoint:
 
     def test_user_rotation_returns_201_created(self, client):
         """Test successful rotation returns 201 Created."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         response = client.post(
             f"/api/v1/admin/users/{user_id}/rotations",
             json={"reason": "Password changed"},
@@ -241,7 +241,7 @@ class TestUserRotationEndpoint:
 
     def test_user_rotation_returns_user_id(self, client):
         """Test rotation response includes user_id."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         response = client.post(
             f"/api/v1/admin/users/{user_id}/rotations",
             json={"reason": "Suspicious activity"},
@@ -253,7 +253,7 @@ class TestUserRotationEndpoint:
 
     def test_user_rotation_returns_version_info(self, client):
         """Test rotation response includes version information."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         response = client.post(
             f"/api/v1/admin/users/{user_id}/rotations",
             json={"reason": "Test"},
@@ -277,7 +277,7 @@ class TestUserRotationEndpoint:
 
     def test_user_rotation_requires_reason(self, client):
         """Test rotation requires reason field."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         response = client.post(
             f"/api/v1/admin/users/{user_id}/rotations",
             json={},

--- a/tests/api/test_authorization_api.py
+++ b/tests/api/test_authorization_api.py
@@ -34,7 +34,7 @@ Reference:
 
 from typing import Annotated
 from unittest.mock import AsyncMock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from fastapi import Depends, FastAPI
@@ -141,7 +141,7 @@ def mock_authorization():
 def mock_current_user():
     """Create a mock current user."""
     return {
-        "id": uuid4(),
+        "id": uuid7(),
         "email": "test@example.com",
         "role": UserRole.USER,
     }
@@ -194,7 +194,7 @@ class TestRequirePermission:
 
     def test_returns_403_when_permission_denied(self, test_app, mock_authorization):
         """Test that 403 is returned when permission check fails."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -207,7 +207,7 @@ class TestRequirePermission:
 
     def test_allows_access_when_permission_granted(self, test_app, mock_authorization):
         """Test that access is allowed when permission check passes."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = True
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -219,7 +219,7 @@ class TestRequirePermission:
 
     def test_checks_correct_resource_and_action(self, test_app, mock_authorization):
         """Test that correct resource and action are passed to check."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -244,7 +244,7 @@ class TestRequireCasbinRole:
 
     def test_returns_403_when_role_not_assigned(self, test_app, mock_authorization):
         """Test that 403 is returned when user doesn't have role."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.has_role.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -257,7 +257,7 @@ class TestRequireCasbinRole:
 
     def test_allows_access_when_role_assigned(self, test_app, mock_authorization):
         """Test that access is allowed when user has role."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.has_role.return_value = True
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -269,7 +269,7 @@ class TestRequireCasbinRole:
 
     def test_checks_correct_role(self, test_app, mock_authorization):
         """Test that correct role is passed to has_role check."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.has_role.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -293,7 +293,7 @@ class TestRequireAnyPermission:
 
     def test_returns_403_when_no_permissions_match(self, test_app, mock_authorization):
         """Test that 403 is returned when no permissions match."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -306,7 +306,7 @@ class TestRequireAnyPermission:
         self, test_app, mock_authorization
     ):
         """Test that access is allowed when first permission matches."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # First permission matches, second doesn't
         async def side_effect(user_id, resource, action):
@@ -324,7 +324,7 @@ class TestRequireAnyPermission:
         self, test_app, mock_authorization
     ):
         """Test that access is allowed when second permission matches."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # First permission doesn't match, second does
         async def side_effect(user_id, resource, action):
@@ -352,7 +352,7 @@ class TestRequireAllPermissions:
         self, test_app, mock_authorization
     ):
         """Test that 403 is returned when first permission is missing."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # First permission fails
         async def side_effect(user_id, resource, action):
@@ -370,7 +370,7 @@ class TestRequireAllPermissions:
         self, test_app, mock_authorization
     ):
         """Test that 403 is returned when second permission is missing."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Second permission fails
         async def side_effect(user_id, resource, action):
@@ -388,7 +388,7 @@ class TestRequireAllPermissions:
         self, test_app, mock_authorization
     ):
         """Test that access is allowed when all permissions granted."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = True
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -410,7 +410,7 @@ class TestErrorResponseFormat:
 
     def test_403_response_has_correct_structure(self, test_app, mock_authorization):
         """Test that 403 response has proper error structure."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.check_permission.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -423,7 +423,7 @@ class TestErrorResponseFormat:
 
     def test_403_response_includes_error_message(self, test_app, mock_authorization):
         """Test that 403 response includes meaningful error message."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_authorization.has_role.return_value = False
 
         client = create_client_with_mocks(test_app, mock_authorization, str(user_id))
@@ -450,7 +450,7 @@ class TestRoleHierarchy:
 
     def test_admin_can_access_user_endpoints(self, test_app, mock_authorization):
         """Test that admin role can access user-level endpoints."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Admin has both admin and user roles
         # Note: authorization calls use keyword args (user_id=..., role=...)
@@ -468,7 +468,7 @@ class TestRoleHierarchy:
 
     def test_user_cannot_access_admin_endpoints(self, test_app, mock_authorization):
         """Test that user role cannot access admin-level endpoints."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         # User doesn't have admin role
         # Note: authorization calls use keyword args (user_id=..., role=...)
@@ -510,7 +510,7 @@ class TestEdgeCases:
             return {"ok": True}
 
         mock_auth = AsyncMock()
-        client = create_client_with_mocks(app, mock_auth, str(uuid4()))
+        client = create_client_with_mocks(app, mock_auth, str(uuid7()))
 
         # Empty permission list should deny access (no permissions to satisfy)
         response = client.get("/empty-any")
@@ -534,7 +534,7 @@ class TestEdgeCases:
             return {"ok": True}
 
         mock_auth = AsyncMock()
-        client = create_client_with_mocks(app, mock_auth, str(uuid4()))
+        client = create_client_with_mocks(app, mock_auth, str(uuid7()))
 
         # Empty permission list means all (zero) permissions satisfied
         response = client.get("/empty-all")

--- a/tests/api/test_sessions_api.py
+++ b/tests/api/test_sessions_api.py
@@ -20,7 +20,7 @@ Note:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from fastapi import FastAPI, Request, status
@@ -130,7 +130,7 @@ def test_app():
         return {
             "sessions": [
                 {
-                    "id": str(uuid4()),
+                    "id": str(uuid7()),
                     "device_info": "Chrome on macOS",
                     "ip_address": "192.168.1.1",
                     "location": "New York, US",
@@ -389,14 +389,14 @@ class TestGetSession:
 
     def test_get_session_unauthorized(self, client):
         """Test getting session without token returns 401."""
-        session_id = str(uuid4())
+        session_id = str(uuid7())
         response = client.get(f"/api/v1/sessions/{session_id}")
 
         assert response.status_code == 401
 
     def test_get_session_success(self, client):
         """Test successful session retrieval returns 200."""
-        session_id = str(uuid4())
+        session_id = str(uuid7())
         response = client.get(
             f"/api/v1/sessions/{session_id}",
             headers={"Authorization": "Bearer mock_token"},
@@ -430,14 +430,14 @@ class TestRevokeSession:
 
     def test_revoke_session_unauthorized(self, client):
         """Test revoking session without token returns 401."""
-        session_id = str(uuid4())
+        session_id = str(uuid7())
         response = client.delete(f"/api/v1/sessions/{session_id}")
 
         assert response.status_code == 401
 
     def test_revoke_session_success(self, client):
         """Test successful session revocation returns 204."""
-        session_id = str(uuid4())
+        session_id = str(uuid7())
         response = client.delete(
             f"/api/v1/sessions/{session_id}",
             headers={"Authorization": "Bearer mock_token"},
@@ -519,7 +519,7 @@ class TestSessionResponseFormats:
 
     def test_session_response_includes_all_fields(self, client):
         """Test session response includes all expected fields."""
-        session_id = str(uuid4())
+        session_id = str(uuid7())
         response = client.get(
             f"/api/v1/sessions/{session_id}",
             headers={"Authorization": "Bearer mock_token"},

--- a/tests/integration/test_audit_durability.py
+++ b/tests/integration/test_audit_durability.py
@@ -17,7 +17,7 @@ Usage:
     pytest tests/integration/test_audit_durability.py -v
 """
 
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from sqlalchemy import select
@@ -43,7 +43,7 @@ async def test_audit_persists_when_business_transaction_fails(
 
     Compliance: PCI-DSS 10.2.4, SOC 2 CC6.1
     """
-    user_id = uuid4()
+    user_id = uuid7()
 
     # Create separate sessions (simulates real-world setup)
     async with test_database.get_session() as business_session:
@@ -54,7 +54,7 @@ async def test_audit_persists_when_business_transaction_fails(
                 action=AuditAction.USER_LOGIN_SUCCESS,
                 user_id=user_id,
                 resource_type="session",
-                resource_id=uuid4(),
+                resource_id=uuid7(),
                 ip_address="192.168.1.1",
                 context={"test": "durability"},
             )
@@ -95,7 +95,7 @@ async def test_audit_persists_on_constraint_violation(
 
     Compliance: PCI-DSS 10.2.4 (failed access attempts MUST be logged)
     """
-    user_id = uuid4()
+    user_id = uuid7()
 
     # Separate sessions for audit and business logic
     async with test_database.get_session() as audit_session:
@@ -105,7 +105,7 @@ async def test_audit_persists_on_constraint_violation(
             action=AuditAction.PROVIDER_CONNECTED,
             user_id=user_id,
             resource_type="provider",
-            resource_id=uuid4(),
+            resource_id=uuid7(),
             ip_address="10.0.0.1",
             context={"provider": "schwab", "status": "attempt"},
         )
@@ -145,9 +145,9 @@ async def test_multiple_audits_persist_independently(
 
     Compliance: SOC 2 CC6.1 (comprehensive activity logging)
     """
-    user_id_1 = uuid4()
-    user_id_2 = uuid4()
-    user_id_3 = uuid4()
+    user_id_1 = uuid7()
+    user_id_2 = uuid7()
+    user_id_3 = uuid7()
 
     # Record first audit (separate session)
     async with test_database.get_session() as audit_session_1:
@@ -219,8 +219,8 @@ async def test_audit_session_commits_immediately(
 
     Compliance: GDPR Article 30 (audit must be complete even if operation fails)
     """
-    user_id = uuid4()
-    resource_id = uuid4()
+    user_id = uuid7()
+    resource_id = uuid7()
 
     # Open business session but DON'T commit yet
     async with test_database.get_session() as business_session:

--- a/tests/integration/test_audit_postgres_adapter.py
+++ b/tests/integration/test_audit_postgres_adapter.py
@@ -17,7 +17,7 @@ Architecture:
 """
 
 from datetime import datetime, timedelta, UTC
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from sqlalchemy import select, update, delete
@@ -36,8 +36,8 @@ class TestPostgresAuditAdapterRecord:
     async def test_record_creates_audit_log_in_database(self, test_database):
         """Test record() creates audit log in PostgreSQL."""
         # Arrange
-        user_id = uuid4()
-        resource_id = uuid4()
+        user_id = uuid7()
+        resource_id = uuid7()
 
         # Act: Record audit log (commits independently)
         async with test_database.get_session() as audit_session:
@@ -74,7 +74,7 @@ class TestPostgresAuditAdapterRecord:
     async def test_record_with_none_context(self, test_database):
         """Test record() handles None context correctly."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Act: Record with None context
         async with test_database.get_session() as audit_session:
@@ -99,7 +99,7 @@ class TestPostgresAuditAdapterRecord:
     async def test_record_with_complex_context(self, test_database):
         """Test record() handles complex nested JSONB context."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         complex_context = {
             "authentication": {
                 "method": "oauth",
@@ -149,7 +149,7 @@ class TestPostgresAuditAdapterRecord:
     async def test_record_multiple_logs(self, test_database):
         """Test recording multiple audit logs."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Act: Record 3 audit logs (each commits independently)
         for i in range(3):
@@ -184,7 +184,7 @@ class TestPostgresAuditAdapterImmutability:
         (no savepoints). The PostgreSQL RULE blocks updates at the connection level.
         """
         # Arrange: Create audit log
-        user_id = uuid4()
+        user_id = uuid7()
 
         async with test_database.get_session() as audit_session:
             adapter = PostgresAuditAdapter(session=audit_session)
@@ -218,7 +218,7 @@ class TestPostgresAuditAdapterImmutability:
     async def test_cannot_delete_audit_log(self, test_database):
         """Test DELETE operations are blocked by PostgreSQL RULES."""
         # Arrange: Create audit log
-        user_id = uuid4()
+        user_id = uuid7()
 
         async with test_database.get_session() as audit_session:
             adapter = PostgresAuditAdapter(session=audit_session)
@@ -258,7 +258,7 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_returns_all_logs_for_user(self, test_database):
         """Test query() retrieves all logs for a user."""
         # Arrange: Create 3 logs for user
-        user_id = uuid4()
+        user_id = uuid7()
 
         for i in range(3):
             async with test_database.get_session() as audit_session:
@@ -289,7 +289,7 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_filter_by_action(self, test_database):
         """Test query() filters by action type."""
         # Arrange: Create different action types
-        user_id = uuid4()
+        user_id = uuid7()
 
         async with test_database.get_session() as audit_session:
             adapter = PostgresAuditAdapter(session=audit_session)
@@ -330,7 +330,7 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_filter_by_resource_type(self, test_database):
         """Test query() filters by resource_type."""
         # Arrange: Create different resource types
-        user_id = uuid4()
+        user_id = uuid7()
 
         async with test_database.get_session() as audit_session:
             adapter = PostgresAuditAdapter(session=audit_session)
@@ -371,7 +371,7 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_pagination(self, test_database):
         """Test query() pagination with limit and offset."""
         # Arrange: Create 10 logs
-        user_id = uuid4()
+        user_id = uuid7()
 
         for i in range(10):
             async with test_database.get_session() as audit_session:
@@ -406,7 +406,7 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_date_range_filter(self, test_database):
         """Test query() filters by date range."""
         # Arrange: Create logs at different times (simulated)
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Create 3 logs (will have similar timestamps in test)
         for i in range(3):
@@ -442,7 +442,7 @@ class TestPostgresAuditAdapterQuery:
         # Act: Query for non-existent user
         async with test_database.get_session() as query_session:
             adapter = PostgresAuditAdapter(session=query_session)
-            result = await adapter.query(user_id=uuid4())
+            result = await adapter.query(user_id=uuid7())
 
             # Assert
             assert isinstance(result, Success)
@@ -452,8 +452,8 @@ class TestPostgresAuditAdapterQuery:
     async def test_query_converts_uuids_to_strings(self, test_database):
         """Test query() converts UUID fields to strings."""
         # Arrange
-        user_id = uuid4()
-        resource_id = uuid4()
+        user_id = uuid7()
+        resource_id = uuid7()
 
         async with test_database.get_session() as audit_session:
             adapter = PostgresAuditAdapter(session=audit_session)
@@ -479,8 +479,8 @@ class TestPostgresAuditAdapterQuery:
             assert isinstance(log["resource_id"], str)
 
             # Can convert back to UUID
-            assert uuid4().__class__(log["id"])
-            assert uuid4().__class__(log["user_id"])
+            assert uuid7().__class__(log["id"])
+            assert uuid7().__class__(log["user_id"])
 
 
 @pytest.mark.integration
@@ -491,7 +491,7 @@ class TestPostgresAuditAdapterEdgeCases:
     async def test_query_with_multiple_filters(self, test_database):
         """Test query() with all filters combined."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Create mix of logs
         async with test_database.get_session() as audit_session:
@@ -584,7 +584,7 @@ class TestPostgresAuditAdapterEdgeCases:
             result = await adapter.record(
                 action=AuditAction.USER_LOGIN_SUCCESS,
                 resource_type="session",
-                user_id=uuid4(),
+                user_id=uuid7(),
                 user_agent=long_user_agent,
             )
 
@@ -599,7 +599,7 @@ class TestPostgresAuditAdapterEdgeCases:
         This test verifies that multiple audit records persist correctly.
         """
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Act: Record via separate sessions (mirrors production)
         async with test_database.get_session() as audit_session1:

--- a/tests/integration/test_authorization_casbin.py
+++ b/tests/integration/test_authorization_casbin.py
@@ -23,7 +23,7 @@ Reference:
 """
 
 import os
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 import pytest_asyncio
@@ -144,7 +144,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_readonly_can_read_accounts_direct(self, casbin_enforcer):
         """Test readonly role can read accounts (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "readonly")
 
         # Test directly with enforcer (enforce is sync, even on AsyncEnforcer)
@@ -154,7 +154,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_readonly_cannot_write_accounts_direct(self, casbin_enforcer):
         """Test readonly role cannot write to accounts (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "readonly")
 
         allowed = casbin_enforcer.enforce(user_id, "accounts", "write")
@@ -163,7 +163,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_user_inherits_readonly_direct(self, casbin_enforcer):
         """Test user role inherits readonly permissions (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "user")
 
         # User should inherit readonly's read permission
@@ -173,7 +173,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_user_can_write_accounts_direct(self, casbin_enforcer):
         """Test user role can write to accounts (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "user")
 
         allowed = casbin_enforcer.enforce(user_id, "accounts", "write")
@@ -182,7 +182,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_admin_has_all_permissions_direct(self, casbin_enforcer):
         """Test admin role has all permissions (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "admin")
 
         # Admin should have access to admin-only resources (enforce is sync)
@@ -193,7 +193,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_user_cannot_access_admin_direct(self, casbin_enforcer):
         """Test user role cannot access admin resources (direct enforcer)."""
-        user_id = str(uuid4())
+        user_id = str(uuid7())
         await casbin_enforcer.add_role_for_user(user_id, "user")
 
         allowed = casbin_enforcer.enforce(user_id, "admin", "read")
@@ -202,7 +202,7 @@ class TestEnforcerDirect:
     @pytest.mark.asyncio
     async def test_unassigned_user_denied_direct(self, casbin_enforcer):
         """Test user without role is denied (direct enforcer)."""
-        user_id = str(uuid4())  # No role assigned
+        user_id = str(uuid7())  # No role assigned
 
         allowed = casbin_enforcer.enforce(user_id, "accounts", "read")
         assert allowed is False
@@ -224,7 +224,7 @@ class TestCasbinAdapterPermissions:
     @pytest.mark.asyncio
     async def test_adapter_checks_permission(self, casbin_adapter, casbin_enforcer):
         """Test adapter delegates permission check to enforcer."""
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "readonly")
 
         allowed = await casbin_adapter.check_permission(
@@ -238,7 +238,7 @@ class TestCasbinAdapterPermissions:
     @pytest.mark.asyncio
     async def test_adapter_denies_unauthorized(self, casbin_adapter, casbin_enforcer):
         """Test adapter denies unauthorized access."""
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "readonly")
 
         allowed = await casbin_adapter.check_permission(
@@ -252,7 +252,7 @@ class TestCasbinAdapterPermissions:
     @pytest.mark.asyncio
     async def test_adapter_denies_unassigned_user(self, casbin_adapter):
         """Test adapter denies user without any role."""
-        user_id = uuid4()  # No role assigned
+        user_id = uuid7()  # No role assigned
 
         allowed = await casbin_adapter.check_permission(
             user_id=user_id,
@@ -276,7 +276,7 @@ class TestRoleOperations:
     async def test_get_roles_for_user(self, casbin_adapter, casbin_enforcer):
         """Test getting roles assigned to a user."""
         # Assign role
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "user")
 
         # Get roles
@@ -290,7 +290,7 @@ class TestRoleOperations:
     ):
         """Test has_role returns True for assigned role."""
         # Assign role
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "admin")
 
         # Check has_role
@@ -304,7 +304,7 @@ class TestRoleOperations:
     ):
         """Test has_role returns False for unassigned role."""
         # Assign user role (not admin)
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "user")
 
         # Check for admin role
@@ -315,8 +315,8 @@ class TestRoleOperations:
     @pytest.mark.asyncio
     async def test_assign_role_success(self, casbin_adapter, casbin_enforcer):
         """Test successful role assignment."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # Assign role via adapter
         result = await casbin_adapter.assign_role(
@@ -336,8 +336,8 @@ class TestRoleOperations:
         self, casbin_adapter, casbin_enforcer
     ):
         """Test assigning same role twice returns False."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # First assignment
         await casbin_adapter.assign_role(
@@ -358,8 +358,8 @@ class TestRoleOperations:
     @pytest.mark.asyncio
     async def test_revoke_role_success(self, casbin_adapter, casbin_enforcer):
         """Test successful role revocation."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # First assign role
         await casbin_enforcer.add_role_for_user(str(user_id), "user")
@@ -383,8 +383,8 @@ class TestRoleOperations:
         self, casbin_adapter, casbin_enforcer
     ):
         """Test revoking unassigned role returns False."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # Try to revoke role user doesn't have
         result = await casbin_adapter.revoke_role(
@@ -411,7 +411,7 @@ class TestCacheIntegration:
     ):
         """Test that permission check results are cached."""
         # Assign role
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "readonly")
 
         # First check - should miss cache and set
@@ -429,8 +429,8 @@ class TestCacheIntegration:
         self, casbin_adapter, casbin_enforcer, mock_cache
     ):
         """Test that role assignment invalidates user's cache."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # Assign role
         await casbin_adapter.assign_role(
@@ -458,7 +458,7 @@ class TestAuditIntegration:
     ):
         """Test that permission checks are audited."""
         # Assign role
-        user_id = uuid4()
+        user_id = uuid7()
         await casbin_enforcer.add_role_for_user(str(user_id), "readonly")
 
         # Check permission
@@ -491,8 +491,8 @@ class TestEventIntegration:
         self, casbin_adapter, casbin_enforcer, mock_event_bus
     ):
         """Test that role assignment publishes domain events."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # Assign role
         await casbin_adapter.assign_role(
@@ -509,8 +509,8 @@ class TestEventIntegration:
         self, casbin_adapter, casbin_enforcer, mock_event_bus
     ):
         """Test that role revocation publishes domain events."""
-        user_id = uuid4()
-        admin_id = uuid4()
+        user_id = uuid7()
+        admin_id = uuid7()
 
         # First assign role
         await casbin_enforcer.add_role_for_user(str(user_id), "user")

--- a/tests/integration/test_domain_events_flow.py
+++ b/tests/integration/test_domain_events_flow.py
@@ -18,7 +18,7 @@ Architecture:
 """
 
 from datetime import datetime, UTC
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from sqlalchemy import select
@@ -75,7 +75,7 @@ class TestEventFlowEndToEnd:
         """Test UserRegistrationSucceeded → audit record created."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserRegistrationSucceeded(
             user_id=user_id,
             email="integration@example.com",
@@ -106,7 +106,7 @@ class TestEventFlowEndToEnd:
         """Test UserPasswordChangeSucceeded → audit record created."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserPasswordChangeSucceeded(user_id=user_id, initiated_by="user")
 
         # Act - Pass session to avoid "Event loop is closed" error
@@ -133,9 +133,9 @@ class TestEventFlowEndToEnd:
         """Test ProviderConnectionSucceeded → audit record created."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
-        provider_id = uuid4()
-        connection_id = uuid4()
+        user_id = uuid7()
+        provider_id = uuid7()
+        connection_id = uuid7()
         event = ProviderConnectionSucceeded(
             user_id=user_id,
             connection_id=connection_id,
@@ -168,9 +168,9 @@ class TestEventFlowEndToEnd:
         """Test ProviderTokenRefreshFailed → audit record created."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
-        provider_id = uuid4()
-        connection_id = uuid4()
+        user_id = uuid7()
+        provider_id = uuid7()
+        connection_id = uuid7()
         event = ProviderTokenRefreshFailed(
             user_id=user_id,
             connection_id=connection_id,
@@ -207,7 +207,7 @@ class TestMultipleEventsSequence:
         """Test publishing multiple events creates separate audit records."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Act - Publish 3 different events (pass session to each)
         async with test_database.get_session() as session:
@@ -223,8 +223,8 @@ class TestMultipleEventsSequence:
                 UserPasswordChangeSucceeded(user_id=user_id, initiated_by="user"),
                 session=session,
             )
-            provider_id = uuid4()
-            connection_id = uuid4()
+            provider_id = uuid7()
+            connection_id = uuid7()
             await event_bus.publish(
                 ProviderConnectionSucceeded(
                     user_id=user_id,
@@ -257,7 +257,7 @@ class TestMultipleEventsSequence:
         """Test same event type published multiple times creates multiple records."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
 
         # Act - Publish same event 3 times with different data (pass session)
         async with test_database.get_session() as session:
@@ -270,7 +270,7 @@ class TestMultipleEventsSequence:
                 session=session,
             )
 
-            user_id_2 = uuid4()
+            user_id_2 = uuid7()
             await event_bus.publish(
                 UserRegistrationSucceeded(
                     user_id=user_id_2,
@@ -280,7 +280,7 @@ class TestMultipleEventsSequence:
                 session=session,
             )
 
-            user_id_3 = uuid4()
+            user_id_3 = uuid7()
             await event_bus.publish(
                 UserRegistrationSucceeded(
                     user_id=user_id_3,
@@ -319,7 +319,7 @@ class TestHandlerExecutionOrder:
         """
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserRegistrationSucceeded(
             user_id=user_id,
             email="concurrent@example.com",
@@ -362,7 +362,7 @@ class TestFailOpenBehaviorWithRealInfrastructure:
         """
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserRegistrationSucceeded(
             user_id=user_id,
             email="failopen@example.com",
@@ -387,13 +387,13 @@ class TestEventDataIntegrity:
         """Test event fields are preserved correctly in audit record."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
-        provider_id = uuid4()
-        connection_id = uuid4()
+        user_id = uuid7()
+        provider_id = uuid7()
+        connection_id = uuid7()
         timestamp = datetime.now(UTC)
 
         event = ProviderConnectionSucceeded(
-            event_id=uuid4(),  # Explicit event_id
+            event_id=uuid7(),  # Explicit event_id
             occurred_at=timestamp,  # Explicit timestamp
             user_id=user_id,
             connection_id=connection_id,
@@ -424,7 +424,7 @@ class TestEventDataIntegrity:
         """Test events with optional fields (None values) handled correctly."""
         # Arrange
         event_bus = get_event_bus()
-        user_id = uuid4()
+        user_id = uuid7()
 
         # UserPasswordChangeSucceeded doesn't have ip_address (unlike ATTEMPTED)
         event = UserPasswordChangeSucceeded(user_id=user_id, initiated_by="admin")

--- a/tests/integration/test_session_cache.py
+++ b/tests/integration/test_session_cache.py
@@ -16,7 +16,7 @@ Reference:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -38,8 +38,8 @@ def create_test_session_data(  # type: ignore[no-untyped-def]
     """Create test SessionData with sensible defaults."""
     now = datetime.now(UTC)
     return SessionData(
-        id=session_id or uuid4(),
-        user_id=user_id or uuid4(),
+        id=session_id or uuid7(),
+        user_id=user_id or uuid7(),
         device_info=device_info,
         user_agent=user_agent,
         ip_address=ip_address,
@@ -85,7 +85,7 @@ class TestSessionCacheGetSet:
     @pytest.mark.asyncio
     async def test_get_nonexistent_session_returns_none(self, session_cache):
         """Test getting a session that doesn't exist returns None."""
-        result = await session_cache.get(uuid4())
+        result = await session_cache.get(uuid7())
         assert result is None
 
     @pytest.mark.asyncio
@@ -127,7 +127,7 @@ class TestSessionCacheGetSet:
     async def test_set_session_adds_to_user_index(self, session_cache):
         """Test that set() adds session to user's session index."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         session_data = create_test_session_data(user_id=user_id)
 
         # Act
@@ -142,10 +142,10 @@ class TestSessionCacheGetSet:
         """Test all SessionData fields are properly serialized/deserialized."""
         # Arrange - session with all fields populated
         now = datetime.now(UTC)
-        refresh_token_id = uuid4()
+        refresh_token_id = uuid7()
         session_data = SessionData(
-            id=uuid4(),
-            user_id=uuid4(),
+            id=uuid7(),
+            user_id=uuid7(),
             device_info="Safari on macOS",
             user_agent="Mozilla/5.0 Safari/605.1.15",
             ip_address="10.0.0.1",
@@ -211,14 +211,14 @@ class TestSessionCacheDelete:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_session_returns_false(self, session_cache):
         """Test deleting nonexistent session returns False."""
-        result = await session_cache.delete(uuid4())
+        result = await session_cache.delete(uuid7())
         assert result is False
 
     @pytest.mark.asyncio
     async def test_delete_all_for_user(self, session_cache):
         """Test deleting all sessions for a user."""
         # Arrange - create multiple sessions for same user
-        user_id = uuid4()
+        user_id = uuid7()
         session1 = create_test_session_data(user_id=user_id)
         session2 = create_test_session_data(user_id=user_id)
         session3 = create_test_session_data(user_id=user_id)
@@ -250,7 +250,7 @@ class TestSessionCacheDelete:
     @pytest.mark.asyncio
     async def test_delete_all_for_user_with_no_sessions(self, session_cache):
         """Test delete_all_for_user with user having no sessions."""
-        result = await session_cache.delete_all_for_user(uuid4())
+        result = await session_cache.delete_all_for_user(uuid7())
         assert result == 0
 
 
@@ -274,7 +274,7 @@ class TestSessionCacheExists:
     @pytest.mark.asyncio
     async def test_exists_returns_false_for_nonexistent_session(self, session_cache):
         """Test exists returns False for non-cached session."""
-        result = await session_cache.exists(uuid4())
+        result = await session_cache.exists(uuid7())
         assert result is False
 
 
@@ -286,7 +286,7 @@ class TestSessionCacheUserIndex:
     async def test_get_user_session_ids_returns_all_sessions(self, session_cache):
         """Test getting all session IDs for a user."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         session1 = create_test_session_data(user_id=user_id)
         session2 = create_test_session_data(user_id=user_id)
 
@@ -306,15 +306,15 @@ class TestSessionCacheUserIndex:
         self, session_cache
     ):
         """Test getting session IDs for user with no sessions."""
-        result = await session_cache.get_user_session_ids(uuid4())
+        result = await session_cache.get_user_session_ids(uuid7())
         assert result == []
 
     @pytest.mark.asyncio
     async def test_add_user_session(self, session_cache):
         """Test adding session to user index directly."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
 
         # Act
         await session_cache.add_user_session(user_id, session_id)
@@ -327,8 +327,8 @@ class TestSessionCacheUserIndex:
     async def test_add_user_session_idempotent(self, session_cache):
         """Test adding same session twice doesn't duplicate."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
 
         # Act - add twice
         await session_cache.add_user_session(user_id, session_id)
@@ -343,9 +343,9 @@ class TestSessionCacheUserIndex:
     async def test_remove_user_session(self, session_cache):
         """Test removing session from user index."""
         # Arrange
-        user_id = uuid4()
-        session_id1 = uuid4()
-        session_id2 = uuid4()
+        user_id = uuid7()
+        session_id1 = uuid7()
+        session_id2 = uuid7()
 
         await session_cache.add_user_session(user_id, session_id1)
         await session_cache.add_user_session(user_id, session_id2)
@@ -362,8 +362,8 @@ class TestSessionCacheUserIndex:
     async def test_remove_last_user_session_clears_index(self, session_cache):
         """Test removing last session clears the user index key."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         await session_cache.add_user_session(user_id, session_id)
 
         # Act
@@ -377,9 +377,9 @@ class TestSessionCacheUserIndex:
     async def test_remove_nonexistent_session_from_user_index(self, session_cache):
         """Test removing non-existent session from user index is safe."""
         # Arrange
-        user_id = uuid4()
-        existing_session = uuid4()
-        nonexistent_session = uuid4()
+        user_id = uuid7()
+        existing_session = uuid7()
+        nonexistent_session = uuid7()
         await session_cache.add_user_session(user_id, existing_session)
 
         # Act - should not raise
@@ -400,8 +400,8 @@ class TestSessionCacheUpdateActivity:
         # Arrange
         old_time = datetime.now(UTC) - timedelta(hours=1)
         session_data = SessionData(
-            id=uuid4(),
-            user_id=uuid4(),
+            id=uuid7(),
+            user_id=uuid7(),
             device_info="Chrome on Windows",
             user_agent="Mozilla/5.0",
             ip_address="192.168.1.1",
@@ -457,7 +457,7 @@ class TestSessionCacheUpdateActivity:
     @pytest.mark.asyncio
     async def test_update_last_activity_nonexistent_returns_false(self, session_cache):
         """Test update_last_activity on non-cached session returns False."""
-        result = await session_cache.update_last_activity(uuid4())
+        result = await session_cache.update_last_activity(uuid7())
         assert result is False
 
 
@@ -470,8 +470,8 @@ class TestSessionCacheEdgeCases:
         """Test session with None optional fields is handled correctly."""
         # Arrange - session with minimal data
         session_data = SessionData(
-            id=uuid4(),
-            user_id=uuid4(),
+            id=uuid7(),
+            user_id=uuid7(),
             device_info=None,
             user_agent=None,
             ip_address=None,
@@ -505,8 +505,8 @@ class TestSessionCacheEdgeCases:
     async def test_multiple_users_sessions_isolated(self, session_cache):
         """Test sessions for different users are properly isolated."""
         # Arrange
-        user1_id = uuid4()
-        user2_id = uuid4()
+        user1_id = uuid7()
+        user2_id = uuid7()
 
         user1_session = create_test_session_data(user_id=user1_id)
         user2_session = create_test_session_data(user_id=user2_id)
@@ -532,8 +532,8 @@ class TestSessionCacheEdgeCases:
     ):
         """Test delete_all_for_user doesn't affect other users' sessions."""
         # Arrange
-        user1_id = uuid4()
-        user2_id = uuid4()
+        user1_id = uuid7()
+        user2_id = uuid7()
 
         user1_session = create_test_session_data(user_id=user1_id)
         user2_session = create_test_session_data(user_id=user2_id)

--- a/tests/integration/test_session_repository.py
+++ b/tests/integration/test_session_repository.py
@@ -22,7 +22,7 @@ Note:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 import pytest_asyncio
@@ -62,7 +62,7 @@ async def clean_session_tables(test_database):
 def create_test_user(user_id=None, email=None):
     """Create a test User with all required fields."""
     now = datetime.now(UTC)
-    user_id = user_id or uuid4()
+    user_id = user_id or uuid7()
     return User(
         id=user_id,
         email=email or f"test_{user_id}@example.com",
@@ -100,8 +100,8 @@ def create_test_session(
     """
     now = datetime.now(UTC)
     return SessionData(
-        id=session_id or uuid4(),
-        user_id=user_id or uuid4(),
+        id=session_id or uuid7(),
+        user_id=user_id or uuid7(),
         device_info=device_info,
         user_agent="Mozilla/5.0 Chrome/120.0",
         ip_address=ip_address,
@@ -131,7 +131,7 @@ class TestSessionRepositorySave:
         """Test saving a session persists it to the database."""
         # Arrange - Create user first (sessions require user FK)
         user = create_test_user()
-        session_id = uuid4()
+        session_id = uuid7()
         session = create_test_session(session_id=session_id, user_id=user.id)
 
         # Save user first
@@ -161,7 +161,7 @@ class TestSessionRepositorySave:
         """Test saving an existing session updates it."""
         # Arrange
         user = create_test_user()
-        session_id = uuid4()
+        session_id = uuid7()
         session = create_test_session(session_id=session_id, user_id=user.id)
 
         async with test_database.get_session() as db_session:
@@ -262,7 +262,7 @@ class TestSessionRepositoryFindByUserId:
         # Act
         async with test_database.get_session() as db_session:
             repo = SessionRepository(session=db_session)
-            found = await repo.find_by_user_id(uuid4())
+            found = await repo.find_by_user_id(uuid7())
 
         # Assert
         assert found == []
@@ -354,7 +354,7 @@ class TestSessionRepositoryRevokeAll:
         """Test revoke_all_for_user excludes specified session."""
         # Arrange
         user = create_test_user()
-        current_session_id = uuid4()
+        current_session_id = uuid7()
         current_session = create_test_session(
             session_id=current_session_id, user_id=user.id
         )
@@ -492,7 +492,7 @@ class TestSessionRepositoryDelete:
         """Test delete removes session from database."""
         # Arrange
         user = create_test_user()
-        session_id = uuid4()
+        session_id = uuid7()
         session = create_test_session(session_id=session_id, user_id=user.id)
 
         async with test_database.get_session() as db_session:
@@ -523,7 +523,7 @@ class TestSessionRepositoryDelete:
         # Act
         async with test_database.get_session() as db_session:
             repo = SessionRepository(session=db_session)
-            deleted = await repo.delete(uuid4())
+            deleted = await repo.delete(uuid7())
 
         # Assert
         assert deleted is False

--- a/tests/integration/test_user_repository.py
+++ b/tests/integration/test_user_repository.py
@@ -16,7 +16,7 @@ Architecture:
 """
 
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 import pytest_asyncio
@@ -39,7 +39,7 @@ def create_test_user(
     """Create a test User with all required fields."""
     now = datetime.now(UTC)
     return User(
-        id=user_id or uuid4(),
+        id=user_id or uuid7(),
         email=email,
         password_hash=password_hash,
         is_verified=is_verified,
@@ -66,7 +66,7 @@ class TestUserRepositorySave:
     async def test_save_user_persists_to_database(self, test_database):
         """Test saving a user persists it to the database."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         unique_email = f"test_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,
@@ -98,7 +98,7 @@ class TestUserRepositorySave:
     async def test_save_user_with_verified_status(self, test_database):
         """Test saving a user with verified status."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         unique_email = f"admin_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,
@@ -130,7 +130,7 @@ class TestUserRepositoryFindByEmail:
     async def test_find_by_email_returns_user(self, test_database):
         """Test find_by_email returns existing user."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         email = f"findme_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,
@@ -168,7 +168,7 @@ class TestUserRepositoryFindByEmail:
     async def test_find_by_email_is_case_insensitive(self, test_database):
         """Test find_by_email is case insensitive."""
         # Arrange - Use unique email to avoid conflicts
-        user_id = uuid4()
+        user_id = uuid7()
         unique_suffix = str(user_id)[:8]
         email_mixed_case = f"Test_{unique_suffix}@Example.com"
         email_lowercase = f"test_{unique_suffix}@example.com"
@@ -202,7 +202,7 @@ class TestUserRepositoryFindById:
     async def test_find_by_id_returns_user(self, test_database):
         """Test find_by_id returns existing user."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         unique_email = f"findbyid_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,
@@ -231,7 +231,7 @@ class TestUserRepositoryFindById:
         # Act
         async with test_database.get_session() as session:
             repo = UserRepository(session=session)
-            found = await repo.find_by_id(uuid4())
+            found = await repo.find_by_id(uuid7())
 
         # Assert
         assert found is None
@@ -245,7 +245,7 @@ class TestUserRepositoryUpdate:
     async def test_update_user_persists_changes(self, test_database):
         """Test updating a user persists changes to database."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         unique_email = f"update_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,
@@ -281,7 +281,7 @@ class TestUserRepositoryUpdate:
     async def test_update_user_failed_login_attempts(self, test_database):
         """Test updating failed login attempts."""
         # Arrange - Use unique email per test run
-        user_id = uuid4()
+        user_id = uuid7()
         unique_email = f"login_{user_id}@example.com"
         user = create_test_user(
             user_id=user_id,

--- a/tests/unit/test_application_authenticate_user_handler.py
+++ b/tests/unit/test_application_authenticate_user_handler.py
@@ -22,7 +22,8 @@ Token generation is handled by GenerateAuthTokensHandler (CQRS separation).
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -51,7 +52,7 @@ def create_mock_user(
 ) -> Mock:
     """Create a mock User entity for testing."""
     mock_user = Mock(spec=User)
-    mock_user.id = user_id or uuid4()
+    mock_user.id = user_id or uuid7()
     mock_user.email = email
     mock_user.password_hash = password_hash
     mock_user.is_verified = is_verified

--- a/tests/unit/test_application_create_session_handler.py
+++ b/tests/unit/test_application_create_session_handler.py
@@ -21,7 +21,8 @@ or generate tokens (CQRS separation).
 
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, Mock
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -44,7 +45,7 @@ def create_mock_user(
 ) -> Mock:
     """Create a mock User entity for testing."""
     mock_user = Mock(spec=User)
-    mock_user.id = user_id or uuid4()
+    mock_user.id = user_id or uuid7()
     mock_user.session_tier = session_tier
     mock_user.max_sessions = max_sessions
     mock_user.get_max_sessions.return_value = max_sessions
@@ -57,8 +58,8 @@ def create_mock_session_data(
 ) -> Mock:
     """Create a mock SessionData for testing."""
     mock_session = Mock(spec=SessionData)
-    mock_session.id = session_id or uuid4()
-    mock_session.user_id = user_id or uuid4()
+    mock_session.id = session_id or uuid7()
+    mock_session.user_id = user_id or uuid7()
     mock_session.device_info = "Chrome on Windows"
     mock_session.is_revoked = False
     mock_session.revoked_at = None
@@ -88,7 +89,7 @@ class TestCreateSessionHandlerSuccess:
     async def test_create_session_returns_response(self):
         """Test successful session creation returns Success with response."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
 
         mock_session_repo = AsyncMock()
@@ -138,7 +139,7 @@ class TestCreateSessionHandlerSuccess:
     async def test_create_session_enriches_device_info(self):
         """Test session creation enriches device info from user agent."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
         user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0"
 
@@ -183,7 +184,7 @@ class TestCreateSessionHandlerSuccess:
     async def test_create_session_enriches_location(self):
         """Test session creation enriches location from IP address."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
         ip_address = "8.8.8.8"
 
@@ -228,7 +229,7 @@ class TestCreateSessionHandlerSuccess:
     async def test_create_session_saves_to_database(self):
         """Test session is persisted to database."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
 
         mock_session_repo = AsyncMock()
@@ -273,7 +274,7 @@ class TestCreateSessionHandlerSuccess:
     async def test_create_session_caches_session(self):
         """Test session is cached in Redis."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
 
         mock_session_repo = AsyncMock()
@@ -340,7 +341,7 @@ class TestCreateSessionHandlerFailure:
         )
 
         command = CreateSession(
-            user_id=uuid4(),
+            user_id=uuid7(),
             ip_address="192.168.1.1",
             user_agent="Chrome",
         )
@@ -361,7 +362,7 @@ class TestCreateSessionHandlerSessionLimit:
     async def test_create_session_evicts_oldest_when_at_limit(self):
         """Test oldest session is evicted when user is at session limit."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=3)
         oldest_session = create_mock_session_data(user_id=user_id)
 
@@ -410,7 +411,7 @@ class TestCreateSessionHandlerSessionLimit:
     async def test_create_session_does_not_evict_when_under_limit(self):
         """Test no eviction when user is under session limit."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=3)
 
         mock_session_repo = AsyncMock()
@@ -454,7 +455,7 @@ class TestCreateSessionHandlerSessionLimit:
     async def test_create_session_no_limit_for_unlimited_tier(self):
         """Test users with unlimited tier have no session limit."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(
             user_id=user_id, session_tier="unlimited", max_sessions=None
         )
@@ -503,7 +504,7 @@ class TestCreateSessionHandlerEvents:
     async def test_create_session_publishes_created_event(self):
         """Test session creation publishes SessionCreatedEvent."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=None)
 
         mock_session_repo = AsyncMock()
@@ -555,7 +556,7 @@ class TestCreateSessionHandlerEvents:
     async def test_create_session_publishes_evicted_event_on_eviction(self):
         """Test session eviction publishes SessionEvictedEvent."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = create_mock_user(user_id=user_id, max_sessions=3)
         oldest_session = create_mock_session_data(user_id=user_id)
 

--- a/tests/unit/test_application_generate_auth_tokens_handler.py
+++ b/tests/unit/test_application_generate_auth_tokens_handler.py
@@ -19,7 +19,7 @@ or create sessions (CQRS separation).
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -54,8 +54,8 @@ class TestGenerateAuthTokensHandlerSuccess:
     async def test_generate_tokens_returns_auth_tokens(self):
         """Test successful generation returns Success with AuthTokens."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
 
         mock_token_service = Mock()
         mock_token_service.generate_access_token.return_value = "jwt_access_token_123"
@@ -99,8 +99,8 @@ class TestGenerateAuthTokensHandlerSuccess:
     async def test_generate_tokens_calls_jwt_service_correctly(self):
         """Test handler calls JWT service with correct parameters."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         email = "test@example.com"
         roles = ["user", "admin"]
 
@@ -168,10 +168,10 @@ class TestGenerateAuthTokensHandlerSuccess:
         )
 
         command = GenerateAuthTokens(
-            user_id=uuid4(),
+            user_id=uuid7(),
             email="test@example.com",
             roles=["user"],
-            session_id=uuid4(),
+            session_id=uuid7(),
         )
 
         # Act
@@ -185,8 +185,8 @@ class TestGenerateAuthTokensHandlerSuccess:
     async def test_generate_tokens_persists_refresh_token(self):
         """Test handler persists refresh token hash to database."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         expires_at = datetime.now(UTC) + timedelta(days=30)
 
         mock_token_service = Mock()
@@ -233,8 +233,8 @@ class TestGenerateAuthTokensHandlerSuccess:
     async def test_generate_tokens_with_multiple_roles(self):
         """Test token generation with multiple user roles."""
         # Arrange
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         roles = ["user", "admin", "moderator"]
 
         mock_token_service = Mock()
@@ -306,10 +306,10 @@ class TestGenerateAuthTokensHandlerTokenContent:
         )
 
         command = GenerateAuthTokens(
-            user_id=uuid4(),
+            user_id=uuid7(),
             email="test@example.com",
             roles=["user"],
-            session_id=uuid4(),
+            session_id=uuid7(),
         )
 
         # Act
@@ -348,10 +348,10 @@ class TestGenerateAuthTokensHandlerTokenContent:
         )
 
         command = GenerateAuthTokens(
-            user_id=uuid4(),
+            user_id=uuid7(),
             email="test@example.com",
             roles=["user"],
-            session_id=uuid4(),
+            session_id=uuid7(),
         )
 
         # Act

--- a/tests/unit/test_application_register_user_handler.py
+++ b/tests/unit/test_application_register_user_handler.py
@@ -16,7 +16,8 @@ Architecture:
 """
 
 from unittest.mock import AsyncMock, Mock
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -184,7 +185,7 @@ class TestRegisterUserHandlerFailure:
         """Test registration fails when email already registered."""
         # Arrange
         existing_user = Mock()
-        existing_user.id = uuid4()
+        existing_user.id = uuid7()
         existing_user.email = "existing@example.com"
 
         mock_user_repo = AsyncMock()
@@ -218,7 +219,7 @@ class TestRegisterUserHandlerFailure:
         """Test duplicate email does not save user or token."""
         # Arrange
         existing_user = Mock()
-        existing_user.id = uuid4()
+        existing_user.id = uuid7()
 
         mock_user_repo = AsyncMock()
         mock_user_repo.find_by_email.return_value = existing_user
@@ -324,7 +325,7 @@ class TestRegisterUserHandlerEvents:
         """Test duplicate email publishes FAILED event."""
         # Arrange
         existing_user = Mock()
-        existing_user.id = uuid4()
+        existing_user.id = uuid7()
 
         mock_user_repo = AsyncMock()
         mock_user_repo.find_by_email.return_value = existing_user

--- a/tests/unit/test_application_revoke_session_handlers.py
+++ b/tests/unit/test_application_revoke_session_handlers.py
@@ -11,7 +11,7 @@ Architecture:
 """
 
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -42,8 +42,8 @@ def create_mock_session_data(
 ):
     """Create a mock SessionData for testing."""
     mock = Mock(spec=SessionData)
-    mock.id = session_id or uuid4()
-    mock.user_id = user_id or uuid4()
+    mock.id = session_id or uuid7()
+    mock.user_id = user_id or uuid7()
     mock.device_info = device_info
     mock.is_revoked = is_revoked
     mock.revoked_at = None
@@ -58,8 +58,8 @@ class TestRevokeSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_session_returns_success(self):
         """Test successful revocation returns Success with session_id."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=user_id)
 
         mock_repo = AsyncMock()
@@ -88,8 +88,8 @@ class TestRevokeSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_session_marks_session_revoked(self):
         """Test revocation marks session as revoked."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=user_id)
 
         mock_repo = AsyncMock()
@@ -119,8 +119,8 @@ class TestRevokeSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_session_removes_from_cache(self):
         """Test revocation removes session from cache."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=user_id)
 
         mock_repo = AsyncMock()
@@ -149,8 +149,8 @@ class TestRevokeSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_session_publishes_event(self):
         """Test revocation publishes SessionRevokedEvent."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(
             session_id=session_id,
             user_id=user_id,
@@ -206,8 +206,8 @@ class TestRevokeSessionHandlerFailure:
         )
 
         command = RevokeSession(
-            session_id=uuid4(),
-            user_id=uuid4(),
+            session_id=uuid7(),
+            user_id=uuid7(),
             reason="user_logout",
         )
 
@@ -219,9 +219,9 @@ class TestRevokeSessionHandlerFailure:
     @pytest.mark.asyncio
     async def test_revoke_session_returns_not_owner(self):
         """Test revocation fails with NOT_OWNER when user doesn't own session."""
-        owner_id = uuid4()
-        other_user_id = uuid4()
-        session_id = uuid4()
+        owner_id = uuid7()
+        other_user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=owner_id)
 
         mock_repo = AsyncMock()
@@ -250,8 +250,8 @@ class TestRevokeSessionHandlerFailure:
     @pytest.mark.asyncio
     async def test_revoke_session_returns_already_revoked(self):
         """Test revocation fails with ALREADY_REVOKED for revoked session."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(
             session_id=session_id, user_id=user_id, is_revoked=True
         )
@@ -287,7 +287,7 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_returns_count(self):
         """Test bulk revocation returns count of revoked sessions."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.revoke_all_for_user.return_value = 5
@@ -314,7 +314,7 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_clears_cache(self):
         """Test bulk revocation clears all user sessions from cache."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.revoke_all_for_user.return_value = 3
@@ -340,7 +340,7 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_publishes_event(self):
         """Test bulk revocation publishes AllSessionsRevokedEvent."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.revoke_all_for_user.return_value = 3
@@ -371,8 +371,8 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_with_except_session_id(self):
         """Test bulk revocation excludes current session."""
-        user_id = uuid4()
-        current_session_id = uuid4()
+        user_id = uuid7()
+        current_session_id = uuid7()
         excluded_session = create_mock_session_data(
             session_id=current_session_id, user_id=user_id, is_revoked=False
         )
@@ -407,8 +407,8 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_re_caches_excluded_session(self):
         """Test excluded session is re-cached after bulk clear."""
-        user_id = uuid4()
-        current_session_id = uuid4()
+        user_id = uuid7()
+        current_session_id = uuid7()
         excluded_session = create_mock_session_data(
             session_id=current_session_id, user_id=user_id, is_revoked=False
         )
@@ -441,7 +441,7 @@ class TestRevokeAllSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_revoke_all_sessions_returns_zero_when_no_sessions(self):
         """Test bulk revocation returns zero when no sessions to revoke."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.revoke_all_for_user.return_value = 0

--- a/tests/unit/test_application_rotation_handlers.py
+++ b/tests/unit/test_application_rotation_handlers.py
@@ -12,7 +12,7 @@ Architecture:
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -61,7 +61,7 @@ def _create_mock_user(
 ):
     """Create a mock User for testing."""
     mock = Mock()
-    mock.id = user_id or uuid4()
+    mock.id = user_id or uuid7()
     mock.email = email
     mock.min_token_version = min_token_version
     mock.updated_at = datetime.now(UTC)
@@ -277,7 +277,7 @@ class TestTriggerUserRotationHandlerSuccess:
     @pytest.mark.asyncio
     async def test_user_rotation_returns_success(self):
         """Test successful rotation returns Success with user version info."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = _create_mock_user(user_id=user_id, min_token_version=1)
 
         mock_repo = AsyncMock()
@@ -306,7 +306,7 @@ class TestTriggerUserRotationHandlerSuccess:
     @pytest.mark.asyncio
     async def test_user_rotation_increments_user_version(self):
         """Test rotation increments user.min_token_version."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = _create_mock_user(user_id=user_id, min_token_version=3)
 
         mock_repo = AsyncMock()
@@ -334,7 +334,7 @@ class TestTriggerUserRotationHandlerSuccess:
     @pytest.mark.asyncio
     async def test_user_rotation_emits_attempted_event(self):
         """Test rotation emits UserTokenRotationAttempted event first."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = _create_mock_user(user_id=user_id)
 
         mock_repo = AsyncMock()
@@ -366,7 +366,7 @@ class TestTriggerUserRotationHandlerSuccess:
     @pytest.mark.asyncio
     async def test_user_rotation_emits_succeeded_event(self):
         """Test successful rotation emits UserTokenRotationSucceeded event."""
-        user_id = uuid4()
+        user_id = uuid7()
         mock_user = _create_mock_user(user_id=user_id, min_token_version=2)
 
         mock_repo = AsyncMock()
@@ -405,7 +405,7 @@ class TestTriggerUserRotationHandlerFailure:
     @pytest.mark.asyncio
     async def test_user_rotation_returns_not_found(self):
         """Test rotation returns Failure when user doesn't exist."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.find_by_id.return_value = None
@@ -431,7 +431,7 @@ class TestTriggerUserRotationHandlerFailure:
     @pytest.mark.asyncio
     async def test_user_rotation_emits_failed_event_for_not_found(self):
         """Test rotation emits UserTokenRotationFailed when user not found."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.find_by_id.return_value = None

--- a/tests/unit/test_application_session_query_handlers.py
+++ b/tests/unit/test_application_session_query_handlers.py
@@ -12,7 +12,7 @@ Architecture:
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -40,8 +40,8 @@ def create_mock_session_data(
 ):
     """Create a mock SessionData for testing."""
     mock = Mock(spec=SessionData)
-    mock.id = session_id or uuid4()
-    mock.user_id = user_id or uuid4()
+    mock.id = session_id or uuid7()
+    mock.user_id = user_id or uuid7()
     mock.device_info = device_info
     mock.ip_address = ip_address
     mock.location = location
@@ -59,8 +59,8 @@ class TestGetSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_get_session_returns_session_from_cache(self):
         """Test handler returns session found in cache."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=user_id)
 
         mock_cache = AsyncMock()
@@ -86,8 +86,8 @@ class TestGetSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_get_session_falls_back_to_database(self):
         """Test handler falls back to database on cache miss."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=user_id)
 
         mock_cache = AsyncMock()
@@ -112,8 +112,8 @@ class TestGetSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_get_session_populates_cache_on_miss(self):
         """Test handler populates cache when found in database."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(
             session_id=session_id, user_id=user_id, is_revoked=False
         )
@@ -138,8 +138,8 @@ class TestGetSessionHandlerSuccess:
     @pytest.mark.asyncio
     async def test_get_session_does_not_cache_revoked_session(self):
         """Test handler doesn't cache revoked sessions."""
-        user_id = uuid4()
-        session_id = uuid4()
+        user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(
             session_id=session_id, user_id=user_id, is_revoked=True
         )
@@ -180,7 +180,7 @@ class TestGetSessionHandlerFailure:
             session_cache=mock_cache,
         )
 
-        query = GetSession(session_id=uuid4(), user_id=uuid4())
+        query = GetSession(session_id=uuid7(), user_id=uuid7())
 
         result = await handler.handle(query)
 
@@ -190,9 +190,9 @@ class TestGetSessionHandlerFailure:
     @pytest.mark.asyncio
     async def test_get_session_returns_not_owner(self):
         """Test handler returns NOT_OWNER when user doesn't own session."""
-        owner_id = uuid4()
-        other_user_id = uuid4()
-        session_id = uuid4()
+        owner_id = uuid7()
+        other_user_id = uuid7()
+        session_id = uuid7()
         mock_session = create_mock_session_data(session_id=session_id, user_id=owner_id)
 
         mock_cache = AsyncMock()
@@ -220,7 +220,7 @@ class TestListSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_list_sessions_returns_all_sessions(self):
         """Test handler returns all sessions for user."""
-        user_id = uuid4()
+        user_id = uuid7()
         sessions = [
             create_mock_session_data(user_id=user_id, is_revoked=False),
             create_mock_session_data(user_id=user_id, is_revoked=False),
@@ -244,7 +244,7 @@ class TestListSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_list_sessions_with_active_only_filter(self):
         """Test handler filters to active sessions only."""
-        user_id = uuid4()
+        user_id = uuid7()
         active_sessions = [
             create_mock_session_data(user_id=user_id, is_revoked=False),
             create_mock_session_data(user_id=user_id, is_revoked=False),
@@ -266,9 +266,9 @@ class TestListSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_list_sessions_marks_current_session(self):
         """Test handler marks current session in list."""
-        user_id = uuid4()
-        current_session_id = uuid4()
-        other_session_id = uuid4()
+        user_id = uuid7()
+        current_session_id = uuid7()
+        other_session_id = uuid7()
 
         sessions = [
             create_mock_session_data(session_id=current_session_id, user_id=user_id),
@@ -297,7 +297,7 @@ class TestListSessionsHandlerSuccess:
     @pytest.mark.asyncio
     async def test_list_sessions_returns_empty_list(self):
         """Test handler returns empty list when no sessions."""
-        user_id = uuid4()
+        user_id = uuid7()
 
         mock_repo = AsyncMock()
         mock_repo.find_by_user_id.return_value = []

--- a/tests/unit/test_domain_account.py
+++ b/tests/unit/test_domain_account.py
@@ -15,7 +15,8 @@ Architecture:
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -49,8 +50,8 @@ def create_account(
     if balance is None:
         balance = Money(Decimal("10000.00"), currency)
     return Account(
-        id=account_id or uuid4(),
-        connection_id=connection_id or uuid4(),
+        id=account_id or uuid7(),
+        connection_id=connection_id or uuid7(),
         provider_account_id=provider_account_id,
         account_number_masked=account_number_masked,
         name=name,
@@ -175,8 +176,8 @@ class TestAccountCreation:
 
     def test_account_created_with_required_fields(self):
         """Test account can be created with all required fields."""
-        account_id = uuid4()
-        connection_id = uuid4()
+        account_id = uuid7()
+        connection_id = uuid7()
         balance = Money(Decimal("10000.00"), "USD")
 
         account = Account(

--- a/tests/unit/test_domain_events_authorization.py
+++ b/tests/unit/test_domain_events_authorization.py
@@ -10,7 +10,8 @@ Reference:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -32,13 +33,13 @@ from src.domain.events import (
 @pytest.fixture
 def user_id() -> UUID:
     """Test user ID."""
-    return uuid4()
+    return uuid7()
 
 
 @pytest.fixture
 def admin_id() -> UUID:
     """Test admin user ID."""
-    return uuid4()
+    return uuid7()
 
 
 # =============================================================================

--- a/tests/unit/test_domain_events_event_bus.py
+++ b/tests/unit/test_domain_events_event_bus.py
@@ -18,7 +18,7 @@ Architecture:
 
 import asyncio
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -50,7 +50,7 @@ class TestInMemoryEventBusBasicFlow:
             received_event = event
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -81,7 +81,7 @@ class TestInMemoryEventBusBasicFlow:
             call_order.append("handler_3")
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -104,7 +104,7 @@ class TestInMemoryEventBusBasicFlow:
         event_bus = InMemoryEventBus(logger=mock_logger)
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act & Assert - Should not raise exception
@@ -137,7 +137,7 @@ class TestInMemoryEventBusFailOpen:
             successful_handlers.append("handler_2")
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -177,7 +177,7 @@ class TestInMemoryEventBusFailOpen:
             pass  # Success
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -215,7 +215,7 @@ class TestInMemoryEventBusEventData:
             received_data["event_id"] = event.event_id
             received_data["occurred_at"] = event.occurred_at
 
-        user_id = uuid4()
+        user_id = uuid7()
         event = UserRegistrationSucceeded(
             user_id=user_id, email="test@example.com", verification_token="test_token"
         )
@@ -246,11 +246,11 @@ class TestInMemoryEventBusEventData:
             received_events.append(("password_change", event))
 
         registration_event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         password_event = UserPasswordChangeSucceeded(
-            user_id=uuid4(), initiated_by="user"
+            user_id=uuid7(), initiated_by="user"
         )
 
         # Act
@@ -292,7 +292,7 @@ class TestInMemoryEventBusAsyncSupport:
             execution_order.append("fast_end")
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -329,7 +329,7 @@ class TestInMemoryEventBusAsyncSupport:
             async_operation_completed = True
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -355,7 +355,7 @@ class TestInMemoryEventBusLogging:
             pass
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -381,7 +381,7 @@ class TestInMemoryEventBusLogging:
             raise ValueError("Test error message")
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act
@@ -418,7 +418,7 @@ class TestInMemoryEventBusEdgeCases:
             call_count += 1
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act - Subscribe same handler twice
@@ -442,13 +442,13 @@ class TestInMemoryEventBusEdgeCases:
             received_emails.append(event.email)
 
         event1 = UserRegistrationSucceeded(
-            user_id=uuid4(), email="user1@example.com", verification_token="token1"
+            user_id=uuid7(), email="user1@example.com", verification_token="token1"
         )
         event2 = UserRegistrationSucceeded(
-            user_id=uuid4(), email="user2@example.com", verification_token="token2"
+            user_id=uuid7(), email="user2@example.com", verification_token="token2"
         )
         event3 = UserRegistrationSucceeded(
-            user_id=uuid4(), email="user3@example.com", verification_token="token3"
+            user_id=uuid7(), email="user3@example.com", verification_token="token3"
         )
 
         # Act
@@ -475,7 +475,7 @@ class TestInMemoryEventBusEdgeCases:
             return "This return value should be ignored"
 
         event = UserRegistrationSucceeded(
-            user_id=uuid4(), email="test@example.com", verification_token="test_token"
+            user_id=uuid7(), email="test@example.com", verification_token="test_token"
         )
 
         # Act & Assert - Should not raise exception

--- a/tests/unit/test_domain_provider_connection.py
+++ b/tests/unit/test_domain_provider_connection.py
@@ -14,7 +14,8 @@ Architecture:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -104,9 +105,9 @@ def create_connection(
 ) -> ProviderConnection:
     """Helper to create ProviderConnection entities for testing."""
     return ProviderConnection(
-        id=connection_id or uuid4(),
-        user_id=user_id or uuid4(),
-        provider_id=provider_id or uuid4(),
+        id=connection_id or uuid7(),
+        user_id=user_id or uuid7(),
+        provider_id=provider_id or uuid7(),
         provider_slug=provider_slug,
         alias=alias,
         status=status,
@@ -123,9 +124,9 @@ class TestProviderConnectionCreation:
     def test_connection_created_with_all_required_fields(self):
         """Test connection can be created with all required fields."""
         # Arrange
-        connection_id = uuid4()
-        user_id = uuid4()
-        provider_id = uuid4()
+        connection_id = uuid7()
+        user_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         connection = ProviderConnection(

--- a/tests/unit/test_domain_provider_events.py
+++ b/tests/unit/test_domain_provider_events.py
@@ -13,7 +13,7 @@ Architecture:
 - Validates all events follow 3-state pattern
 """
 
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -37,8 +37,8 @@ class TestProviderConnectionAttempted:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderConnectionAttempted(
@@ -58,14 +58,14 @@ class TestProviderConnectionAttempted:
         """Test event is immutable (frozen dataclass)."""
         # Arrange
         event = ProviderConnectionAttempted(
-            user_id=uuid4(),
-            provider_id=uuid4(),
+            user_id=uuid7(),
+            provider_id=uuid7(),
             provider_slug="schwab",
         )
 
         # Act & Assert
         with pytest.raises(AttributeError):
-            event.user_id = uuid4()  # type: ignore[misc]
+            event.user_id = uuid7()  # type: ignore[misc]
 
 
 @pytest.mark.unit
@@ -75,9 +75,9 @@ class TestProviderConnectionSucceeded:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderConnectionSucceeded(
@@ -98,15 +98,15 @@ class TestProviderConnectionSucceeded:
         """Test event is immutable (frozen dataclass)."""
         # Arrange
         event = ProviderConnectionSucceeded(
-            user_id=uuid4(),
-            connection_id=uuid4(),
-            provider_id=uuid4(),
+            user_id=uuid7(),
+            connection_id=uuid7(),
+            provider_id=uuid7(),
             provider_slug="schwab",
         )
 
         # Act & Assert
         with pytest.raises(AttributeError):
-            event.connection_id = uuid4()  # type: ignore[misc]
+            event.connection_id = uuid7()  # type: ignore[misc]
 
 
 @pytest.mark.unit
@@ -116,8 +116,8 @@ class TestProviderConnectionFailed:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderConnectionFailed(
@@ -147,8 +147,8 @@ class TestProviderConnectionFailed:
         for reason in reasons:
             # Act
             event = ProviderConnectionFailed(
-                user_id=uuid4(),
-                provider_id=uuid4(),
+                user_id=uuid7(),
+                provider_id=uuid7(),
                 provider_slug="schwab",
                 reason=reason,
             )
@@ -164,9 +164,9 @@ class TestProviderDisconnectionAttempted:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderDisconnectionAttempted(
@@ -191,9 +191,9 @@ class TestProviderDisconnectionSucceeded:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderDisconnectionSucceeded(
@@ -218,9 +218,9 @@ class TestProviderDisconnectionFailed:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderDisconnectionFailed(
@@ -246,9 +246,9 @@ class TestProviderTokenRefreshAttempted:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderTokenRefreshAttempted(
@@ -273,9 +273,9 @@ class TestProviderTokenRefreshSucceeded:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderTokenRefreshSucceeded(
@@ -300,9 +300,9 @@ class TestProviderTokenRefreshFailed:
     def test_event_created_with_all_required_fields(self):
         """Test event can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
-        connection_id = uuid4()
-        provider_id = uuid4()
+        user_id = uuid7()
+        connection_id = uuid7()
+        provider_id = uuid7()
 
         # Act
         event = ProviderTokenRefreshFailed(
@@ -326,9 +326,9 @@ class TestProviderTokenRefreshFailed:
         """Test event defaults needs_user_action to False."""
         # Act
         event = ProviderTokenRefreshFailed(
-            user_id=uuid4(),
-            connection_id=uuid4(),
-            provider_id=uuid4(),
+            user_id=uuid7(),
+            connection_id=uuid7(),
+            provider_id=uuid7(),
             provider_slug="schwab",
             reason="network_error",
         )
@@ -348,9 +348,9 @@ class TestProviderTokenRefreshFailed:
         for reason in reasons:
             # Act
             event = ProviderTokenRefreshFailed(
-                user_id=uuid4(),
-                connection_id=uuid4(),
-                provider_id=uuid4(),
+                user_id=uuid7(),
+                connection_id=uuid7(),
+                provider_id=uuid7(),
                 provider_slug="schwab",
                 reason=reason,
             )

--- a/tests/unit/test_domain_session_entity.py
+++ b/tests/unit/test_domain_session_entity.py
@@ -15,7 +15,7 @@ Architecture:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -28,8 +28,8 @@ class TestSessionCreation:
 
     def test_session_creation_with_required_fields(self):
         """Test session creation with only required fields."""
-        session_id = uuid4()
-        user_id = uuid4()
+        session_id = uuid7()
+        user_id = uuid7()
 
         session = Session(id=session_id, user_id=user_id)
 
@@ -42,9 +42,9 @@ class TestSessionCreation:
 
     def test_session_creation_with_all_fields(self):
         """Test session creation with all fields populated."""
-        session_id = uuid4()
-        user_id = uuid4()
-        refresh_token_id = uuid4()
+        session_id = uuid7()
+        user_id = uuid7()
+        refresh_token_id = uuid7()
         now = datetime.now(UTC)
         expires_at = now + timedelta(days=30)
 
@@ -81,33 +81,33 @@ class TestSessionIsActive:
 
     def test_is_active_returns_true_for_new_session(self):
         """Test new session is active by default."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         assert session.is_active() is True
 
     def test_is_active_returns_false_when_revoked(self):
         """Test revoked session is not active."""
-        session = Session(id=uuid4(), user_id=uuid4(), is_revoked=True)
+        session = Session(id=uuid7(), user_id=uuid7(), is_revoked=True)
 
         assert session.is_active() is False
 
     def test_is_active_returns_false_when_expired(self):
         """Test expired session is not active."""
         past_time = datetime.now(UTC) - timedelta(hours=1)
-        session = Session(id=uuid4(), user_id=uuid4(), expires_at=past_time)
+        session = Session(id=uuid7(), user_id=uuid7(), expires_at=past_time)
 
         assert session.is_active() is False
 
     def test_is_active_returns_true_when_not_expired(self):
         """Test session with future expiration is active."""
         future_time = datetime.now(UTC) + timedelta(days=30)
-        session = Session(id=uuid4(), user_id=uuid4(), expires_at=future_time)
+        session = Session(id=uuid7(), user_id=uuid7(), expires_at=future_time)
 
         assert session.is_active() is True
 
     def test_is_active_returns_true_when_no_expiration(self):
         """Test session without expiration is active."""
-        session = Session(id=uuid4(), user_id=uuid4(), expires_at=None)
+        session = Session(id=uuid7(), user_id=uuid7(), expires_at=None)
 
         assert session.is_active() is True
 
@@ -115,7 +115,7 @@ class TestSessionIsActive:
         """Test session that is both revoked and expired is not active."""
         past_time = datetime.now(UTC) - timedelta(hours=1)
         session = Session(
-            id=uuid4(), user_id=uuid4(), is_revoked=True, expires_at=past_time
+            id=uuid7(), user_id=uuid7(), is_revoked=True, expires_at=past_time
         )
 
         assert session.is_active() is False
@@ -127,7 +127,7 @@ class TestSessionRevoke:
 
     def test_revoke_marks_session_as_revoked(self):
         """Test revoke sets is_revoked to True."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.revoke("user_logout")
 
@@ -135,7 +135,7 @@ class TestSessionRevoke:
 
     def test_revoke_sets_revoked_reason(self):
         """Test revoke stores the reason."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.revoke("password_changed")
 
@@ -143,7 +143,7 @@ class TestSessionRevoke:
 
     def test_revoke_sets_revoked_at_timestamp(self):
         """Test revoke sets timestamp."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         before_revoke = datetime.now(UTC)
 
         session.revoke("security_concern")
@@ -153,7 +153,7 @@ class TestSessionRevoke:
 
     def test_revoke_makes_session_inactive(self):
         """Test revoked session becomes inactive."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         assert session.is_active() is True
 
         session.revoke("admin_action")
@@ -171,7 +171,7 @@ class TestSessionRevoke:
         ]
 
         for reason in reasons:
-            session = Session(id=uuid4(), user_id=uuid4())
+            session = Session(id=uuid7(), user_id=uuid7())
             session.revoke(reason)
             assert session.revoked_reason == reason
 
@@ -182,7 +182,7 @@ class TestSessionUpdateActivity:
 
     def test_update_activity_updates_timestamp(self):
         """Test update_activity sets last_activity_at."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         before_update = datetime.now(UTC)
 
         session.update_activity()
@@ -192,7 +192,7 @@ class TestSessionUpdateActivity:
 
     def test_update_activity_with_same_ip(self):
         """Test update_activity with same IP doesn't track change."""
-        session = Session(id=uuid4(), user_id=uuid4(), ip_address="192.168.1.1")
+        session = Session(id=uuid7(), user_id=uuid7(), ip_address="192.168.1.1")
 
         session.update_activity(ip_address="192.168.1.1")
 
@@ -202,7 +202,7 @@ class TestSessionUpdateActivity:
 
     def test_update_activity_with_different_ip_tracks_change(self):
         """Test update_activity with different IP tracks change."""
-        session = Session(id=uuid4(), user_id=uuid4(), ip_address="192.168.1.1")
+        session = Session(id=uuid7(), user_id=uuid7(), ip_address="192.168.1.1")
 
         session.update_activity(ip_address="10.0.0.1")
 
@@ -212,7 +212,7 @@ class TestSessionUpdateActivity:
 
     def test_update_activity_sets_ip_when_none(self):
         """Test update_activity sets IP if none was set."""
-        session = Session(id=uuid4(), user_id=uuid4(), ip_address=None)
+        session = Session(id=uuid7(), user_id=uuid7(), ip_address=None)
 
         session.update_activity(ip_address="192.168.1.1")
 
@@ -220,7 +220,7 @@ class TestSessionUpdateActivity:
 
     def test_update_activity_without_ip(self):
         """Test update_activity without IP only updates timestamp."""
-        session = Session(id=uuid4(), user_id=uuid4(), ip_address="192.168.1.1")
+        session = Session(id=uuid7(), user_id=uuid7(), ip_address="192.168.1.1")
         before_update = datetime.now(UTC)
 
         session.update_activity()
@@ -235,7 +235,7 @@ class TestSessionRecordProviderAccess:
 
     def test_record_provider_access_stores_provider(self):
         """Test record_provider_access adds provider to list."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.record_provider_access("schwab")
 
@@ -243,7 +243,7 @@ class TestSessionRecordProviderAccess:
 
     def test_record_provider_access_sets_last_provider(self):
         """Test record_provider_access sets last_provider_accessed."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.record_provider_access("fidelity")
 
@@ -251,7 +251,7 @@ class TestSessionRecordProviderAccess:
 
     def test_record_provider_access_sets_sync_timestamp(self):
         """Test record_provider_access sets last_provider_sync_at."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         before_access = datetime.now(UTC)
 
         session.record_provider_access("schwab")
@@ -261,7 +261,7 @@ class TestSessionRecordProviderAccess:
 
     def test_record_provider_access_multiple_providers(self):
         """Test recording access to multiple providers."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.record_provider_access("schwab")
         session.record_provider_access("fidelity")
@@ -272,7 +272,7 @@ class TestSessionRecordProviderAccess:
 
     def test_record_provider_access_no_duplicates(self):
         """Test same provider not added twice to list."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.record_provider_access("schwab")
         session.record_provider_access("schwab")
@@ -287,7 +287,7 @@ class TestSessionSuspiciousActivity:
 
     def test_increment_suspicious_activity_increases_count(self):
         """Test increment adds to counter."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         assert session.suspicious_activity_count == 0
 
         session.increment_suspicious_activity()
@@ -296,7 +296,7 @@ class TestSessionSuspiciousActivity:
 
     def test_increment_suspicious_activity_multiple_times(self):
         """Test multiple increments."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.increment_suspicious_activity()
         session.increment_suspicious_activity()
@@ -311,7 +311,7 @@ class TestSessionMarkAsTrusted:
 
     def test_mark_as_trusted_sets_flag(self):
         """Test mark_as_trusted sets is_trusted to True."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
         assert session.is_trusted is False
 
         session.mark_as_trusted()
@@ -320,7 +320,7 @@ class TestSessionMarkAsTrusted:
 
     def test_mark_as_trusted_idempotent(self):
         """Test mark_as_trusted can be called multiple times."""
-        session = Session(id=uuid4(), user_id=uuid4())
+        session = Session(id=uuid7(), user_id=uuid7())
 
         session.mark_as_trusted()
         session.mark_as_trusted()

--- a/tests/unit/test_domain_transaction.py
+++ b/tests/unit/test_domain_transaction.py
@@ -12,7 +12,7 @@ Coverage target: 100%
 
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -257,8 +257,8 @@ class TestTransactionCreation:
 
     def test_create_minimal_transaction(self):
         """Create transaction with only required fields."""
-        transaction_id = uuid4()
-        account_id = uuid4()
+        transaction_id = uuid7()
+        account_id = uuid7()
         now = datetime.now(UTC)
 
         transaction = Transaction(
@@ -289,8 +289,8 @@ class TestTransactionCreation:
     def test_create_trade_transaction_with_security_details(self):
         """Create trade transaction with all security fields."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="trade-123",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -329,8 +329,8 @@ class TestTransactionCreation:
         }
 
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="schwab-123",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.SELL,
@@ -353,8 +353,8 @@ class TestTransactionQueryMethods:
     def test_is_trade_returns_true_for_trade_type(self):
         """is_trade() should return True for TRADE type."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -371,8 +371,8 @@ class TestTransactionQueryMethods:
     def test_is_trade_returns_false_for_non_trade_types(self):
         """is_trade() should return False for non-TRADE types."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.DEPOSIT,
@@ -389,8 +389,8 @@ class TestTransactionQueryMethods:
     def test_is_transfer_returns_true_for_transfer_type(self):
         """is_transfer() should return True for TRANSFER type."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.WITHDRAWAL,
@@ -407,8 +407,8 @@ class TestTransactionQueryMethods:
     def test_is_income_returns_true_for_income_type(self):
         """is_income() should return True for INCOME type."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.INCOME,
             subtype=TransactionSubtype.DIVIDEND,
@@ -425,8 +425,8 @@ class TestTransactionQueryMethods:
     def test_is_fee_returns_true_for_fee_type(self):
         """is_fee() should return True for FEE type."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.FEE,
             subtype=TransactionSubtype.ACCOUNT_FEE,
@@ -443,8 +443,8 @@ class TestTransactionQueryMethods:
     def test_is_debit_returns_true_for_negative_amount(self):
         """is_debit() should return True for negative amounts."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.WITHDRAWAL,
@@ -461,8 +461,8 @@ class TestTransactionQueryMethods:
     def test_is_debit_returns_false_for_positive_amount(self):
         """is_debit() should return False for positive amounts."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.DEPOSIT,
@@ -479,8 +479,8 @@ class TestTransactionQueryMethods:
     def test_is_credit_returns_true_for_positive_amount(self):
         """is_credit() should return True for positive amounts."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.DEPOSIT,
@@ -497,8 +497,8 @@ class TestTransactionQueryMethods:
     def test_is_credit_returns_false_for_negative_amount(self):
         """is_credit() should return False for negative amounts."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.WITHDRAWAL,
@@ -515,8 +515,8 @@ class TestTransactionQueryMethods:
     def test_is_settled_returns_true_for_settled_status(self):
         """is_settled() should return True for SETTLED status."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -538,8 +538,8 @@ class TestTransactionQueryMethods:
             TransactionStatus.CANCELLED,
         ]:
             transaction = Transaction(
-                id=uuid4(),
-                account_id=uuid4(),
+                id=uuid7(),
+                account_id=uuid7(),
                 provider_transaction_id="test-1",
                 transaction_type=TransactionType.TRADE,
                 subtype=TransactionSubtype.BUY,
@@ -556,8 +556,8 @@ class TestTransactionQueryMethods:
     def test_has_security_details_returns_true_when_all_present(self):
         """has_security_details() should return True when symbol, quantity, unit_price all present."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -577,8 +577,8 @@ class TestTransactionQueryMethods:
     def test_has_security_details_returns_false_when_symbol_missing(self):
         """has_security_details() should return False when symbol is None."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -598,8 +598,8 @@ class TestTransactionQueryMethods:
     def test_has_security_details_returns_false_when_quantity_missing(self):
         """has_security_details() should return False when quantity is None."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -619,8 +619,8 @@ class TestTransactionQueryMethods:
     def test_has_security_details_returns_false_when_unit_price_missing(self):
         """has_security_details() should return False when unit_price is None."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRADE,
             subtype=TransactionSubtype.BUY,
@@ -644,8 +644,8 @@ class TestTransactionImmutability:
     def test_transaction_is_frozen(self):
         """Transaction should be immutable (frozen dataclass)."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.DEPOSIT,
@@ -664,8 +664,8 @@ class TestTransactionImmutability:
     def test_transaction_has_no_update_methods(self):
         """Transaction should not have any update methods."""
         transaction = Transaction(
-            id=uuid4(),
-            account_id=uuid4(),
+            id=uuid7(),
+            account_id=uuid7(),
             provider_transaction_id="test-1",
             transaction_type=TransactionType.TRANSFER,
             subtype=TransactionSubtype.DEPOSIT,

--- a/tests/unit/test_domain_user_entity.py
+++ b/tests/unit/test_domain_user_entity.py
@@ -14,7 +14,8 @@ Architecture:
 """
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid_extensions import uuid7
 
 import pytest
 
@@ -33,7 +34,7 @@ def create_user(
     """Helper to create User entities for testing."""
     now = datetime.now(UTC)
     return User(
-        id=user_id or uuid4(),
+        id=user_id or uuid7(),
         email=email,
         password_hash=password_hash,
         is_verified=is_verified,
@@ -52,7 +53,7 @@ class TestUserCreation:
     def test_user_created_with_all_required_fields(self):
         """Test User can be created with all required fields."""
         # Arrange
-        user_id = uuid4()
+        user_id = uuid7()
         now = datetime.now(UTC)
 
         # Act

--- a/tests/unit/test_infrastructure_audit_postgres_adapter.py
+++ b/tests/unit/test_infrastructure_audit_postgres_adapter.py
@@ -16,7 +16,7 @@ Architecture:
 
 from datetime import datetime, UTC
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid_extensions import uuid7
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
@@ -43,7 +43,7 @@ class TestPostgresAuditAdapterRecord:
 
         adapter = PostgresAuditAdapter(session=mock_session)
 
-        user_id = uuid4()
+        user_id = uuid7()
         test_context = {"method": "password", "mfa": True}
 
         # Act
@@ -129,7 +129,7 @@ class TestPostgresAuditAdapterRecord:
         result = await adapter.record(
             action=AuditAction.USER_LOGIN_SUCCESS,
             resource_type="session",
-            user_id=uuid4(),
+            user_id=uuid7(),
         )
 
         # Assert
@@ -193,10 +193,10 @@ class TestPostgresAuditAdapterQuery:
         mock_session = AsyncMock()
 
         # Create mock audit logs
-        user_id = uuid4()
+        user_id = uuid7()
         mock_logs = [
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.USER_LOGIN_SUCCESS,
                 user_id=user_id,
                 resource_type="session",
@@ -207,7 +207,7 @@ class TestPostgresAuditAdapterQuery:
                 created_at=datetime(2024, 11, 15, 12, 0, 0, tzinfo=UTC),
             ),
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.DATA_VIEWED,
                 user_id=user_id,
                 resource_type="account",
@@ -273,7 +273,7 @@ class TestPostgresAuditAdapterQuery:
 
         # Act
         result = await adapter.query(
-            user_id=uuid4(),
+            user_id=uuid7(),
             action=AuditAction.USER_LOGIN_SUCCESS,
         )
 
@@ -287,10 +287,10 @@ class TestPostgresAuditAdapterQuery:
         # Arrange
         mock_session = AsyncMock()
 
-        user_id = uuid4()
+        user_id = uuid7()
         mock_logs = [
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.PROVIDER_CONNECTED,
                 user_id=user_id,
                 resource_type="provider",
@@ -334,9 +334,9 @@ class TestPostgresAuditAdapterQuery:
         # Create 3 mock logs
         mock_logs = [
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.USER_LOGIN_SUCCESS,
-                user_id=uuid4(),
+                user_id=uuid7(),
                 resource_type="session",
                 resource_id=None,
                 ip_address="192.168.1.1",
@@ -381,7 +381,7 @@ class TestPostgresAuditAdapterQuery:
 
         # Act
         result = await adapter.query(
-            user_id=uuid4(),
+            user_id=uuid7(),
             action=AuditAction.USER_LOGIN_SUCCESS,
         )
 
@@ -397,8 +397,8 @@ class TestPostgresAuditAdapterQuery:
         # Arrange
         mock_session = AsyncMock()
 
-        log_id = uuid4()
-        user_id = uuid4()
+        log_id = uuid7()
+        user_id = uuid7()
 
         mock_logs = [
             MagicMock(
@@ -445,7 +445,7 @@ class TestPostgresAuditAdapterQuery:
         # Log with None user_id (system action)
         mock_logs = [
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.ADMIN_BACKUP_CREATED,
                 user_id=None,  # System action, no user
                 resource_type="system",
@@ -512,9 +512,9 @@ class TestPostgresAuditAdapterEdgeCases:
 
         mock_logs = [
             MagicMock(
-                id=uuid4(),
+                id=uuid7(),
                 action=AuditAction.USER_LOGIN_SUCCESS,
-                user_id=uuid4(),
+                user_id=uuid7(),
                 resource_type="session",
                 resource_id=None,
                 ip_address="192.168.1.1",
@@ -568,7 +568,7 @@ class TestPostgresAuditAdapterEdgeCases:
             action=AuditAction.USER_LOGIN_SUCCESS,
             resource_type="session",
         )
-        result2 = await adapter2.query(user_id=uuid4())
+        result2 = await adapter2.query(user_id=uuid7())
 
         # Assert: Both adapters work independently
         assert isinstance(result1, Success)

--- a/uv.lock
+++ b/uv.lock
@@ -620,6 +620,7 @@ dependencies = [
     { name = "structlog" },
     { name = "urllib3" },
     { name = "user-agents" },
+    { name = "uuid7" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -675,6 +676,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "urllib3", specifier = ">=2.5.0" },
     { name = "user-agents", specifier = ">=2.2.0" },
+    { name = "uuid7", specifier = ">=0.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.37.0" },
 ]
 
@@ -2276,6 +2278,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/e1/63c5bfb485a945010c8cbc7a52f85573561737648d36b30394248730a7bc/user-agents-2.2.0.tar.gz", hash = "sha256:d36d25178db65308d1458c5fa4ab39c9b2619377010130329f3955e7626ead26", size = 9525, upload-time = "2020-08-23T06:01:56.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/1c/20bb3d7b2bad56d881e3704131ddedbb16eb787101306887dff349064662/user_agents-2.2.0-py3-none-any.whl", hash = "sha256:a98c4dc72ecbc64812c4534108806fb0a0b3a11ec3fd1eafe807cee5b0a942e7", size = 9614, upload-time = "2020-08-23T06:01:54.047Z" },
+]
+
+[[package]]
+name = "uuid7"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052, upload-time = "2021-12-29T01:38:21.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477, upload-time = "2021-12-29T01:38:20.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate entire codebase from UUID v4 (random) to UUID v7 (time-ordered) for better database performance and chronological sorting capabilities.

Changes:
- Add uuid7>=0.1.0 dependency (installs as uuid_extensions module)
- Update all UUID generation from uuid4() to uuid7()
- Update 5 domain entities (User, Session, Account, ProviderConnection, Transaction)
- Update 12 application layer handlers
- Update 6 infrastructure layer files
- Update 1 presentation layer file (trace middleware)
- Update 26 test files (402 uuid7() calls)
- Update 11 architecture documentation files
- Configure mypy to ignore uuid_extensions (no type stubs)

Benefits:
- Time-ordered IDs enable chronological sorting by ID alone
- 10-30% faster B-tree index operations
- Better database page utilization (reduced fragmentation)
- ID itself encodes creation timestamp (debugging aid)
- Future-proof standard (RFC 9562, May 2024)

Testing:
- All 1018 tests passing (0 failures, 17 skipped)
- 79% code coverage maintained
- Lint and format checks passed
- No database schema changes required (PostgreSQL UUID type is version-agnostic)

Impact:
- Zero production impact (pre-release, no data migration needed)
- Backward compatible (UUID v7 stored same as v4 in PostgreSQL)
- No API changes (UUID type unchanged)