### PR TITLE
refactor(providers): auth-agnostic provider protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2025-12-26
+
+### Changed
+
+- **Auth-Agnostic Provider Protocol Refactor** (Hotfix)
+  - Refactored `ProviderProtocol` to be auth-agnostic: `fetch_*` methods now accept `credentials: dict[str, Any]` instead of `access_token: str`
+  - Added `OAuthProviderProtocol` extending base protocol with OAuth-specific methods (`exchange_code_for_tokens`, `refresh_access_token`)
+  - Added `is_oauth_provider()` TypeGuard function for runtime capability checking with type narrowing
+  - Updated `SchwabProvider` to extract `access_token` internally from credentials dict
+  - Updated sync handlers (`SyncAccountsHandler`, `SyncTransactionsHandler`, `SyncHoldingsHandler`) to pass full credentials dict
+  - Updated OAuth callbacks and token refresh endpoints to use `get_provider()` + `is_oauth_provider()` pattern
+  - Replaced `get_oauth_provider()` export with `is_oauth_provider()` in container
+  - This change enables future providers with different auth mechanisms (API Key, Certificate, etc.) to use the same interface
+
+### Documentation
+
+- Updated `docs/architecture/provider-integration-architecture.md` with auth-agnostic design:
+  - New Decision 1: Auth-Agnostic Provider Protocol (base + OAuth extension)
+  - New Decision 2: Factory with Capability Checking (TypeGuard pattern)
+  - Updated code examples showing credentials dict pattern
+  - Added usage patterns for sync handlers vs OAuth callbacks
+
 ## [1.2.0] - 2025-12-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dashtam"
-version = "1.2.0"
+version = "1.2.1"
 description = "A secure financial data aggregation platform built with hexagonal architecture, CQRS, and domain-driven design"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/application/commands/handlers/sync_accounts_handler.py
+++ b/src/application/commands/handlers/sync_accounts_handler.py
@@ -159,13 +159,10 @@ class SyncAccountsHandler:
             return Failure(error=SyncAccountsError.CREDENTIALS_DECRYPTION_FAILED)
 
         credentials_data = decrypt_result.value
-        access_token = credentials_data.get("access_token")
 
