### PR TITLE
docs(api): Add Phase 5 API documentation

### DIFF
--- a/docs/api/account-operations.md
+++ b/docs/api/account-operations.md
@@ -1,0 +1,308 @@
+# Account Operations API
+
+## Overview
+
+This document describes the account API endpoints for Dashtam.
+Accounts represent financial accounts (brokerage, IRA, etc.) linked via provider connections.
+
+**Base URL**: `{BASE_URL}` (used in examples below)
+
+| Environment | BASE_URL |
+|-------------|----------|
+| Development | `https://dashtam.local/api/v1` |
+| Test | `https://test.dashtam.local/api/v1` |
+| Production | `https://api.dashtam.com/api/v1` |
+
+**Authentication**: All endpoints require JWT Bearer token.
+
+---
+
+## Endpoints Summary
+
+| Resource | Method | Endpoint | Description |
+|----------|--------|----------|-------------|
+| Accounts | GET | `/accounts` | List all accounts for user |
+| Accounts | GET | `/accounts/{id}` | Get account details |
+| Account Syncs | POST | `/accounts/syncs` | Sync accounts from provider |
+| Provider Accounts | GET | `/providers/{id}/accounts` | List accounts for a connection |
+
+---
+
+## List All Accounts
+
+### GET /accounts
+
+List all accounts for the authenticated user across all provider connections.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/accounts" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| active_only | boolean | No | Only return active accounts (default: false) |
+| account_type | string | No | Filter by account type (e.g., "brokerage", "ira") |
+
+**Success Response (200 OK):**
+
+```json
+{
+  "accounts": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_account_id": "12345678",
+      "account_number_masked": "****1234",
+      "name": "Individual Brokerage",
+      "account_type": "brokerage",
+      "balance": "25000.50",
+      "currency": "USD",
+      "available_balance": "24500.00",
+      "is_active": true,
+      "last_synced_at": "2025-12-04T15:30:00Z",
+      "created_at": "2025-12-01T10:00:00Z",
+      "updated_at": "2025-12-04T15:30:00Z"
+    },
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440001",
+      "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_account_id": "87654321",
+      "account_number_masked": "****5678",
+      "name": "Roth IRA",
+      "account_type": "roth_ira",
+      "balance": "50000.00",
+      "currency": "USD",
+      "available_balance": null,
+      "is_active": true,
+      "last_synced_at": "2025-12-04T15:30:00Z",
+      "created_at": "2025-12-01T10:00:00Z",
+      "updated_at": "2025-12-04T15:30:00Z"
+    }
+  ],
+  "total": 2,
+  "active_count": 2,
+  "total_balance_by_currency": {
+    "USD": "75000.50"
+  }
+}
+```
+
+---
+
+## Get Account
+
+### GET /accounts/{id}
+
+Get details of a specific account.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/accounts/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+  "provider_account_id": "12345678",
+  "account_number_masked": "****1234",
+  "name": "Individual Brokerage",
+  "account_type": "brokerage",
+  "balance": "25000.50",
+  "currency": "USD",
+  "available_balance": "24500.00",
+  "is_active": true,
+  "last_synced_at": "2025-12-04T15:30:00Z",
+  "created_at": "2025-12-01T10:00:00Z",
+  "updated_at": "2025-12-04T15:30:00Z"
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Account not found
+- `403 Forbidden` - Not authorized to access this account
+
+---
+
+## Sync Accounts
+
+### POST /accounts/syncs
+
+Sync accounts from a provider connection. Fetches latest account data from provider and updates database.
+
+**Request:**
+
+```bash
+curl -k -X POST "{BASE_URL}/accounts/syncs" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+    "force": false
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| connection_id | UUID | Yes | Provider connection to sync from |
+| force | boolean | No | Force sync even if recently synced (default: false) |
+
+**Success Response (201 Created):**
+
+```json
+{
+  "created": 0,
+  "updated": 2,
+  "unchanged": 0,
+  "errors": 0,
+  "message": "Successfully synced 2 accounts",
+  "accounts_created": 0,
+  "accounts_updated": 2
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized to sync this connection
+- `429 Too Many Requests` - Sync rate limit exceeded (try again later)
+
+**Notes:**
+
+- Default sync interval is 15 minutes; use `force: true` to bypass
+- Sync creates new accounts or updates existing ones based on provider_account_id
+- Connection must be in ACTIVE status
+
+---
+
+## List Accounts by Connection
+
+### GET /providers/{id}/accounts
+
+List all accounts for a specific provider connection.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/providers/123e4567-e89b-12d3-a456-426614174000/accounts" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| active_only | boolean | No | Only return active accounts (default: false) |
+
+**Success Response (200 OK):**
+
+```json
+{
+  "accounts": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_account_id": "12345678",
+      "account_number_masked": "****1234",
+      "name": "Individual Brokerage",
+      "account_type": "brokerage",
+      "balance": "25000.50",
+      "currency": "USD",
+      "is_active": true,
+      "last_synced_at": "2025-12-04T15:30:00Z"
+    }
+  ],
+  "total": 1,
+  "active_count": 1
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized to access this connection
+
+---
+
+## Account Types
+
+| Type | Description |
+|------|-------------|
+| brokerage | Standard brokerage account |
+| ira | Traditional IRA |
+| roth_ira | Roth IRA |
+| sep_ira | SEP IRA |
+| simple_ira | SIMPLE IRA |
+| 401k | 401(k) retirement account |
+| 403b | 403(b) retirement account |
+| checking | Checking account |
+| savings | Savings account |
+| money_market | Money market account |
+| cd | Certificate of deposit |
+| hsa | Health savings account |
+| education | Education savings (529, etc.) |
+| trust | Trust account |
+| other | Other account type |
+
+---
+
+## Account Sync Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant DB
+    participant Provider
+
+    Client->>API: POST /accounts/syncs (connection_id)
+    API->>DB: Verify connection ownership
+    API->>DB: Check last sync time
+    
+    alt Recently synced (< 15 min) and not forced
+        API->>Client: 429 Rate Limit Exceeded
+    else Ready to sync
+        API->>Provider: Fetch accounts (access_token)
+        Provider->>API: Account data
+        
+        loop For each account
+            API->>DB: Upsert account
+        end
+        
+        API->>DB: Update connection.last_sync_at
+        API->>Client: 201 + sync statistics
+    end
+```
+
+---
+
+## Error Response Format (RFC 7807)
+
+All errors follow RFC 7807 Problem Details format:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/not_found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Account not found",
+  "instance": "/api/v1/accounts/550e8400-e29b-41d4-a716-446655440000",
+  "trace_id": "abc123-def456-ghi789"
+}
+```
+
+---
+
+**Created**: 2025-12-04 | **Last Updated**: 2025-12-04

--- a/docs/api/provider-connection.md
+++ b/docs/api/provider-connection.md
@@ -1,0 +1,398 @@
+# Provider Connection API
+
+## Overview
+
+This document describes the provider connection API endpoints for Dashtam.
+Provider connections enable users to link their financial accounts (e.g., Charles Schwab)
+via OAuth 2.0 for secure data access.
+
+**Base URL**: `{BASE_URL}` (used in examples below)
+
+| Environment | BASE_URL |
+|-------------|----------|
+| Development | `https://dashtam.local/api/v1` |
+| Test | `https://test.dashtam.local/api/v1` |
+| Production | `https://api.dashtam.com/api/v1` |
+
+**Authentication**: All endpoints require JWT Bearer token (except OAuth callback which validates state).
+
+---
+
+## Endpoints Summary
+
+| Resource | Method | Endpoint | Description |
+|----------|--------|----------|-------------|
+| Providers | GET | `/providers` | List all connections |
+| Providers | GET | `/providers/{id}` | Get connection details |
+| Providers | POST | `/providers` | Initiate OAuth connection |
+| Providers | POST | `/providers/callback` | Complete OAuth callback |
+| Providers | PATCH | `/providers/{id}` | Update connection (alias) |
+| Providers | DELETE | `/providers/{id}` | Disconnect provider |
+| Token Refreshes | POST | `/providers/{id}/token-refreshes` | Refresh provider tokens |
+
+---
+
+## List Provider Connections
+
+### GET /providers
+
+List all provider connections for the authenticated user.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/providers" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| active_only | boolean | No | Only return active connections (default: false) |
+
+**Success Response (200 OK):**
+
+```json
+{
+  "connections": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "user_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_id": "00000000-0000-0000-0000-000000000001",
+      "provider_slug": "schwab",
+      "alias": "My Schwab Account",
+      "status": "active",
+      "is_connected": true,
+      "needs_reauthentication": false,
+      "connected_at": "2025-12-01T10:00:00Z",
+      "last_sync_at": "2025-12-04T15:30:00Z",
+      "created_at": "2025-12-01T10:00:00Z",
+      "updated_at": "2025-12-04T15:30:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+---
+
+## Get Provider Connection
+
+### GET /providers/{id}
+
+Get details of a specific provider connection.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/providers/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "123e4567-e89b-12d3-a456-426614174000",
+  "provider_id": "00000000-0000-0000-0000-000000000001",
+  "provider_slug": "schwab",
+  "alias": "My Schwab Account",
+  "status": "active",
+  "is_connected": true,
+  "needs_reauthentication": false,
+  "connected_at": "2025-12-01T10:00:00Z",
+  "last_sync_at": "2025-12-04T15:30:00Z",
+  "created_at": "2025-12-01T10:00:00Z",
+  "updated_at": "2025-12-04T15:30:00Z"
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized to access this connection
+
+---
+
+## Initiate Provider Connection (OAuth)
+
+### POST /providers
+
+Start the OAuth flow to connect a financial provider.
+
+**Request:**
+
+```bash
+curl -k -X POST "{BASE_URL}/providers" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_slug": "schwab",
+    "alias": "My Schwab Account",
+    "redirect_uri": "https://myapp.com/oauth/callback"
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| provider_slug | string | Yes | Provider identifier (e.g., "schwab") |
+| alias | string | No | User-friendly name for connection |
+| redirect_uri | string | No | Custom redirect URI (uses default if not provided) |
+
+**Success Response (201 Created):**
+
+```json
+{
+  "authorization_url": "https://api.schwabapi.com/v1/oauth/authorize?client_id=xxx&response_type=code&redirect_uri=xxx&state=abc123&scope=read_accounts%20read_transactions",
+  "state": "abc123def456...",
+  "expires_in": 600
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Provider not supported
+
+**Notes:**
+
+- Redirect user to `authorization_url` for OAuth consent
+- State token expires in 10 minutes
+- After user consent, provider redirects to callback with code and state
+
+---
+
+## Complete OAuth Callback
+
+### POST /providers/callback
+
+Complete the OAuth flow after user consent. Called by frontend after redirect.
+
+**Request:**
+
+```bash
+curl -k -X POST "{BASE_URL}/providers/callback?code=AUTH_CODE&state=abc123def456" \
+  -H "Content-Type: application/json"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| code | string | Yes | Authorization code from provider |
+| state | string | Yes | CSRF state token from initiation |
+
+**Success Response (201 Created):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "123e4567-e89b-12d3-a456-426614174000",
+  "provider_id": "00000000-0000-0000-0000-000000000001",
+  "provider_slug": "schwab",
+  "alias": "My Schwab Account",
+  "status": "active",
+  "is_connected": true,
+  "needs_reauthentication": false,
+  "connected_at": "2025-12-04T20:00:00Z",
+  "last_sync_at": null,
+  "created_at": "2025-12-04T20:00:00Z",
+  "updated_at": "2025-12-04T20:00:00Z"
+}
+```
+
+**Error Responses:**
+
+- `400 Bad Request` - Invalid or expired state token
+- `502 Bad Gateway` - Provider authentication failed
+
+---
+
+## Update Provider Connection
+
+### PATCH /providers/{id}
+
+Update connection properties (currently only alias).
+
+**Request:**
+
+```bash
+curl -k -X PATCH "{BASE_URL}/providers/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "alias": "Personal Brokerage"
+  }'
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "provider_slug": "schwab",
+  "alias": "Personal Brokerage",
+  "status": "active",
+  "is_connected": true
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized to update this connection
+
+---
+
+## Disconnect Provider
+
+### DELETE /providers/{id}
+
+Disconnect and remove a provider connection.
+
+**Request:**
+
+```bash
+curl -k -X DELETE "{BASE_URL}/providers/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Success Response (204 No Content):**
+
+No body returned.
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized to disconnect this connection
+
+**Notes:**
+
+- Connection status transitions to DISCONNECTED
+- Credentials are cleared
+- Connection record is kept for audit purposes
+- Associated accounts and transactions remain in database
+
+---
+
+## Refresh Provider Tokens
+
+### POST /providers/{id}/token-refreshes
+
+Refresh OAuth tokens for a provider connection.
+
+**Request:**
+
+```bash
+curl -k -X POST "{BASE_URL}/providers/550e8400-e29b-41d4-a716-446655440000/token-refreshes" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "force": false
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| force | boolean | No | Force refresh even if not expired (default: false) |
+
+**Success Response (201 Created):**
+
+```json
+{
+  "success": true,
+  "message": "Token refresh scheduled",
+  "expires_at": "2025-12-04T20:30:00Z"
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection not found
+- `403 Forbidden` - Not authorized or connection not active
+- `502 Bad Gateway` - Provider token refresh failed
+
+---
+
+## OAuth Connection Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Cache
+    participant Provider
+
+    Note over Client,Provider: Step 1: Initiate Connection
+    Client->>API: POST /providers (provider_slug, alias)
+    API->>Cache: Store state (user_id, provider, alias)
+    API->>Client: 201 + authorization_url, state
+
+    Note over Client,Provider: Step 2: User Consent
+    Client->>Provider: Redirect to authorization_url
+    Provider->>Provider: User logs in and consents
+    Provider->>Client: Redirect with code + state
+
+    Note over Client,Provider: Step 3: Complete Connection
+    Client->>API: POST /providers/callback?code=xxx&state=yyy
+    API->>Cache: Validate and retrieve state
+    API->>Provider: Exchange code for tokens
+    Provider->>API: access_token + refresh_token
+    API->>API: Encrypt and store credentials
+    API->>API: Create provider connection
+    API->>Client: 201 + connection details
+
+    Note over Client,Provider: Step 4: Use Connection
+    Client->>API: POST /accounts/syncs (connection_id)
+    API->>Provider: Fetch accounts (with access_token)
+    Provider->>API: Account data
+    API->>Client: 201 + sync results
+```
+
+---
+
+## Connection Status Values
+
+| Status | Description |
+|--------|-------------|
+| pending | OAuth flow started, awaiting completion |
+| active | Connected and tokens valid |
+| expired | Access token expired, needs refresh |
+| revoked | User revoked access at provider |
+| failed | Connection attempt failed |
+| disconnected | User disconnected in Dashtam |
+
+---
+
+## Error Response Format (RFC 7807)
+
+All errors follow RFC 7807 Problem Details format:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/not_found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Connection not found",
+  "instance": "/api/v1/providers/550e8400-e29b-41d4-a716-446655440000",
+  "trace_id": "abc123-def456-ghi789"
+}
+```
+
+---
+
+## Supported Providers
+
+| Provider | Slug | Status |
+|----------|------|--------|
+| Charles Schwab | `schwab` | Active |
+| Plaid | `plaid` | Planned (Phase 6) |
+
+---
+
+**Created**: 2025-12-04 | **Last Updated**: 2025-12-04

--- a/docs/api/transaction-operations.md
+++ b/docs/api/transaction-operations.md
@@ -1,0 +1,316 @@
+# Transaction Operations API
+
+## Overview
+
+This document describes the transaction API endpoints for Dashtam.
+Transactions represent historical financial activity (trades, deposits, withdrawals, transfers).
+
+**Base URL**: `{BASE_URL}` (used in examples below)
+
+| Environment | BASE_URL |
+|-------------|----------|
+| Development | `https://dashtam.local/api/v1` |
+| Test | `https://test.dashtam.local/api/v1` |
+| Production | `https://api.dashtam.com/api/v1` |
+
+**Authentication**: All endpoints require JWT Bearer token.
+
+---
+
+## Endpoints Summary
+
+| Resource | Method | Endpoint | Description |
+|----------|--------|----------|-------------|
+| Transactions | GET | `/transactions/{id}` | Get transaction details |
+| Transaction Syncs | POST | `/transactions/syncs` | Sync transactions from provider |
+| Account Transactions | GET | `/accounts/{id}/transactions` | List transactions for an account |
+
+---
+
+## Get Transaction
+
+### GET /transactions/{id}
+
+Get details of a specific transaction.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/transactions/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "account_id": "123e4567-e89b-12d3-a456-426614174000",
+  "provider_transaction_id": "TXN12345678",
+  "transaction_type": "trade",
+  "transaction_subtype": "buy",
+  "status": "settled",
+  "transaction_date": "2025-12-01",
+  "settlement_date": "2025-12-03",
+  "amount": "-1500.00",
+  "currency": "USD",
+  "description": "Buy 10 AAPL @ $150.00",
+  "symbol": "AAPL",
+  "asset_type": "equity",
+  "quantity": "10.0",
+  "price": "150.00",
+  "fees": "0.00",
+  "net_amount": "-1500.00",
+  "cusip": "037833100",
+  "created_at": "2025-12-01T10:00:00Z",
+  "updated_at": "2025-12-01T10:00:00Z"
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Transaction not found
+- `403 Forbidden` - Not authorized to access this transaction
+
+---
+
+## Sync Transactions
+
+### POST /transactions/syncs
+
+Sync transactions from a provider connection. Fetches transaction history from provider.
+
+**Request:**
+
+```bash
+curl -k -X POST "{BASE_URL}/transactions/syncs" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connection_id": "123e4567-e89b-12d3-a456-426614174000",
+    "account_id": "456e7890-e89b-12d3-a456-426614174001",
+    "start_date": "2025-01-01",
+    "end_date": "2025-12-04",
+    "force": false
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| connection_id | UUID | Yes | Provider connection to sync from |
+| account_id | UUID | No | Specific account to sync (syncs all if omitted) |
+| start_date | date | No | Start date for transaction range (default: 30 days ago) |
+| end_date | date | No | End date for transaction range (default: today) |
+| force | boolean | No | Force sync even if recently synced (default: false) |
+
+**Success Response (201 Created):**
+
+```json
+{
+  "created": 15,
+  "updated": 3,
+  "unchanged": 82,
+  "errors": 0,
+  "message": "Successfully synced 100 transactions",
+  "transactions_created": 15,
+  "transactions_updated": 3
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Connection or account not found
+- `403 Forbidden` - Not authorized to sync
+- `429 Too Many Requests` - Sync rate limit exceeded
+
+**Notes:**
+
+- Maximum date range is typically 1 year (provider dependent)
+- Transactions are identified by provider_transaction_id for upsert
+- Connection must be in ACTIVE status
+
+---
+
+## List Transactions by Account
+
+### GET /accounts/{id}/transactions
+
+List transactions for a specific account with pagination and filters.
+
+**Request:**
+
+```bash
+curl -k -X GET "{BASE_URL}/accounts/123e4567-e89b-12d3-a456-426614174000/transactions" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| limit | integer | No | Max results (1-100, default: 50) |
+| offset | integer | No | Results to skip (default: 0) |
+| transaction_type | string | No | Filter by type (e.g., "trade", "transfer") |
+| start_date | date | No | Filter from date (inclusive) |
+| end_date | date | No | Filter to date (inclusive) |
+
+**Example with Filters:**
+
+```bash
+curl -k -X GET "{BASE_URL}/accounts/123e4567-e89b-12d3-a456-426614174000/transactions?start_date=2025-11-01&end_date=2025-12-01&limit=25" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "transactions": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "account_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_transaction_id": "TXN12345678",
+      "transaction_type": "trade",
+      "transaction_subtype": "buy",
+      "status": "settled",
+      "transaction_date": "2025-12-01",
+      "amount": "-1500.00",
+      "currency": "USD",
+      "description": "Buy 10 AAPL @ $150.00",
+      "symbol": "AAPL",
+      "asset_type": "equity",
+      "quantity": "10.0",
+      "price": "150.00"
+    },
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440001",
+      "account_id": "123e4567-e89b-12d3-a456-426614174000",
+      "provider_transaction_id": "TXN87654321",
+      "transaction_type": "income",
+      "transaction_subtype": "dividend",
+      "status": "settled",
+      "transaction_date": "2025-11-15",
+      "amount": "25.50",
+      "currency": "USD",
+      "description": "AAPL Dividend",
+      "symbol": "AAPL",
+      "asset_type": "equity",
+      "quantity": null,
+      "price": null
+    }
+  ],
+  "total_count": 150,
+  "has_more": true
+}
+```
+
+**Error Responses:**
+
+- `404 Not Found` - Account not found
+- `403 Forbidden` - Not authorized to access this account
+
+---
+
+## Transaction Types
+
+| Type | Description |
+|------|-------------|
+| trade | Security buy/sell transactions |
+| transfer | Money movement (deposit, withdrawal, transfer) |
+| income | Dividends, interest, distributions |
+| fee | Account fees, commissions |
+| other | Miscellaneous transactions |
+
+---
+
+## Transaction Subtypes
+
+### Trade Subtypes
+
+| Subtype | Description |
+|---------|-------------|
+| buy | Purchase securities |
+| sell | Sell securities |
+| short_sell | Short sale |
+| buy_to_cover | Cover short position |
+
+### Transfer Subtypes
+
+| Subtype | Description |
+|---------|-------------|
+| deposit | Cash deposit |
+| withdrawal | Cash withdrawal |
+| transfer_in | Transfer from another account |
+| transfer_out | Transfer to another account |
+| wire_in | Incoming wire transfer |
+| wire_out | Outgoing wire transfer |
+| ach_in | Incoming ACH transfer |
+| ach_out | Outgoing ACH transfer |
+
+### Income Subtypes
+
+| Subtype | Description |
+|---------|-------------|
+| dividend | Stock dividend |
+| interest | Interest income |
+| capital_gain | Capital gain distribution |
+| return_of_capital | Return of capital |
+
+### Fee Subtypes
+
+| Subtype | Description |
+|---------|-------------|
+| commission | Trading commission |
+| management_fee | Account management fee |
+| margin_interest | Margin interest charge |
+| other_fee | Miscellaneous fees |
+
+---
+
+## Transaction Status Values
+
+| Status | Description |
+|--------|-------------|
+| pending | Transaction initiated, not yet settled |
+| settled | Transaction completed and settled |
+| failed | Transaction failed |
+| cancelled | Transaction cancelled |
+
+---
+
+## Asset Types
+
+| Type | Description |
+|------|-------------|
+| equity | Common/preferred stock |
+| option | Options contracts |
+| etf | Exchange-traded funds |
+| mutual_fund | Mutual funds |
+| bond | Bonds and fixed income |
+| future | Futures contracts |
+| crypto | Cryptocurrency |
+| cash | Cash/money market |
+| other | Other asset types |
+
+---
+
+## Error Response Format (RFC 7807)
+
+All errors follow RFC 7807 Problem Details format:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/not_found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Transaction not found",
+  "instance": "/api/v1/transactions/550e8400-e29b-41d4-a716-446655440000",
+  "trace_id": "abc123-def456-ghi789"
+}
+```
+
+---
+
+**Created**: 2025-12-04 | **Last Updated**: 2025-12-04


### PR DESCRIPTION
## Summary

Adds API documentation for Phase 5 endpoints that was missing from PR #92.

## Changes

### API Documentation (3 files)
- `docs/api/provider-connection.md` - Provider OAuth flow and connection management (7 endpoints)
- `docs/api/account-operations.md` - Account listing, sync, retrieval (4 endpoints)  
- `docs/api/transaction-operations.md` - Transaction retrieval and sync (3 endpoints)

### Documentation Features
- Environment-agnostic URLs using `{BASE_URL}` placeholder
- Curl examples for all endpoints
- Request/response JSON examples
- RFC 7807 error response format
- Mermaid diagrams for OAuth and sync flows
- Reference tables for types, subtypes, and statuses

## Checklist

- [x] Markdown linting passes (0 errors)
- [x] Follows existing `docs/api/authentication.md` format
- [x] All endpoints documented with examples
- [x] Phase 5 audit report created

## Related

- Completes documentation requirements for F5.1, F5.2, F5.3
- Phase 5 Audit: `~/references/audit/phase-5-audit-2025-12-04.md`