-        if not access_token:
-            return Failure(error=SyncAccountsError.CREDENTIALS_INVALID)
-
-        # 6. Fetch accounts from provider
-        fetch_result = await self._provider.fetch_accounts(access_token)
+        # 6. Fetch accounts from provider (pass full credentials dict)
+        # Provider extracts what it needs (access_token for OAuth, api_key for API Key, etc.)
+        fetch_result = await self._provider.fetch_accounts(credentials_data)
 
         if isinstance(fetch_result, Failure):
             return Failure(

--- a/src/application/commands/handlers/sync_holdings_handler.py
+++ b/src/application/commands/handlers/sync_holdings_handler.py
@@ -175,14 +175,11 @@ class SyncHoldingsHandler:
             return Failure(error=SyncHoldingsError.CREDENTIALS_DECRYPTION_FAILED)
 
         credentials_data = decrypt_result.value
-        access_token = credentials_data.get("access_token")
 
-        if not access_token:
-            return Failure(error=SyncHoldingsError.CREDENTIALS_INVALID)
-
-        # 7. Fetch holdings from provider
+        # 7. Fetch holdings from provider (pass full credentials dict)
+        # Provider extracts what it needs (access_token for OAuth, api_key for API Key, etc.)
         fetch_result = await self._provider.fetch_holdings(
-            access_token=access_token,
+            credentials=credentials_data,
             provider_account_id=account.provider_account_id,
         )
 

--- a/src/application/commands/handlers/sync_transactions_handler.py
+++ b/src/application/commands/handlers/sync_transactions_handler.py
@@ -169,10 +169,6 @@ class SyncTransactionsHandler:
             return Failure(error=SyncTransactionsError.CREDENTIALS_DECRYPTION_FAILED)
 
         credentials_data = decrypt_result.value
-        access_token = credentials_data.get("access_token")
-
-        if not access_token:
-            return Failure(error=SyncTransactionsError.CREDENTIALS_INVALID)
 
         # 5. Get accounts to sync
         if command.account_id:
@@ -207,9 +203,10 @@ class SyncTransactionsHandler:
         accounts_synced = 0
 
         for account in accounts:
-            # Fetch transactions from provider
+            # Fetch transactions from provider (pass full credentials dict)
+            # Provider extracts what it needs (access_token for OAuth, api_key for API Key, etc.)
             fetch_result = await self._provider.fetch_transactions(
-                access_token=access_token,
+                credentials=credentials_data,
                 provider_account_id=account.provider_account_id,
                 start_date=start_date,
                 end_date=end_date,

--- a/src/core/container/__init__.py
+++ b/src/core/container/__init__.py
@@ -93,7 +93,7 @@ from src.core.container.data_handlers import (
 )
 
 # Provider factory
-from src.core.container.providers import get_provider
+from src.core.container.providers import get_provider, is_oauth_provider
 
 # Authorization (Casbin RBAC)
 from src.core.container.authorization import (
@@ -161,6 +161,7 @@ __all__ = [
     "get_sync_transactions_handler",
     # Providers
     "get_provider",
+    "is_oauth_provider",
     # Authorization
     "init_enforcer",
     "get_enforcer",

--- a/src/core/container/providers.py
+++ b/src/core/container/providers.py
@@ -1,19 +1,40 @@
 """Provider dependency factory.
 
 Factory for creating financial provider adapters based on slug.
-Currently supports Charles Schwab; extensible for future providers.
+Single factory (get_provider) with capability checking (is_oauth_provider).
+
+Usage:
+    - get_provider(): Returns any provider by slug (auth-agnostic)
+    - is_oauth_provider(): TypeGuard for OAuth capability checking
+
+Pattern:
+    # For sync handlers (all providers)
+    provider = get_provider("schwab")
+    result = await provider.fetch_accounts(credentials)
+
+    # For OAuth callbacks (OAuth providers only)
+    provider = get_provider("schwab")
+    if is_oauth_provider(provider):
+        tokens = await provider.exchange_code_for_tokens(code)
 
 Reference:
     See docs/architecture/provider-integration-architecture.md for complete
     provider patterns and integration details.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeGuard
 
 from src.core.config import settings
 
 if TYPE_CHECKING:
-    from src.domain.protocols.provider_protocol import ProviderProtocol
+    from src.domain.protocols.provider_protocol import (
+        OAuthProviderProtocol,
+        ProviderProtocol,
+    )
+
+
+# OAuth providers - these support exchange_code_for_tokens and refresh_access_token
+OAUTH_PROVIDERS = {"schwab"}
 
 
 # ============================================================================
@@ -27,15 +48,18 @@ def get_provider(slug: str) -> "ProviderProtocol":
     Factory function that returns the correct provider implementation
     based on the provider slug. Follows Composition Root pattern.
 
+    This returns providers typed as ProviderProtocol (auth-agnostic).
+    For OAuth-specific operations, use get_oauth_provider() instead.
+
     Currently supported providers:
         - 'schwab': Charles Schwab (OAuth, Trader API)
 
     Future providers (not yet implemented):
+        - 'alpaca': Alpaca (API Key, Trading API)
         - 'chase': Chase Bank (OAuth)
-        - 'yodlee': Yodlee (aggregator)
 
     Args:
-        slug: Provider identifier (e.g., 'schwab', 'chase').
+        slug: Provider identifier (e.g., 'schwab', 'alpaca').
 
     Returns:
         Provider adapter implementing ProviderProtocol.
@@ -44,13 +68,10 @@ def get_provider(slug: str) -> "ProviderProtocol":
         ValueError: If provider slug is unknown or provider not configured.
 
     Usage:
-        # Application Layer (command handlers)
+        # Application Layer (sync handlers - auth-agnostic)
         from src.core.container import get_provider
         provider = get_provider("schwab")
-        result = await provider.exchange_code_for_tokens(auth_code)
-
-        # Presentation Layer (FastAPI Depends)
-        # Use a dependency that calls this factory with the slug parameter
+        result = await provider.fetch_accounts(credentials)
 
     Reference:
         - docs/architecture/provider-integration-architecture.md
@@ -69,9 +90,51 @@ def get_provider(slug: str) -> "ProviderProtocol":
             return SchwabProvider(settings=settings)
 
         # Future providers:
-        # case "chase":
-        #     from src.infrastructure.providers.chase import ChaseProvider
-        #     return ChaseProvider(settings=settings)
+        # case "alpaca":
+        #     from src.infrastructure.providers.alpaca import AlpacaProvider
+        #     return AlpacaProvider(settings=settings)
 
         case _:
             raise ValueError(f"Unknown provider: {slug}. Supported: 'schwab'")
+
+
+def is_oauth_provider(
+    provider: "ProviderProtocol",
+) -> TypeGuard["OAuthProviderProtocol"]:
+    """Check if provider supports OAuth authentication.
+
+    TypeGuard function that performs runtime check and narrows type.
+    After this returns True, the provider is typed as OAuthProviderProtocol.
+
+    Use this to check provider capabilities before calling OAuth methods:
+        - exchange_code_for_tokens()
+        - refresh_access_token()
+
+    Args:
+        provider: Any provider instance.
+
+    Returns:
+        True if provider supports OAuth (has exchange_code_for_tokens method).
+        Type is narrowed to OAuthProviderProtocol when True.
+
+    Usage:
+        # In OAuth callback handler:
+        provider = get_provider(slug)
+        if is_oauth_provider(provider):
+            # Type is now OAuthProviderProtocol
+            tokens = await provider.exchange_code_for_tokens(code)
+        else:
+            raise ValueError(f"Provider {slug} doesn't support OAuth")
+
+        # In token refresh handler:
+        provider = get_provider(connection.provider_slug)
+        if is_oauth_provider(provider):
+            result = await provider.refresh_access_token(refresh_token)
+        else:
+            # API Key providers don't need token refresh
+            return Success("No refresh needed")
+
+    Reference:
+        - docs/architecture/provider-integration-architecture.md
+    """
+    return provider.slug in OAUTH_PROVIDERS

--- a/src/domain/protocols/__init__.py
+++ b/src/domain/protocols/__init__.py
@@ -59,6 +59,7 @@ from src.domain.protocols.provider_connection_repository import (
 )
 from src.domain.protocols.provider_repository import ProviderRepository
 from src.domain.protocols.provider_protocol import (
+    OAuthProviderProtocol,
     OAuthTokens,
     ProviderAccountData,
     ProviderHoldingData,
@@ -103,6 +104,7 @@ __all__ = [
     # Rate Limit protocol
     "RateLimitProtocol",
     # Provider protocols and data types
+    "OAuthProviderProtocol",
     "OAuthTokens",
     "ProviderAccountData",
     "ProviderConnectionRepository",

--- a/src/infrastructure/providers/schwab/schwab_provider.py
+++ b/src/infrastructure/providers/schwab/schwab_provider.py
@@ -28,6 +28,7 @@ Reference:
 import base64
 import json
 from datetime import date
+from typing import Any
 from uuid import UUID
 
 import httpx
@@ -435,7 +436,7 @@ class SchwabProvider:
 
     async def fetch_accounts(
         self,
-        access_token: str,
+        credentials: dict[str, Any],
         user_id: UUID | None = None,
     ) -> Result[list[ProviderAccountData], ProviderError]:
         """Fetch all accounts for the authenticated user.
@@ -444,14 +445,30 @@ class SchwabProvider:
         Delegates to SchwabAccountsAPI for HTTP and SchwabAccountMapper for mapping.
 
         Args:
-            access_token: Valid Schwab access token.
+            credentials: Decrypted credentials dict containing 'access_token'.
             user_id: Optional user ID for caching (required for cache).
 
         Returns:
             Success(list[ProviderAccountData]): Account data from Schwab.
-            Failure(ProviderAuthenticationError): If token is invalid/expired.
+            Failure(ProviderAuthenticationError): If credentials are invalid/expired.
             Failure(ProviderUnavailableError): If Schwab API is unreachable.
         """
+        # Extract access_token from credentials (Schwab uses OAuth)
+        access_token = credentials.get("access_token")
+        if not access_token:
+            logger.warning(
+                "schwab_fetch_accounts_missing_access_token",
+                provider=self.slug,
+            )
+            return Failure(
+                error=ProviderAuthenticationError(
+                    code=ErrorCode.PROVIDER_AUTHENTICATION_FAILED,
+                    message="Missing access_token in credentials",
+                    provider_name=self.slug,
+                    is_token_expired=False,
+                )
+            )
+
         logger.info(
             "schwab_fetch_accounts_started",
             provider=self.slug,
@@ -530,7 +547,7 @@ class SchwabProvider:
 
     async def fetch_transactions(
         self,
-        access_token: str,
+        credentials: dict[str, Any],
         provider_account_id: str,
         start_date: date | None = None,
         end_date: date | None = None,
@@ -540,16 +557,32 @@ class SchwabProvider:
         Delegates to SchwabTransactionsAPI for HTTP and SchwabTransactionMapper for mapping.
 
         Args:
-            access_token: Valid Schwab access token.
+            credentials: Decrypted credentials dict containing 'access_token'.
             provider_account_id: Schwab account number.
             start_date: Beginning of date range (default: 30 days ago).
             end_date: End of date range (default: today).
 
         Returns:
             Success(list[ProviderTransactionData]): Transaction data from Schwab.
-            Failure(ProviderAuthenticationError): If token is invalid/expired.
+            Failure(ProviderAuthenticationError): If credentials are invalid/expired.
             Failure(ProviderUnavailableError): If Schwab API is unreachable.
         """
+        # Extract access_token from credentials (Schwab uses OAuth)
+        access_token = credentials.get("access_token")
+        if not access_token:
+            logger.warning(
+                "schwab_fetch_transactions_missing_access_token",
+                provider=self.slug,
+            )
+            return Failure(
+                error=ProviderAuthenticationError(
+                    code=ErrorCode.PROVIDER_AUTHENTICATION_FAILED,
+                    message="Missing access_token in credentials",
+                    provider_name=self.slug,
+                    is_token_expired=False,
+                )
+            )
+
         logger.info(
             "schwab_fetch_transactions_started",
             provider=self.slug,
@@ -587,7 +620,7 @@ class SchwabProvider:
 
     async def fetch_holdings(
         self,
-        access_token: str,
+        credentials: dict[str, Any],
         provider_account_id: str,
     ) -> Result[list[ProviderHoldingData], ProviderError]:
         """Fetch holdings (positions) for a specific account.
@@ -596,14 +629,30 @@ class SchwabProvider:
         then uses SchwabHoldingMapper to convert.
 
         Args:
-            access_token: Valid Schwab access token.
+            credentials: Decrypted credentials dict containing 'access_token'.
             provider_account_id: Schwab account number (hash value).
 
         Returns:
             Success(list[ProviderHoldingData]): Holding data from Schwab.
-            Failure(ProviderAuthenticationError): If token is invalid/expired.
+            Failure(ProviderAuthenticationError): If credentials are invalid/expired.
             Failure(ProviderUnavailableError): If Schwab API is unreachable.
         """
+        # Extract access_token from credentials (Schwab uses OAuth)
+        access_token = credentials.get("access_token")
+        if not access_token:
+            logger.warning(
+                "schwab_fetch_holdings_missing_access_token",
+                provider=self.slug,
+            )
+            return Failure(
+                error=ProviderAuthenticationError(
+                    code=ErrorCode.PROVIDER_AUTHENTICATION_FAILED,
+                    message="Missing access_token in credentials",
+                    provider_name=self.slug,
+                    is_token_expired=False,
+                )
+            )
+
         logger.info(
             "schwab_fetch_holdings_started",
             provider=self.slug,

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "dashtam"
-version = "1.2.0"
+version = "1.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Refactors `ProviderProtocol` to be auth-agnostic, enabling support for providers with different authentication mechanisms (OAuth, API Key, Certificate, etc.).

## Changes

### Protocol Refactor
- **`ProviderProtocol`** (base) - Now auth-agnostic:
  - `fetch_accounts(credentials: dict[str, Any])` 
  - `fetch_transactions(credentials: dict[str, Any], ...)`
  - `fetch_holdings(credentials: dict[str, Any], ...)`

- **`OAuthProviderProtocol`** (extends base) - OAuth-specific methods:
  - `exchange_code_for_tokens(authorization_code: str)`
  - `refresh_access_token(refresh_token: str)`

- **`is_oauth_provider(provider) -> TypeGuard[OAuthProviderProtocol]`** - Runtime capability checking with type narrowing

### Usage Pattern
```python
# Sync handlers (ALL providers - auth-agnostic)
provider = get_provider(connection.provider_slug)
result = await provider.fetch_accounts(credentials)  # Works for OAuth AND API Key

# OAuth callbacks (OAuth providers only)
provider = get_provider("schwab")
if is_oauth_provider(provider):
    tokens = await provider.exchange_code_for_tokens(code)
```

### Files Changed
- `src/domain/protocols/provider_protocol.py` - Refactored protocol, added `OAuthProviderProtocol`
- `src/infrastructure/providers/schwab/schwab_provider.py` - Updated `fetch_*` methods
- `src/application/commands/handlers/sync_*.py` - Pass credentials dict
- `src/core/container/providers.py` - Added `is_oauth_provider()` TypeGuard
- `src/presentation/routers/oauth_callbacks.py` - Use new pattern
- `src/presentation/routers/api/v1/providers.py` - Use new pattern
- `docs/architecture/provider-integration-architecture.md` - Updated documentation

## Verification
- ✅ 1978 tests passing
- ✅ 87% coverage
- ✅ Lint passes
- ✅ Format passes  
- ✅ Type-check passes
- ✅ Docs build passes

## Version
Bumped to v1.2.1 (PATCH - internal refactor, no public API changes)

Co-Authored-By: Warp <agent@warp.dev>