### PR TITLE
feat(providers): add Alpaca provider integration (F7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-12-26
+
+### Added
+
+- **F7.1**: Alpaca Provider Integration
+  - Implemented `AlpacaProvider` adapter with auth-agnostic `ProviderProtocol` (first API Key provider)
+  - Added `AlpacaAccountsAPI` client for account and positions endpoints
+  - Added `AlpacaTransactionsAPI` client for activities endpoint
+  - Added mappers: `AlpacaAccountMapper`, `AlpacaHoldingMapper`, `AlpacaTransactionMapper`
+  - **Authentication**: API Key headers (`APCA-API-KEY-ID`, `APCA-API-SECRET-KEY`) - no OAuth flow
+  - **Environment Support**: Paper (`paper-api.alpaca.markets`) and Live (`api.alpaca.markets`)
+  - **Features**: Account sync, holdings/positions sync, transaction/activities sync
+  - **Credential Structure**: `{"api_key": "...", "api_secret": "..."}`
+  - Added 101 tests with 100% coverage on all Alpaca provider code
+  - Added database seed for Alpaca provider with `credential_type: api_key`
+  - Added container factory registration for Alpaca provider
+
+### Documentation
+
+- Added "Phase 3b: API-Key Provider Implementation" section to `adding-new-providers.md`
+  - Key differences table comparing OAuth vs API-Key providers
+  - Complete Alpaca provider example with code snippets
+  - API client authentication pattern with custom headers
+  - Container registration pattern for API-Key providers
+  - Database seed configuration for non-OAuth credential types
+
+### Changed
+
+- Total test count increased from 1,978 to 2,079 tests (+101)
+- Overall coverage maintained at 87%+
+
 ## [1.2.1] - 2025-12-26
 
 ### Changed

--- a/WARP.md
+++ b/WARP.md
@@ -40,7 +40,7 @@
 - **Test-driven**: 85%+ coverage target, all tests pass before merge
 - **Documentation-first**: Architecture decisions documented before coding
 
-**v1.2.0 Released**: 2025-12-26 | **Phases 0-7 Complete** (45 features) | **GitHub**: <https://github.com/faiyaz7283/Dashtam/releases/tag/v1.2.0>
+**v1.3.0 Released**: 2025-12-26 | **Phases 0-7 Complete** (46 features) | **GitHub**: <https://github.com/faiyaz7283/Dashtam/releases/tag/v1.3.0>
 
 ---
 
@@ -294,12 +294,13 @@
 - ✅ **Quality**: Zero lint violations, strict type checking, all tests passing
 - ✅ **Release**: v1.1.0 (minor version bump for new feature)
 
-#### Phase 7: Provider Capabilities & Data Models ✅ COMPLETED (2/2 features)
+#### Phase 7: Provider Capabilities & Data Models ✅ COMPLETED (3/3 features)
 
-**Release**: 2025-12-26 | **Tag**: v1.2.0 | **Tests**: 1,978 passed, 19 skipped | **Coverage**: 87%
+**Release**: 2025-12-26 | **Tag**: v1.3.0 | **Tests**: 2,079 passed, 19 skipped | **Coverage**: 87%
 
 | Feature | Description |
 |---------|-------------|
+| F7.1 | Alpaca Provider Integration (API Key auth) |
 | F7.4 | Provider-Specific Entities (Holdings Support) |
 | F7.5 | Balance Tracking |
 
@@ -320,6 +321,18 @@
 - ✅ Provider capability flags (HAS_HOLDINGS, HAS_BALANCE_HISTORY)
 - ✅ 232 new tests added (1,746 → 1,978)
 - ✅ Coverage increased to 87%
+- ✅ **F7.1**: Alpaca provider (first API Key provider) with 101 tests, 100% coverage
+
+**F7.1 Alpaca Provider Summary** (completed 2025-12-26):
+
+- ✅ **Provider**: AlpacaProvider implementing auth-agnostic ProviderProtocol
+- ✅ **API Clients**: AlpacaAccountsAPI (account + positions), AlpacaTransactionsAPI (activities)
+- ✅ **Mappers**: Account, Holding, Transaction mappers with comprehensive field mapping
+- ✅ **Authentication**: API Key headers (APCA-API-KEY-ID, APCA-API-SECRET-KEY)
+- ✅ **Environments**: Paper (sandbox) and Live support
+- ✅ **Tests**: 101 tests with 100% coverage on all Alpaca provider code
+- ✅ **Documentation**: Added API-key provider section to adding-new-providers.md
+- ✅ **Total Tests**: 1,978 → 2,079 (+101 tests)
 
 **F7.4 Holdings Summary** (completed 2025-12-26):
 
@@ -1037,7 +1050,7 @@ git push origin development
 - **MINOR**: New features (backward compatible)
 - **PATCH**: Bug fixes, internal refactors (backward compatible)
 
-**Recommended Approach: Batch Patches, Tag on Release**
+##### Recommended Approach: Batch Patches, Tag on Release
 
 - **PATCH versions** accumulate in `development` without tags
 - **Tags created only when releasing to `main`**

--- a/alembic/seeds/provider_seeder.py
+++ b/alembic/seeds/provider_seeder.py
@@ -1,9 +1,9 @@
 """Provider seeder for default providers.
 
-Seeds default providers (Schwab) into the providers table.
+Seeds default providers (Schwab, Alpaca) into the providers table.
 Idempotent via slug uniqueness check - safe to run on every migration.
 
-Schwab is the initial provider Dashtam ships with. Future providers
+These are the built-in providers that ship with Dashtam. Future providers
 (Chase, Fidelity, etc.) can be added here or via admin APIs.
 
 Reference:
@@ -29,6 +29,16 @@ DEFAULT_PROVIDERS = [
         "description": "Connect your Charles Schwab brokerage account to sync "
         "accounts, positions, and transactions.",
         "website_url": "https://www.schwab.com",
+        "is_active": True,
+    },
+    {
+        "slug": "alpaca",
+        "name": "Alpaca",
+        "category": "brokerage",
+        "credential_type": "api_key",
+        "description": "Connect your Alpaca brokerage account to sync "
+        "accounts, positions, and transactions. Supports both paper and live trading.",
+        "website_url": "https://alpaca.markets",
         "is_active": True,
     },
     # Future providers can be added here:

--- a/env/.env.ci.example
+++ b/env/.env.ci.example
@@ -66,12 +66,17 @@ PYTHONUNBUFFERED=1
 SCHWAB_API_KEY=mock_schwab_client_id
 SCHWAB_API_SECRET=mock_schwab_client_secret
 SCHWAB_API_BASE_URL=http://mock/schwab
-SCHWAB_REDIRECT_URI=http://mock/callback
+SCHWAB_REDIRECT_URI=http://mock/oauth/schwab/callback
+
+# Alpaca Configuration (mocked)
+ALPACA_CLIENT_ID=mock_alpaca_client_id
+ALPACA_CLIENT_SECRET=mock_alpaca_client_secret
+ALPACA_REDIRECT_URI=http://mock/oauth/alpaca/callback
 
 # Chase Configuration (mocked)
 CHASE_API_KEY=mock_chase_api_key
 CHASE_API_SECRET=mock_chase_api_secret
-CHASE_REDIRECT_URI=http://mock/callback
+CHASE_REDIRECT_URI=http://mock/oauth/chase/callback
 
 # Optional: Code coverage reporting
 # Set this in your CI secrets if using Codecov

--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -74,10 +74,22 @@ DB_ECHO=false
 
 # Schwab OAuth Configuration
 # Get these from https://developer.schwab.com/
+# Register these callback URLs in Schwab Developer Portal:
+#   - https://127.0.0.1:8182/oauth/schwab/callback (standalone)
+#   - https://dashtam.local/oauth/schwab/callback (via Traefik)
 # SCHWAB_API_KEY=your_client_id_here
 # SCHWAB_API_SECRET=your_client_secret_here
 SCHWAB_API_BASE_URL=https://api.schwabapi.com
-SCHWAB_REDIRECT_URI=https://127.0.0.1:8182
+SCHWAB_REDIRECT_URI=https://dashtam.local/oauth/schwab/callback
+
+# Alpaca OAuth Configuration
+# Get these from https://app.alpaca.markets (OAuth Apps section)
+# Register these callback URLs in Alpaca Dashboard:
+#   - https://127.0.0.1:8182/oauth/alpaca/callback (standalone)
+#   - https://dashtam.local/oauth/alpaca/callback (via Traefik)
+# ALPACA_CLIENT_ID=your_alpaca_client_id
+# ALPACA_CLIENT_SECRET=your_alpaca_client_secret
+ALPACA_REDIRECT_URI=https://dashtam.local/oauth/alpaca/callback
 
 # Chase Configuration (Future)
 # CHASE_API_KEY=your_chase_api_key

--- a/env/.env.test.example
+++ b/env/.env.test.example
@@ -53,12 +53,17 @@ API_CALLBACK_SSL_KEY_FILE=certs/callback_key.pem
 SCHWAB_API_KEY=test_schwab_client_id
 SCHWAB_API_SECRET=test_schwab_client_secret
 SCHWAB_API_BASE_URL=http://localhost:8999/mock/schwab
-SCHWAB_REDIRECT_URI=https://localhost:8183/callback
+SCHWAB_REDIRECT_URI=https://test.dashtam.local/oauth/schwab/callback
+
+# Alpaca Configuration (mocked)
+ALPACA_CLIENT_ID=test_alpaca_client_id
+ALPACA_CLIENT_SECRET=test_alpaca_client_secret
+ALPACA_REDIRECT_URI=https://test.dashtam.local/oauth/alpaca/callback
 
 # Chase Configuration (mocked)
 CHASE_API_KEY=test_chase_api_key
 CHASE_API_SECRET=test_chase_api_secret
-CHASE_REDIRECT_URI=https://localhost:8183/callback
+CHASE_REDIRECT_URI=https://test.dashtam.local/oauth/chase/callback
 
 # Redis Configuration
 # Use Docker internal hostname 'redis' not 'localhost'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dashtam"
-version = "1.2.1"
+version = "1.3.0"
 description = "A secure financial data aggregation platform built with hexagonal architecture, CQRS, and domain-driven design"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -227,6 +227,20 @@ class Settings(BaseSettings):
         description="OAuth redirect URI for Schwab callback",
     )
 
+    # Provider: Alpaca Configuration
+    alpaca_client_id: str | None = Field(
+        default=None,
+        description="Alpaca OAuth client ID",
+    )
+    alpaca_client_secret: str | None = Field(
+        default=None,
+        description="Alpaca OAuth client secret",
+    )
+    alpaca_redirect_uri: str | None = Field(
+        default=None,
+        description="OAuth redirect URI for Alpaca callback",
+    )
+
     model_config = SettingsConfigDict(
         # env_file handled by Docker compose (not coupled to specific environment)
         env_file_encoding="utf-8",

--- a/src/infrastructure/providers/alpaca/__init__.py
+++ b/src/infrastructure/providers/alpaca/__init__.py
@@ -1,0 +1,34 @@
+"""Alpaca provider package.
+
+Provides integration with Alpaca Trading API for accounts, holdings, and transactions.
+Uses API Key authentication (APCA-API-KEY-ID, APCA-API-SECRET-KEY headers).
+
+Key Differences from OAuth Providers:
+    - API Key authentication (not OAuth Bearer tokens)
+    - No token exchange or refresh needed
+    - Credentials are passed directly to API methods
+    - Single account per API key
+
+Reference:
+    - https://docs.alpaca.markets/docs/trading-api
+"""
+
+from src.infrastructure.providers.alpaca.alpaca_provider import AlpacaProvider
+from src.infrastructure.providers.alpaca.api import (
+    AlpacaAccountsAPI,
+    AlpacaTransactionsAPI,
+)
+from src.infrastructure.providers.alpaca.mappers import (
+    AlpacaAccountMapper,
+    AlpacaHoldingMapper,
+    AlpacaTransactionMapper,
+)
+
+__all__ = [
+    "AlpacaProvider",
+    "AlpacaAccountsAPI",
+    "AlpacaTransactionsAPI",
+    "AlpacaAccountMapper",
+    "AlpacaHoldingMapper",
+    "AlpacaTransactionMapper",
+]

--- a/src/infrastructure/providers/alpaca/alpaca_provider.py
+++ b/src/infrastructure/providers/alpaca/alpaca_provider.py
@@ -1,0 +1,363 @@
+"""Alpaca provider implementing ProviderProtocol.
+
+Handles API Key authentication and Trading API calls for accounts/transactions/holdings.
+
+Configuration loaded from settings (src/core/config.py):
+    - alpaca_client_id: API Key ID (APCA-API-KEY-ID)
+    - alpaca_client_secret: API Secret Key (APCA-API-SECRET-KEY)
+    - alpaca_api_base_url: API base URL (paper or live)
+
+Alpaca API Documentation:
+    - Trading API: https://docs.alpaca.markets/docs/trading-api
+    - Authentication: https://docs.alpaca.markets/docs/using-oauth2-and-trading-api
+
+Architecture:
+    AlpacaProvider orchestrates:
+    - api/accounts_api.py: HTTP client for account and positions endpoints
+    - api/transactions_api.py: HTTP client for activities endpoint
+    - mappers/account_mapper.py: JSON → ProviderAccountData
+    - mappers/holding_mapper.py: JSON → ProviderHoldingData
+    - mappers/transaction_mapper.py: JSON → ProviderTransactionData
+
+Authentication Difference from Schwab:
+    - Schwab: OAuth 2.0 with token exchange/refresh
+    - Alpaca: API Key authentication (persistent credentials)
+
+    For Alpaca, credentials are stored encrypted in provider_connections.credentials
+    and used directly for API calls (no token refresh needed).
+
+Reference:
+    - docs/architecture/provider-integration-architecture.md
+"""
+
+from datetime import date
+from typing import Any
+
+import structlog
+
+from src.core.config import Settings
+from src.core.result import Failure, Result, Success
+from src.domain.errors import ProviderError
+from src.domain.protocols.cache_protocol import CacheProtocol
+from src.domain.protocols.provider_protocol import (
+    ProviderAccountData,
+    ProviderHoldingData,
+    ProviderTransactionData,
+)
+from src.infrastructure.cache.cache_keys import CacheKeys
+from src.infrastructure.cache.cache_metrics import CacheMetrics
+from src.infrastructure.providers.alpaca.api.accounts_api import AlpacaAccountsAPI
+from src.infrastructure.providers.alpaca.api.transactions_api import (
+    AlpacaTransactionsAPI,
+)
+from src.infrastructure.providers.alpaca.mappers.account_mapper import (
+    AlpacaAccountMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.holding_mapper import (
+    AlpacaHoldingMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.transaction_mapper import (
+    AlpacaTransactionMapper,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class AlpacaProvider:
+    """Alpaca provider adapter implementing ProviderProtocol.
+
+    Handles API Key authentication and Trading API integration for Alpaca.
+    Configuration is loaded from application settings.
+
+    Key Differences from OAuth Providers (Schwab):
+    - Uses API Key authentication (not OAuth Bearer tokens)
+    - No token exchange or refresh needed
+    - Credentials (api_key, api_secret) are passed to each API call
+    - Single account per API key (not multiple accounts)
+
+    Attributes:
+        settings: Application settings containing Alpaca credentials.
+        timeout: HTTP request timeout in seconds.
+
+    Example:
+        >>> from src.core.config import settings
+        >>> provider = AlpacaProvider(settings=settings)
+        >>> credentials = {"api_key": "PKXXXX", "api_secret": "secret123"}
+        >>> result = await provider.fetch_accounts(credentials)
+        >>> match result:
+        ...     case Success(accounts):
+        ...         print(f"Found {len(accounts)} account(s)")
+        ...     case Failure(error):
+        ...         print(f"Failed: {error.message}")
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        cache: CacheProtocol | None = None,
+        cache_keys: CacheKeys | None = None,
+        cache_metrics: CacheMetrics | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize Alpaca provider.
+
+        Args:
+            settings: Application settings with Alpaca configuration.
+            cache: Optional cache for API response caching.
+            cache_keys: Optional cache key utility.
+            cache_metrics: Optional metrics tracker.
+            timeout: HTTP request timeout in seconds.
+        """
+        self._settings = settings
+        self._timeout = timeout
+        self._cache = cache
+        self._cache_keys = cache_keys
+        self._cache_metrics = cache_metrics
+
+        # Get base URL from settings (defaults to paper trading)
+        self._base_url = getattr(
+            settings,
+            "alpaca_api_base_url",
+            "https://paper-api.alpaca.markets",
+        )
+
+        # Initialize API clients and mappers
+        self._accounts_api = AlpacaAccountsAPI(
+            base_url=self._base_url,
+            timeout=timeout,
+        )
+        self._transactions_api = AlpacaTransactionsAPI(
+            base_url=self._base_url,
+            timeout=timeout,
+        )
+        self._account_mapper = AlpacaAccountMapper()
+        self._holding_mapper = AlpacaHoldingMapper()
+        self._transaction_mapper = AlpacaTransactionMapper()
+
+    @property
+    def slug(self) -> str:
+        """Return provider slug identifier."""
+        return "alpaca"
+
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, Any],
+    ) -> Result[list[ProviderAccountData], ProviderError]:
+        """Fetch all accounts for the authenticated user.
+
+        Alpaca has a single account per API key, unlike Schwab which has
+        multiple accounts per user.
+
+        Args:
+            credentials: Decrypted credentials dict containing:
+                - api_key: Alpaca API Key ID
+                - api_secret: Alpaca API Secret Key
+
+        Returns:
+            Success(list[ProviderAccountData]): Single account wrapped in list.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        # Extract API credentials from dict
+        api_key = credentials.get("api_key", "")
+        api_secret = credentials.get("api_secret", "")
+
+        logger.info(
+            "alpaca_fetch_accounts_started",
+            provider=self.slug,
+        )
+
+        # Fetch account data from Alpaca API
+        result = await self._accounts_api.get_account(
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+
+        # Handle API errors
+        if isinstance(result, Failure):
+            return Failure(error=result.error)
+
+        raw_account = result.value
+
+        # Map raw JSON to ProviderAccountData
+        account = self._account_mapper.map_account(raw_account)
+        if account is None:
+            logger.warning(
+                "alpaca_fetch_accounts_mapping_failed",
+                provider=self.slug,
+            )
+            return Success(value=[])
+
+        logger.info(
+            "alpaca_fetch_accounts_succeeded",
+            provider=self.slug,
+            account_count=1,
+        )
+
+        return Success(value=[account])
+
+    async def fetch_transactions(
+        self,
+        credentials: dict[str, Any],
+        provider_account_id: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> Result[list[ProviderTransactionData], ProviderError]:
+        """Fetch transactions (activities) for the account.
+
+        Alpaca calls transactions "activities" in their API. This method
+        fetches all account activities and maps them to Dashtam transactions.
+
+        Note: provider_account_id is required by the protocol but not used by
+        Alpaca since each API key maps to a single account.
+
+        Args:
+            credentials: Decrypted credentials dict containing:
+                - api_key: Alpaca API Key ID
+                - api_secret: Alpaca API Secret Key
+            provider_account_id: Required by protocol but not used (single account).
+            start_date: Beginning of date range.
+            end_date: End of date range.
+
+        Returns:
+            Success(list[ProviderTransactionData]): Transaction data from Alpaca.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        # Extract API credentials from dict
+        api_key = credentials.get("api_key", "")
+        api_secret = credentials.get("api_secret", "")
+
+        logger.info(
+            "alpaca_fetch_transactions_started",
+            provider=self.slug,
+            start_date=str(start_date) if start_date else None,
+            end_date=str(end_date) if end_date else None,
+        )
+
+        # Fetch activities from Alpaca API
+        result = await self._transactions_api.get_transactions(
+            api_key=api_key,
+            api_secret=api_secret,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        # Handle API errors
+        if isinstance(result, Failure):
+            return Failure(error=result.error)
+
+        raw_activities = result.value
+
+        # Map raw JSON to ProviderTransactionData
+        transactions = self._transaction_mapper.map_transactions(raw_activities)
+
+        logger.info(
+            "alpaca_fetch_transactions_succeeded",
+            provider=self.slug,
+            transaction_count=len(transactions),
+        )
+
+        return Success(value=transactions)
+
+    async def fetch_holdings(
+        self,
+        credentials: dict[str, Any],
+        provider_account_id: str,
+    ) -> Result[list[ProviderHoldingData], ProviderError]:
+        """Fetch holdings (positions) for the account.
+
+        Note: provider_account_id is required by the protocol but not used by
+        Alpaca since each API key maps to a single account.
+
+        Args:
+            credentials: Decrypted credentials dict containing:
+                - api_key: Alpaca API Key ID
+                - api_secret: Alpaca API Secret Key
+            provider_account_id: Required by protocol but not used (single account).
+
+        Returns:
+            Success(list[ProviderHoldingData]): Holding data from Alpaca.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        # Extract API credentials from dict
+        api_key = credentials.get("api_key", "")
+        api_secret = credentials.get("api_secret", "")
+
+        logger.info(
+            "alpaca_fetch_holdings_started",
+            provider=self.slug,
+        )
+
+        # Fetch positions from Alpaca API
+        result = await self._accounts_api.get_positions(
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+
+        # Handle API errors
+        if isinstance(result, Failure):
+            return Failure(error=result.error)
+
+        raw_positions = result.value
+
+        # Map raw JSON to ProviderHoldingData
+        holdings = self._holding_mapper.map_holdings(raw_positions)
+
+        logger.info(
+            "alpaca_fetch_holdings_succeeded",
+            provider=self.slug,
+            holding_count=len(holdings),
+        )
+
+        return Success(value=holdings)
+
+    async def validate_credentials(
+        self,
+        credentials: dict[str, Any],
+    ) -> Result[bool, ProviderError]:
+        """Validate API credentials by making a test API call.
+
+        Useful for verifying credentials during provider connection setup.
+
+        Args:
+            credentials: Decrypted credentials dict containing:
+                - api_key: Alpaca API Key ID
+                - api_secret: Alpaca API Secret Key
+
+        Returns:
+            Success(True): If credentials are valid.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        # Extract API credentials from dict
+        api_key = credentials.get("api_key", "")
+        api_secret = credentials.get("api_secret", "")
+
+        logger.info(
+            "alpaca_validate_credentials_started",
+            provider=self.slug,
+        )
+
+        # Use get_account as a lightweight validation call
+        result = await self._accounts_api.get_account(
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+
+        if isinstance(result, Failure):
+            logger.warning(
+                "alpaca_validate_credentials_failed",
+                provider=self.slug,
+                error=result.error.message,
+            )
+            return Failure(error=result.error)
+
+        logger.info(
+            "alpaca_validate_credentials_succeeded",
+            provider=self.slug,
+        )
+
+        return Success(value=True)

--- a/src/infrastructure/providers/alpaca/api/__init__.py
+++ b/src/infrastructure/providers/alpaca/api/__init__.py
@@ -1,0 +1,18 @@
+"""Alpaca API clients package.
+
+HTTP clients for Alpaca Trading API endpoints.
+Uses API Key authentication (APCA-API-KEY-ID, APCA-API-SECRET-KEY headers).
+
+Reference:
+    - https://docs.alpaca.markets/docs/trading-api
+"""
+
+from src.infrastructure.providers.alpaca.api.accounts_api import AlpacaAccountsAPI
+from src.infrastructure.providers.alpaca.api.transactions_api import (
+    AlpacaTransactionsAPI,
+)
+
+__all__ = [
+    "AlpacaAccountsAPI",
+    "AlpacaTransactionsAPI",
+]

--- a/src/infrastructure/providers/alpaca/api/accounts_api.py
+++ b/src/infrastructure/providers/alpaca/api/accounts_api.py
@@ -1,0 +1,370 @@
+"""Alpaca Accounts API client.
+
+HTTP client for Alpaca Trading API account and positions endpoints.
+Uses API Key authentication headers.
+
+Endpoints:
+    GET /v2/account - Get account information
+    GET /v2/positions - Get all open positions
+
+Reference:
+    - https://docs.alpaca.markets/docs/trading-api
+    - https://docs.alpaca.markets/reference/getaccount-1
+"""
+
+from typing import Any
+
+import httpx
+import structlog
+
+from src.core.enums import ErrorCode
+from src.core.result import Failure, Result, Success
+from src.domain.errors import (
+    ProviderAuthenticationError,
+    ProviderError,
+    ProviderInvalidResponseError,
+    ProviderRateLimitError,
+    ProviderUnavailableError,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class AlpacaAccountsAPI:
+    """HTTP client for Alpaca Trading API account and positions endpoints.
+
+    Uses API Key authentication (not OAuth Bearer tokens).
+    Returns raw JSON responses - mapping to domain types is done by mappers.
+
+    Attributes:
+        base_url: Alpaca Trading API base URL (paper or live).
+        timeout: HTTP request timeout in seconds.
+
+    Example:
+        >>> api = AlpacaAccountsAPI(
+        ...     base_url="https://paper-api.alpaca.markets",
+        ...     timeout=30.0,
+        ... )
+        >>> result = await api.get_account(api_key="...", api_secret="...")
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize Alpaca Accounts API client.
+
+        Args:
+            base_url: Alpaca Trading API base URL.
+            timeout: HTTP request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def get_account(
+        self,
+        api_key: str,
+        api_secret: str,
+    ) -> Result[dict[str, Any], ProviderError]:
+        """Fetch account information.
+
+        Args:
+            api_key: Alpaca API Key ID.
+            api_secret: Alpaca API Secret Key.
+
+        Returns:
+            Success(dict): Account JSON object from Alpaca.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        logger.debug("alpaca_accounts_api_get_account_started")
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.get(
+                    f"{self._base_url}/v2/account",
+                    headers=self._build_headers(api_key, api_secret),
+                )
+
+            return self._handle_response(response, "get_account")
+
+        except httpx.TimeoutException as e:
+            logger.warning(
+                "alpaca_accounts_api_timeout",
+                operation="get_account",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message="Alpaca API request timed out",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+        except httpx.RequestError as e:
+            logger.warning(
+                "alpaca_accounts_api_connection_error",
+                operation="get_account",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message=f"Failed to connect to Alpaca API: {e}",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+
+    async def get_positions(
+        self,
+        api_key: str,
+        api_secret: str,
+    ) -> Result[list[dict[str, Any]], ProviderError]:
+        """Fetch all open positions.
+
+        Args:
+            api_key: Alpaca API Key ID.
+            api_secret: Alpaca API Secret Key.
+
+        Returns:
+            Success(list[dict]): List of position JSON objects.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        logger.debug("alpaca_accounts_api_get_positions_started")
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.get(
+                    f"{self._base_url}/v2/positions",
+                    headers=self._build_headers(api_key, api_secret),
+                )
+
+            return self._handle_list_response(response, "get_positions")
+
+        except httpx.TimeoutException as e:
+            logger.warning(
+                "alpaca_accounts_api_timeout",
+                operation="get_positions",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message="Alpaca API request timed out",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+        except httpx.RequestError as e:
+            logger.warning(
+                "alpaca_accounts_api_connection_error",
+                operation="get_positions",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message=f"Failed to connect to Alpaca API: {e}",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+
+    def _build_headers(self, api_key: str, api_secret: str) -> dict[str, str]:
+        """Build HTTP headers for Alpaca API requests.
+
+        Args:
+            api_key: Alpaca API Key ID.
+            api_secret: Alpaca API Secret Key.
+
+        Returns:
+            Headers dict with API key authentication.
+        """
+        return {
+            "APCA-API-KEY-ID": api_key,
+            "APCA-API-SECRET-KEY": api_secret,
+            "Accept": "application/json",
+        }
+
+    def _handle_response(
+        self,
+        response: httpx.Response,
+        operation: str,
+    ) -> Result[dict[str, Any], ProviderError]:
+        """Handle Alpaca API response for single-object endpoints.
+
+        Args:
+            response: HTTP response from Alpaca.
+            operation: Operation name for logging.
+
+        Returns:
+            Success(dict) or Failure(ProviderError).
+        """
+        error_result = self._check_error_response(response, operation)
+        if error_result is not None:
+            return error_result
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            logger.error(
+                f"alpaca_accounts_api_{operation}_invalid_json",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderInvalidResponseError(
+                    code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                    message="Invalid JSON response from Alpaca",
+                    provider_name="alpaca",
+                    response_body=response.text[:500],
+                )
+            )
+
+        if not isinstance(data, dict):
+            return Failure(
+                error=ProviderInvalidResponseError(
+                    code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                    message="Expected object response from Alpaca",
+                    provider_name="alpaca",
+                    response_body=response.text[:500],
+                )
+            )
+
+        logger.debug(f"alpaca_accounts_api_{operation}_succeeded")
+        return Success(value=data)
+
+    def _handle_list_response(
+        self,
+        response: httpx.Response,
+        operation: str,
+    ) -> Result[list[dict[str, Any]], ProviderError]:
+        """Handle Alpaca API response for list endpoints.
+
+        Args:
+            response: HTTP response from Alpaca.
+            operation: Operation name for logging.
+
+        Returns:
+            Success(list[dict]) or Failure(ProviderError).
+        """
+        error_result = self._check_error_response(response, operation)
+        if error_result is not None:
+            return error_result
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            logger.error(
+                f"alpaca_accounts_api_{operation}_invalid_json",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderInvalidResponseError(
+                    code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                    message="Invalid JSON response from Alpaca",
+                    provider_name="alpaca",
+                    response_body=response.text[:500],
+                )
+            )
+
+        if not isinstance(data, list):
+            data = [data] if data else []
+
+        logger.debug(
+            f"alpaca_accounts_api_{operation}_succeeded",
+            count=len(data),
+        )
+        return Success(value=data)
+
+    def _check_error_response(
+        self,
+        response: httpx.Response,
+        operation: str,
+    ) -> Failure[ProviderError] | None:
+        """Check for error status codes and return appropriate error.
+
+        Args:
+            response: HTTP response to check.
+            operation: Operation name for logging.
+
+        Returns:
+            Failure result if error detected, None if response is OK.
+        """
+        # Rate limiting
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            retry_seconds = int(retry_after) if retry_after else None
+            logger.warning(
+                f"alpaca_accounts_api_{operation}_rate_limited",
+                retry_after=retry_seconds,
+            )
+            return Failure(
+                error=ProviderRateLimitError(
+                    code=ErrorCode.PROVIDER_RATE_LIMITED,
+                    message="Alpaca API rate limit exceeded",
+                    provider_name="alpaca",
+                    retry_after=retry_seconds,
+                )
+            )
+
+        # Authentication errors
+        if response.status_code in (401, 403):
+            logger.warning(f"alpaca_accounts_api_{operation}_auth_failed")
+            return Failure(
+                error=ProviderAuthenticationError(
+                    code=ErrorCode.PROVIDER_AUTHENTICATION_FAILED,
+                    message="Alpaca API credentials are invalid",
+                    provider_name="alpaca",
+                    is_token_expired=False,
+                )
+            )
+
+        # Not found
+        if response.status_code == 404:
+            logger.warning(f"alpaca_accounts_api_{operation}_not_found")
+            return Failure(
+                error=ProviderInvalidResponseError(
+                    code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                    message="Alpaca resource not found",
+                    provider_name="alpaca",
+                    response_body=response.text[:500],
+                )
+            )
+
+        # Server errors
+        if response.status_code >= 500:
+            logger.warning(
+                f"alpaca_accounts_api_{operation}_server_error",
+                status_code=response.status_code,
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message=f"Alpaca API server error: {response.status_code}",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+
+        # Success
+        if response.status_code == 200:
+            return None
+
+        # Unexpected status
+        logger.warning(
+            f"alpaca_accounts_api_{operation}_unexpected_status",
+            status_code=response.status_code,
+        )
+        return Failure(
+            error=ProviderInvalidResponseError(
+                code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                message=f"Unexpected response from Alpaca: {response.status_code}",
+                provider_name="alpaca",
+                response_body=response.text[:500],
+            )
+        )

--- a/src/infrastructure/providers/alpaca/api/transactions_api.py
+++ b/src/infrastructure/providers/alpaca/api/transactions_api.py
@@ -1,0 +1,295 @@
+"""Alpaca Transactions API client.
+
+HTTP client for Alpaca Trading API account activities endpoint.
+Uses API Key authentication headers.
+
+Endpoints:
+    GET /v2/account/activities - Get account activities (Alpaca's term for transactions)
+
+Activity Types:
+    FILL - Order fill (trade execution)
+    DIV - Dividend
+    DIVCGL/DIVCGS/DIVNRA/DIVFT/DIVTXEX - Various dividend types
+    INT - Interest
+    JNLC - Journal entry (cash)
+    JNLS - Journal entry (stock)
+    MA - Merger/Acquisition
+    NC - Name change
+    PTC - Pass-through charge
+    REO - Reorg fee
+    SC - Symbol change
+    SSO - Stock spinoff
+    SSP - Stock split
+
+Reference:
+    - https://docs.alpaca.markets/reference/getaccountactivities-1
+"""
+
+from datetime import date
+from typing import Any
+
+import httpx
+import structlog
+
+from src.core.enums import ErrorCode
+from src.core.result import Failure, Result, Success
+from src.domain.errors import (
+    ProviderAuthenticationError,
+    ProviderError,
+    ProviderInvalidResponseError,
+    ProviderRateLimitError,
+    ProviderUnavailableError,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class AlpacaTransactionsAPI:
+    """HTTP client for Alpaca Trading API transactions (activities) endpoint.
+
+    Uses API Key authentication (not OAuth Bearer tokens).
+    Returns raw JSON responses - mapping to domain types is done by mappers.
+
+    Note: Alpaca calls transactions "activities" in their API.
+
+    Attributes:
+        base_url: Alpaca Trading API base URL (paper or live).
+        timeout: HTTP request timeout in seconds.
+
+    Example:
+        >>> api = AlpacaTransactionsAPI(
+        ...     base_url="https://paper-api.alpaca.markets",
+        ...     timeout=30.0,
+        ... )
+        >>> result = await api.get_transactions(api_key="...", api_secret="...")
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize Alpaca Activities API client.
+
+        Args:
+            base_url: Alpaca Trading API base URL.
+            timeout: HTTP request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def get_transactions(
+        self,
+        api_key: str,
+        api_secret: str,
+        *,
+        activity_types: list[str] | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        page_size: int = 100,
+    ) -> Result[list[dict[str, Any]], ProviderError]:
+        """Fetch account transactions (called 'activities' in Alpaca API).
+
+        Args:
+            api_key: Alpaca API Key ID.
+            api_secret: Alpaca API Secret Key.
+            activity_types: Filter by Alpaca activity types (e.g., ["FILL", "DIV"]).
+            start_date: Get transactions after this date.
+            end_date: Get transactions until this date.
+            page_size: Number of transactions per page (max 100).
+
+        Returns:
+            Success(list[dict]): List of transaction JSON objects.
+            Failure(ProviderAuthenticationError): If credentials are invalid.
+            Failure(ProviderUnavailableError): If Alpaca API is unreachable.
+        """
+        logger.debug(
+            "alpaca_transactions_api_get_transactions_started",
+            activity_types=activity_types,
+            start_date=str(start_date) if start_date else None,
+            end_date=str(end_date) if end_date else None,
+        )
+
+        # Build query parameters
+        params: dict[str, Any] = {"page_size": page_size}
+        if activity_types:
+            params["activity_types"] = ",".join(activity_types)
+        if start_date:
+            params["after"] = start_date.isoformat()
+        if end_date:
+            params["until"] = end_date.isoformat()
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.get(
+                    f"{self._base_url}/v2/account/activities",
+                    headers=self._build_headers(api_key, api_secret),
+                    params=params,
+                )
+
+            return self._handle_response(response, "get_transactions")
+
+        except httpx.TimeoutException as e:
+            logger.warning(
+                "alpaca_transactions_api_timeout",
+                operation="get_transactions",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message="Alpaca API request timed out",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+        except httpx.RequestError as e:
+            logger.warning(
+                "alpaca_transactions_api_connection_error",
+                operation="get_transactions",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message=f"Failed to connect to Alpaca API: {e}",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+
+    def _build_headers(self, api_key: str, api_secret: str) -> dict[str, str]:
+        """Build HTTP headers for Alpaca API requests.
+
+        Args:
+            api_key: Alpaca API Key ID.
+            api_secret: Alpaca API Secret Key.
+
+        Returns:
+            Headers dict with API key authentication.
+        """
+        return {
+            "APCA-API-KEY-ID": api_key,
+            "APCA-API-SECRET-KEY": api_secret,
+            "Accept": "application/json",
+        }
+
+    def _handle_response(
+        self,
+        response: httpx.Response,
+        operation: str,
+    ) -> Result[list[dict[str, Any]], ProviderError]:
+        """Handle Alpaca API response for transactions endpoint.
+
+        Args:
+            response: HTTP response from Alpaca.
+            operation: Operation name for logging.
+
+        Returns:
+            Success(list[dict]) or Failure(ProviderError).
+        """
+        error_result = self._check_error_response(response, operation)
+        if error_result is not None:
+            return error_result
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            logger.error(
+                f"alpaca_transactions_api_{operation}_invalid_json",
+                error=str(e),
+            )
+            return Failure(
+                error=ProviderInvalidResponseError(
+                    code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                    message="Invalid JSON response from Alpaca",
+                    provider_name="alpaca",
+                    response_body=response.text[:500],
+                )
+            )
+
+        if not isinstance(data, list):
+            data = [data] if data else []
+
+        logger.debug(
+            f"alpaca_transactions_api_{operation}_succeeded",
+            count=len(data),
+        )
+        return Success(value=data)
+
+    def _check_error_response(
+        self,
+        response: httpx.Response,
+        operation: str,
+    ) -> Failure[ProviderError] | None:
+        """Check for error status codes and return appropriate error.
+
+        Args:
+            response: HTTP response to check.
+            operation: Operation name for logging.
+
+        Returns:
+            Failure result if error detected, None if response is OK.
+        """
+        # Rate limiting
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            retry_seconds = int(retry_after) if retry_after else None
+            logger.warning(
+                f"alpaca_transactions_api_{operation}_rate_limited",
+                retry_after=retry_seconds,
+            )
+            return Failure(
+                error=ProviderRateLimitError(
+                    code=ErrorCode.PROVIDER_RATE_LIMITED,
+                    message="Alpaca API rate limit exceeded",
+                    provider_name="alpaca",
+                    retry_after=retry_seconds,
+                )
+            )
+
+        # Authentication errors
+        if response.status_code in (401, 403):
+            logger.warning(f"alpaca_transactions_api_{operation}_auth_failed")
+            return Failure(
+                error=ProviderAuthenticationError(
+                    code=ErrorCode.PROVIDER_AUTHENTICATION_FAILED,
+                    message="Alpaca API credentials are invalid",
+                    provider_name="alpaca",
+                    is_token_expired=False,
+                )
+            )
+
+        # Server errors
+        if response.status_code >= 500:
+            logger.warning(
+                f"alpaca_transactions_api_{operation}_server_error",
+                status_code=response.status_code,
+            )
+            return Failure(
+                error=ProviderUnavailableError(
+                    code=ErrorCode.PROVIDER_UNAVAILABLE,
+                    message=f"Alpaca API server error: {response.status_code}",
+                    provider_name="alpaca",
+                    is_transient=True,
+                )
+            )
+
+        # Success
+        if response.status_code == 200:
+            return None
+
+        # Unexpected status
+        logger.warning(
+            f"alpaca_transactions_api_{operation}_unexpected_status",
+            status_code=response.status_code,
+        )
+        return Failure(
+            error=ProviderInvalidResponseError(
+                code=ErrorCode.PROVIDER_CREDENTIAL_INVALID,
+                message=f"Unexpected response from Alpaca: {response.status_code}",
+                provider_name="alpaca",
+                response_body=response.text[:500],
+            )
+        )

--- a/src/infrastructure/providers/alpaca/mappers/__init__.py
+++ b/src/infrastructure/providers/alpaca/mappers/__init__.py
@@ -1,0 +1,23 @@
+"""Alpaca data mappers package.
+
+Converts Alpaca API JSON responses to ProviderData types.
+
+Reference:
+    - https://docs.alpaca.markets/docs/trading-api
+"""
+
+from src.infrastructure.providers.alpaca.mappers.account_mapper import (
+    AlpacaAccountMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.holding_mapper import (
+    AlpacaHoldingMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.transaction_mapper import (
+    AlpacaTransactionMapper,
+)
+
+__all__ = [
+    "AlpacaAccountMapper",
+    "AlpacaHoldingMapper",
+    "AlpacaTransactionMapper",
+]

--- a/src/infrastructure/providers/alpaca/mappers/account_mapper.py
+++ b/src/infrastructure/providers/alpaca/mappers/account_mapper.py
@@ -1,0 +1,159 @@
+"""Alpaca account mapper.
+
+Converts Alpaca Trading API account JSON responses to ProviderAccountData.
+Contains Alpaca-specific knowledge about JSON structure.
+
+Alpaca Account Response Structure:
+    {
+        "id": "ba0d71b6-1044-4334-9643-ebbf8e2fcbf9",
+        "account_number": "PA3CRCJ7QUIR",
+        "status": "ACTIVE",
+        "currency": "USD",
+        "buying_power": "200000",
+        "cash": "100000",
+        "equity": "100000",
+        ...
+    }
+
+Reference:
+    - https://docs.alpaca.markets/reference/getaccount-1
+"""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import structlog
+
+from src.domain.enums.account_type import AccountType
+from src.domain.protocols.provider_protocol import ProviderAccountData
+
+logger = structlog.get_logger(__name__)
+
+
+class AlpacaAccountMapper:
+    """Mapper for converting Alpaca account data to ProviderAccountData.
+
+    This mapper handles:
+    - Extracting data from Alpaca's account JSON structure
+    - Converting balance values to Decimal with proper precision
+    - Masking account numbers for security
+    - Determining account type (Alpaca only has brokerage accounts)
+
+    Thread-safe: No mutable state, can be shared across requests.
+
+    Example:
+        >>> mapper = AlpacaAccountMapper()
+        >>> alpaca_data = {"account_number": "PA123", "equity": "100000", ...}
+        >>> result = mapper.map_account(alpaca_data)
+        >>> if result is not None:
+        ...     print(f"Account: {result.name}")
+    """
+
+    def map_account(self, data: dict[str, Any]) -> ProviderAccountData | None:
+        """Map Alpaca account JSON to ProviderAccountData.
+
+        Args:
+            data: Account object from Alpaca API response.
+
+        Returns:
+            ProviderAccountData if mapping succeeds, None if data is invalid
+            or missing required fields.
+
+        Example:
+            >>> data = {
+            ...     "account_number": "PA3CRCJ7QUIR",
+            ...     "status": "ACTIVE",
+            ...     "equity": "100000",
+            ...     "buying_power": "200000",
+            ... }
+            >>> result = mapper.map_account(data)
+            >>> result.provider_account_id
+            'PA3CRCJ7QUIR'
+        """
+        try:
+            return self._map_account_internal(data)
+        except (KeyError, TypeError, InvalidOperation, AttributeError) as e:
+            logger.warning(
+                "alpaca_account_mapping_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return None
+
+    def _map_account_internal(self, data: dict[str, Any]) -> ProviderAccountData | None:
+        """Internal mapping logic.
+
+        Raises exceptions on invalid data (caught by map_account).
+        """
+        # Extract account number (required)
+        account_number = data.get("account_number", "")
+        if not account_number:
+            logger.debug("alpaca_account_missing_account_number")
+            return None
+
+        # Get status
+        status = data.get("status", "UNKNOWN")
+        is_active = status == "ACTIVE"
+
+        # Parse balance values (Alpaca returns strings)
+        equity = self._parse_decimal(data.get("equity", "0"))
+        buying_power = self._parse_decimal(data.get("buying_power"))
+        cash = self._parse_decimal(data.get("cash"))
+
+        # Currency (Alpaca only supports USD)
+        currency = data.get("currency", "USD")
+
+        # Generate masked account number
+        masked = self._mask_account_number(account_number)
+
+        # Generate account name
+        # Alpaca doesn't have account names, so we generate one
+        account_type_label = "Paper" if account_number.startswith("PA") else "Live"
+        name = f"Alpaca {account_type_label} {masked}"
+
+        return ProviderAccountData(
+            provider_account_id=account_number,
+            account_number_masked=masked,
+            name=name,
+            account_type=AccountType.BROKERAGE.value,  # Alpaca only has brokerage
+            balance=equity,
+            currency=currency,
+            available_balance=buying_power if buying_power else cash,
+            is_active=is_active,
+            raw_data=data,
+        )
+
+    def _parse_decimal(self, value: Any) -> Decimal:
+        """Parse numeric value to Decimal with proper precision.
+
+        Args:
+            value: Numeric value (int, float, str, or None).
+
+        Returns:
+            Decimal representation, Decimal("0") for None/invalid.
+        """
+        if value is None:
+            return Decimal("0")
+
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            logger.warning(
+                "alpaca_invalid_decimal_value",
+                value=value,
+                value_type=type(value).__name__,
+            )
+            return Decimal("0")
+
+    def _mask_account_number(self, account_number: str) -> str:
+        """Mask account number for display, showing only last 4 characters.
+
+        Args:
+            account_number: Full account number from Alpaca.
+
+        Returns:
+            Masked string like "****QUIR".
+        """
+        if len(account_number) >= 4:
+            return f"****{account_number[-4:]}"
+        return f"****{account_number}"

--- a/src/infrastructure/providers/alpaca/mappers/holding_mapper.py
+++ b/src/infrastructure/providers/alpaca/mappers/holding_mapper.py
@@ -1,0 +1,246 @@
+"""Alpaca holding (position) mapper.
+
+Converts Alpaca Trading API position JSON responses to ProviderHoldingData.
+Contains Alpaca-specific knowledge about JSON structure.
+
+Alpaca Position Response Structure:
+    {
+        "asset_id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+        "symbol": "AAPL",
+        "exchange": "NASDAQ",
+        "asset_class": "us_equity",
+        "asset_marginable": true,
+        "qty": "100",
+        "avg_entry_price": "150.25",
+        "side": "long",
+        "market_value": "15500.00",
+        "cost_basis": "15025.00",
+        "unrealized_pl": "475.00",
+        "unrealized_plpc": "0.0316",
+        "current_price": "155.00",
+        ...
+    }
+
+Reference:
+    - https://docs.alpaca.markets/reference/getallopenpositions-1
+"""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import structlog
+
+from src.domain.protocols.provider_protocol import ProviderHoldingData
+
+logger = structlog.get_logger(__name__)
+
+
+# =============================================================================
+# Asset Type Mapping
+# =============================================================================
+
+# Alpaca asset_class → Dashtam asset type
+ALPACA_ASSET_TYPE_MAP: dict[str, str] = {
+    "us_equity": "equity",
+    "crypto": "cryptocurrency",
+    # Alpaca doesn't support these yet, but mapping for future
+    "etf": "etf",
+    "option": "option",
+}
+
+
+class AlpacaHoldingMapper:
+    """Mapper for converting Alpaca position data to ProviderHoldingData.
+
+    This mapper handles:
+    - Extracting data from Alpaca's position JSON structure
+    - Mapping Alpaca asset classes to Dashtam types
+    - Converting numeric values to Decimal with proper precision
+    - Handling both long and short positions
+
+    Thread-safe: No mutable state, can be shared across requests.
+
+    Example:
+        >>> mapper = AlpacaHoldingMapper()
+        >>> positions = [{"symbol": "AAPL", "qty": "100", ...}]
+        >>> holdings = mapper.map_holdings(positions)
+        >>> print(f"Mapped {len(holdings)} holdings")
+    """
+
+    def map_holding(self, data: dict[str, Any]) -> ProviderHoldingData | None:
+        """Map single Alpaca position JSON to ProviderHoldingData.
+
+        Args:
+            data: Single position object from Alpaca API response.
+
+        Returns:
+            ProviderHoldingData if mapping succeeds, None if data is invalid
+            or missing required fields.
+
+        Example:
+            >>> data = {
+            ...     "asset_id": "abc123",
+            ...     "symbol": "AAPL",
+            ...     "qty": "100",
+            ...     "market_value": "15500",
+            ...     "cost_basis": "15000",
+            ... }
+            >>> result = mapper.map_holding(data)
+            >>> result.symbol
+            'AAPL'
+        """
+        try:
+            return self._map_holding_internal(data)
+        except (KeyError, TypeError, InvalidOperation, AttributeError, ValueError) as e:
+            logger.warning(
+                "alpaca_holding_mapping_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return None
+
+    def map_holdings(
+        self, data_list: list[dict[str, Any]]
+    ) -> list[ProviderHoldingData]:
+        """Map list of Alpaca position JSON objects to ProviderHoldingData.
+
+        Skips invalid positions and logs warnings. Never raises exceptions.
+
+        Args:
+            data_list: List of position objects from Alpaca API.
+
+        Returns:
+            List of successfully mapped holdings. May be empty if all fail.
+        """
+        holdings: list[ProviderHoldingData] = []
+
+        for data in data_list:
+            holding = self.map_holding(data)
+            if holding is not None:
+                holdings.append(holding)
+
+        return holdings
+
+    def _map_holding_internal(self, data: dict[str, Any]) -> ProviderHoldingData | None:
+        """Internal mapping logic.
+
+        Raises exceptions on invalid data (caught by map_holding).
+        """
+        # Get symbol (required)
+        symbol = data.get("symbol")
+        if not symbol:
+            logger.debug("alpaca_holding_missing_symbol")
+            return None
+
+        # Get asset ID for unique identifier
+        asset_id = data.get("asset_id", "")
+        if not asset_id:
+            # Fall back to symbol if no asset_id
+            asset_id = f"alpaca_{symbol}"
+
+        # Get asset type
+        asset_class = data.get("asset_class", "us_equity")
+        asset_type = self._map_asset_type(asset_class)
+
+        # Get quantity (handle side for short positions)
+        qty_str = data.get("qty", "0")
+        quantity = self._parse_decimal(qty_str)
+        side = data.get("side", "long")
+        if side == "short":
+            quantity = -abs(quantity)
+
+        # Skip zero-quantity positions
+        if quantity == Decimal("0"):
+            logger.debug(
+                "alpaca_holding_zero_quantity",
+                symbol=symbol,
+            )
+            return None
+
+        # Get price and value data
+        cost_basis = self._parse_decimal(data.get("cost_basis", "0"))
+        market_value = self._parse_decimal(data.get("market_value", "0"))
+        avg_entry_price = self._parse_decimal_optional(data.get("avg_entry_price"))
+        current_price = self._parse_decimal_optional(data.get("current_price"))
+
+        # Security name - Alpaca doesn't provide this, use symbol
+        # We could look it up via the assets API but that's extra calls
+        security_name = symbol
+
+        return ProviderHoldingData(
+            provider_holding_id=asset_id,
+            symbol=symbol,
+            security_name=security_name,
+            asset_type=asset_type,
+            quantity=quantity,
+            cost_basis=cost_basis,
+            market_value=market_value,
+            currency="USD",  # Alpaca only supports USD
+            average_price=avg_entry_price,
+            current_price=current_price,
+            raw_data=data,
+        )
+
+    def _map_asset_type(self, asset_class: str) -> str:
+        """Map Alpaca asset class to Dashtam asset type.
+
+        Args:
+            asset_class: Asset class from Alpaca API.
+
+        Returns:
+            Mapped asset type string, defaults to "other".
+        """
+        if not asset_class:
+            return "other"
+
+        normalized = asset_class.lower().strip()
+        mapped = ALPACA_ASSET_TYPE_MAP.get(normalized)
+
+        if mapped is None:
+            logger.info(
+                "alpaca_unknown_asset_type",
+                alpaca_type=asset_class,
+                defaulting_to="other",
+            )
+            return "other"
+
+        return mapped
+
+    def _parse_decimal(self, value: Any) -> Decimal:
+        """Parse numeric value to Decimal with proper precision.
+
+        Args:
+            value: Numeric value (int, float, str, or None).
+
+        Returns:
+            Decimal representation, Decimal("0") for None/invalid.
+        """
+        if value is None:
+            return Decimal("0")
+
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            logger.warning(
+                "alpaca_invalid_decimal_value",
+                value=value,
+                value_type=type(value).__name__,
+            )
+            return Decimal("0")
+
+    def _parse_decimal_optional(self, value: Any) -> Decimal | None:
+        """Parse numeric value to Decimal, returning None for missing/invalid.
+
+        Args:
+            value: Numeric value (int, float, str, or None).
+
+        Returns:
+            Decimal representation or None.
+        """
+        if value is None:
+            return None
+
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            return None

--- a/src/infrastructure/providers/alpaca/mappers/transaction_mapper.py
+++ b/src/infrastructure/providers/alpaca/mappers/transaction_mapper.py
@@ -1,0 +1,429 @@
+"""Alpaca transaction mapper.
+
+Converts Alpaca Trading API activity JSON responses to ProviderTransactionData.
+Contains Alpaca-specific knowledge about JSON structure and activity types.
+
+Alpaca Activity Types:
+    FILL - Order fill (trade execution)
+    DIV - Dividend
+    DIVCGL - Dividend (capital gain long term)
+    DIVCGS - Dividend (capital gain short term)
+    DIVNRA - Dividend (non-resident alien tax)
+    DIVFT - Dividend (foreign tax withheld)
+    DIVTXEX - Dividend (tax exempt)
+    INT - Interest
+    JNLC - Journal entry (cash)
+    JNLS - Journal entry (stock)
+    MA - Merger/Acquisition
+    NC - Name change
+    PTC - Pass-through charge
+    REO - Reorg fee
+    SC - Symbol change
+    SSO - Stock spinoff
+    SSP - Stock split
+
+Activity Response Structure (Trade Fill):
+    {
+        "id": "20210301000000000::8c51c51d-2ccb-4a7c-9bc1-f31b0a7b0ae9",
+        "activity_type": "FILL",
+        "transaction_time": "2021-03-01T09:30:00Z",
+        "type": "fill",
+        "price": "150.25",
+        "qty": "100",
+        "side": "buy",
+        "symbol": "AAPL",
+        "leaves_qty": "0",
+        "order_id": "abc123",
+        "cum_qty": "100",
+        "order_status": "filled"
+    }
+
+Activity Response Structure (Non-Trade):
+    {
+        "id": "20211025000000000::c3599cf9-a5fe-44a2-863a-49f0d3276ae4",
+        "activity_type": "JNLC",
+        "date": "2021-10-25",
+        "net_amount": "100000",
+        "description": "",
+        "status": "executed"
+    }
+
+Reference:
+    - https://docs.alpaca.markets/reference/getaccountactivities-1
+"""
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import structlog
+
+from src.domain.protocols.provider_protocol import ProviderTransactionData
+
+logger = structlog.get_logger(__name__)
+
+
+# =============================================================================
+# Transaction Type Mapping
+# =============================================================================
+
+# Alpaca activity_type → Dashtam transaction_type
+ALPACA_TRANSACTION_TYPE_MAP: dict[str, str] = {
+    # Trade types
+    "FILL": "trade",
+    # Income types
+    "DIV": "income",
+    "DIVCGL": "income",
+    "DIVCGS": "income",
+    "DIVNRA": "income",
+    "DIVFT": "income",
+    "DIVTXEX": "income",
+    "INT": "income",
+    # Transfer types
+    "JNLC": "transfer",
+    "JNLS": "transfer",
+    "WIRE": "transfer",
+    "ACH": "transfer",
+    # Fee types
+    "FEE": "fee",
+    "PTC": "fee",
+    "REO": "fee",
+    # Other/corporate actions
+    "MA": "other",
+    "NC": "other",
+    "SC": "other",
+    "SSO": "other",
+    "SSP": "other",
+}
+
+# Alpaca side → Dashtam subtype (for trades)
+ALPACA_TRADE_SUBTYPE_MAP: dict[str, str] = {
+    "buy": "buy",
+    "sell": "sell",
+    "buy_to_cover": "buy_to_cover",
+    "sell_short": "short_sell",
+}
+
+
+class AlpacaTransactionMapper:
+    """Mapper for converting Alpaca activity data to ProviderTransactionData.
+
+    This mapper handles:
+    - Extracting data from Alpaca's activity JSON structure
+    - Mapping Alpaca activity types to Dashtam transaction types
+    - Determining subtypes based on trade side
+    - Converting amounts and dates with proper precision
+    - Handling both trade and non-trade activities
+
+    Thread-safe: No mutable state, can be shared across requests.
+
+    Example:
+        >>> mapper = AlpacaTransactionMapper()
+        >>> activities = [{"activity_type": "FILL", "symbol": "AAPL", ...}]
+        >>> transactions = mapper.map_transactions(activities)
+        >>> print(f"Mapped {len(transactions)} transactions")
+    """
+
+    def map_transaction(self, data: dict[str, Any]) -> ProviderTransactionData | None:
+        """Map single Alpaca activity JSON to ProviderTransactionData.
+
+        Args:
+            data: Single activity object from Alpaca API response.
+
+        Returns:
+            ProviderTransactionData if mapping succeeds, None if data is invalid
+            or missing required fields.
+        """
+        try:
+            return self._map_transaction_internal(data)
+        except (KeyError, TypeError, InvalidOperation, AttributeError, ValueError) as e:
+            logger.warning(
+                "alpaca_transaction_mapping_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return None
+
+    def map_transactions(
+        self, data_list: list[dict[str, Any]]
+    ) -> list[ProviderTransactionData]:
+        """Map list of Alpaca activity JSON objects to ProviderTransactionData.
+
+        Skips invalid activities and logs warnings. Never raises exceptions.
+
+        Args:
+            data_list: List of activity objects from Alpaca API.
+
+        Returns:
+            List of successfully mapped transactions. May be empty if all fail.
+        """
+        transactions: list[ProviderTransactionData] = []
+
+        for data in data_list:
+            txn = self.map_transaction(data)
+            if txn is not None:
+                transactions.append(txn)
+
+        return transactions
+
+    def _map_transaction_internal(
+        self, data: dict[str, Any]
+    ) -> ProviderTransactionData | None:
+        """Internal mapping logic.
+
+        Raises exceptions on invalid data (caught by map_transaction).
+        """
+        # Extract transaction ID (required)
+        txn_id = data.get("id")
+        if not txn_id:
+            logger.debug("alpaca_transaction_missing_id")
+            return None
+
+        # Get activity type
+        activity_type = data.get("activity_type", "UNKNOWN")
+        transaction_type = self._map_transaction_type(activity_type)
+
+        # Parse transaction date
+        txn_date = self._parse_date(data)
+        if txn_date is None:
+            logger.debug("alpaca_transaction_missing_date", txn_id=txn_id)
+            return None
+
+        # Determine if this is a trade or non-trade activity
+        is_trade = activity_type == "FILL"
+
+        if is_trade:
+            return self._map_trade_activity(data, txn_id, transaction_type, txn_date)
+        else:
+            return self._map_non_trade_activity(
+                data, txn_id, transaction_type, txn_date, activity_type
+            )
+
+    def _map_trade_activity(
+        self,
+        data: dict[str, Any],
+        txn_id: str,
+        transaction_type: str,
+        txn_date: date,
+    ) -> ProviderTransactionData:
+        """Map a trade (FILL) activity."""
+        # Get trade details
+        symbol = data.get("symbol", "")
+        side = data.get("side", "")
+        subtype = self._map_trade_subtype(side)
+
+        # Parse amounts
+        qty = self._parse_decimal(data.get("qty", "0"))
+        price = self._parse_decimal(data.get("price", "0"))
+
+        # Calculate total amount (negative for buys, positive for sells)
+        total_amount = qty * price
+        if side in ("buy", "buy_to_cover"):
+            total_amount = -total_amount
+
+        # Build description
+        description = f"{side.upper()} {qty} {symbol} @ ${price}"
+
+        return ProviderTransactionData(
+            provider_transaction_id=txn_id,
+            transaction_type=transaction_type,
+            subtype=subtype,
+            amount=total_amount,
+            currency="USD",
+            description=description,
+            transaction_date=txn_date,
+            status="executed",
+            symbol=symbol,
+            security_name=symbol,  # Alpaca doesn't provide full name
+            asset_type="equity",  # Alpaca trades are typically equity
+            quantity=qty,
+            unit_price=price,
+            commission=Decimal("0"),  # Alpaca is commission-free
+            raw_data=data,
+        )
+
+    def _map_non_trade_activity(
+        self,
+        data: dict[str, Any],
+        txn_id: str,
+        transaction_type: str,
+        txn_date: date,
+        activity_type: str,
+    ) -> ProviderTransactionData:
+        """Map a non-trade activity (dividend, transfer, etc.)."""
+        # Parse amount
+        amount = self._parse_decimal(data.get("net_amount", "0"))
+
+        # Get description
+        description = data.get("description", "")
+        if not description:
+            description = self._generate_description(activity_type, amount)
+
+        # Get status
+        status = data.get("status", "executed")
+
+        # For dividend activities, try to get the symbol
+        symbol = data.get("symbol")
+
+        return ProviderTransactionData(
+            provider_transaction_id=txn_id,
+            transaction_type=transaction_type,
+            subtype=self._get_non_trade_subtype(activity_type),
+            amount=amount,
+            currency="USD",
+            description=description,
+            transaction_date=txn_date,
+            status=status,
+            symbol=symbol,
+            security_name=symbol if symbol else None,
+            raw_data=data,
+        )
+
+    def _map_transaction_type(self, activity_type: str) -> str:
+        """Map Alpaca activity type to Dashtam transaction type.
+
+        Args:
+            activity_type: Activity type from Alpaca API.
+
+        Returns:
+            Mapped transaction type string, defaults to "other".
+        """
+        if not activity_type:
+            return "other"
+
+        normalized = activity_type.upper().strip()
+        mapped = ALPACA_TRANSACTION_TYPE_MAP.get(normalized)
+
+        if mapped is None:
+            logger.info(
+                "alpaca_unknown_activity_type",
+                alpaca_type=activity_type,
+                defaulting_to="other",
+            )
+            return "other"
+
+        return mapped
+
+    def _map_trade_subtype(self, side: str) -> str | None:
+        """Map Alpaca trade side to Dashtam subtype.
+
+        Args:
+            side: Trade side from Alpaca API (buy, sell, etc.).
+
+        Returns:
+            Mapped subtype or None.
+        """
+        if not side:
+            return None
+
+        normalized = side.lower().strip()
+        return ALPACA_TRADE_SUBTYPE_MAP.get(normalized)
+
+    def _get_non_trade_subtype(self, activity_type: str) -> str | None:
+        """Get subtype for non-trade activities.
+
+        Args:
+            activity_type: Alpaca activity type.
+
+        Returns:
+            Subtype string or None.
+        """
+        subtypes = {
+            "DIV": "dividend",
+            "DIVCGL": "dividend_capital_gain_long",
+            "DIVCGS": "dividend_capital_gain_short",
+            "INT": "interest",
+            "JNLC": "journal_cash",
+            "JNLS": "journal_stock",
+        }
+        return subtypes.get(activity_type.upper())
+
+    def _generate_description(self, activity_type: str, amount: Decimal) -> str:
+        """Generate a description for activities without one.
+
+        Args:
+            activity_type: Alpaca activity type.
+            amount: Transaction amount.
+
+        Returns:
+            Generated description string.
+        """
+        descriptions = {
+            "JNLC": "Journal entry (cash)",
+            "JNLS": "Journal entry (stock)",
+            "DIV": "Dividend",
+            "INT": "Interest",
+            "WIRE": "Wire transfer",
+            "ACH": "ACH transfer",
+        }
+        base = descriptions.get(activity_type, activity_type)
+        if amount >= 0:
+            return f"{base}: ${amount}"
+        return f"{base}: -${abs(amount)}"
+
+    def _parse_date(self, data: dict[str, Any]) -> date | None:
+        """Parse transaction date from Alpaca activity data.
+
+        Alpaca uses different date fields for different activity types:
+        - Trade fills: transaction_time (ISO timestamp)
+        - Non-trade: date (YYYY-MM-DD)
+
+        Args:
+            data: Activity data dict.
+
+        Returns:
+            Parsed date or None if missing/invalid.
+        """
+        # Try transaction_time first (for trades)
+        txn_time = data.get("transaction_time")
+        if txn_time:
+            try:
+                # Parse ISO timestamp
+                if isinstance(txn_time, str):
+                    dt = datetime.fromisoformat(txn_time.replace("Z", "+00:00"))
+                    return dt.date()
+            except (ValueError, TypeError):
+                pass
+
+        # Try date field (for non-trades)
+        date_str = data.get("date")
+        if date_str:
+            try:
+                if isinstance(date_str, str):
+                    return date.fromisoformat(date_str)
+            except (ValueError, TypeError):
+                pass
+
+        # Try created_at as fallback
+        created_at = data.get("created_at")
+        if created_at:
+            try:
+                if isinstance(created_at, str):
+                    dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+                    return dt.date()
+            except (ValueError, TypeError):
+                pass
+
+        return None
+
+    def _parse_decimal(self, value: Any) -> Decimal:
+        """Parse numeric value to Decimal with proper precision.
+
+        Args:
+            value: Numeric value (int, float, str, or None).
+
+        Returns:
+            Decimal representation, Decimal("0") for None/invalid.
+        """
+        if value is None:
+            return Decimal("0")
+
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            logger.warning(
+                "alpaca_invalid_decimal_value",
+                value=value,
+                value_type=type(value).__name__,
+            )
+            return Decimal("0")

--- a/tests/integration/test_alpaca_api.py
+++ b/tests/integration/test_alpaca_api.py
@@ -1,0 +1,825 @@
+"""Integration tests for Alpaca API clients.
+
+Tests for:
+- AlpacaAccountsAPI: HTTP client for account and positions endpoints
+- AlpacaTransactionsAPI: HTTP client for activities endpoint
+
+Uses pytest-httpx to mock HTTP responses.
+"""
+
+import re
+
+import pytest
+
+from src.core.result import Failure, Success
+from src.domain.errors import (
+    ProviderAuthenticationError,
+    ProviderRateLimitError,
+    ProviderUnavailableError,
+)
+from src.infrastructure.providers.alpaca.api.accounts_api import AlpacaAccountsAPI
+from src.infrastructure.providers.alpaca.api.transactions_api import (
+    AlpacaTransactionsAPI,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def accounts_api() -> AlpacaAccountsAPI:
+    """Create AlpacaAccountsAPI instance."""
+    return AlpacaAccountsAPI(
+        base_url="https://paper-api.alpaca.markets",
+        timeout=30.0,
+    )
+
+
+@pytest.fixture
+def transactions_api() -> AlpacaTransactionsAPI:
+    """Create AlpacaTransactionsAPI instance."""
+    return AlpacaTransactionsAPI(
+        base_url="https://paper-api.alpaca.markets",
+        timeout=30.0,
+    )
+
+
+@pytest.fixture
+def api_credentials() -> tuple[str, str]:
+    """Return test API credentials."""
+    return ("PKTEST123", "secret456")
+
+
+# =============================================================================
+# AlpacaAccountsAPI - get_account Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAlpacaAccountsAPIGetAccount:
+    """Tests for AlpacaAccountsAPI.get_account."""
+
+    async def test_get_account_success(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Successful account fetch returns JSON dict."""
+        api_key, api_secret = api_credentials
+        response_json = {
+            "account_number": "PA3CRCJ7QUIR",
+            "status": "ACTIVE",
+            "equity": "150000.50",
+        }
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            json=response_json,
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert result.value["account_number"] == "PA3CRCJ7QUIR"
+
+    async def test_get_account_auth_failure_401(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """401 response returns ProviderAuthenticationError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=401,
+            json={"message": "Invalid credentials"},
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+    async def test_get_account_auth_failure_403(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """403 response returns ProviderAuthenticationError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=403,
+            json={"message": "Forbidden"},
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+    async def test_get_account_rate_limited_429(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """429 response returns ProviderRateLimitError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=429,
+            headers={"Retry-After": "60"},
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderRateLimitError)
+        assert result.error.retry_after == 60
+
+    async def test_get_account_server_error_500(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """500 response returns ProviderUnavailableError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=500,
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_account_sends_correct_headers(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Request includes correct API key headers."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            json={"account_number": "PA123"},
+        )
+
+        await accounts_api.get_account(api_key, api_secret)
+
+        request = httpx_mock.get_request()
+        assert request.headers["APCA-API-KEY-ID"] == api_key
+        assert request.headers["APCA-API-SECRET-KEY"] == api_secret
+
+
+# =============================================================================
+# AlpacaAccountsAPI - get_positions Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAlpacaAccountsAPIGetPositions:
+    """Tests for AlpacaAccountsAPI.get_positions."""
+
+    async def test_get_positions_success(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Successful positions fetch returns list of dicts."""
+        api_key, api_secret = api_credentials
+        response_json = [
+            {"symbol": "AAPL", "qty": "100", "market_value": "15500"},
+            {"symbol": "GOOGL", "qty": "50", "market_value": "70000"},
+        ]
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/positions",
+            json=response_json,
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 2
+        assert result.value[0]["symbol"] == "AAPL"
+
+    async def test_get_positions_empty(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Empty positions returns empty list."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/positions",
+            json=[],
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert result.value == []
+
+    async def test_get_positions_auth_failure(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Auth failure returns ProviderAuthenticationError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/positions",
+            status_code=401,
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+
+# =============================================================================
+# AlpacaTransactionsAPI Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAlpacaTransactionsAPI:
+    """Tests for AlpacaTransactionsAPI."""
+
+    async def test_get_transactions_success(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Successful activities fetch returns list of dicts."""
+        api_key, api_secret = api_credentials
+        response_json = [
+            {
+                "id": "txn1",
+                "activity_type": "FILL",
+                "symbol": "AAPL",
+            },
+            {
+                "id": "txn2",
+                "activity_type": "DIV",
+                "net_amount": "100",
+            },
+        ]
+        # Use url pattern to match any query params (page_size is always added)
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json=response_json,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 2
+
+    async def test_get_transactions_with_date_params(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Date parameters are included in request."""
+        from datetime import date
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json=[],
+        )
+
+        await transactions_api.get_transactions(
+            api_key,
+            api_secret,
+            start_date=date(2021, 1, 1),
+            end_date=date(2021, 12, 31),
+        )
+
+        request = httpx_mock.get_request()
+        assert "after=2021-01-01" in str(request.url)
+        assert "until=2021-12-31" in str(request.url)
+
+    async def test_get_transactions_empty(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Empty activities returns empty list."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json=[],
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert result.value == []
+
+    async def test_get_transactions_auth_failure(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Auth failure returns ProviderAuthenticationError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            status_code=401,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+    async def test_get_transactions_rate_limited(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """429 response returns ProviderRateLimitError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            status_code=429,
+            headers={"Retry-After": "30"},
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderRateLimitError)
+
+    async def test_get_transactions_server_error(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """500 response returns ProviderUnavailableError."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            status_code=503,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_transactions_sends_correct_headers(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Request includes correct API key headers."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json=[],
+        )
+
+        await transactions_api.get_transactions(api_key, api_secret)
+
+        request = httpx_mock.get_request()
+        assert request.headers["APCA-API-KEY-ID"] == api_key
+        assert request.headers["APCA-API-SECRET-KEY"] == api_secret
+
+    async def test_get_transactions_with_activity_types_filter(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Activity types filter is included in request."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json=[],
+        )
+
+        await transactions_api.get_transactions(
+            api_key,
+            api_secret,
+            activity_types=["FILL", "DIV"],
+        )
+
+        request = httpx_mock.get_request()
+        assert "activity_types=FILL%2CDIV" in str(
+            request.url
+        ) or "activity_types=FILL,DIV" in str(request.url)
+
+
+# =============================================================================
+# AlpacaAccountsAPI - Timeout and Connection Error Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAlpacaAccountsAPIErrorHandling:
+    """Tests for AlpacaAccountsAPI error handling."""
+
+    async def test_get_account_timeout(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Timeout returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.TimeoutException("Connection timed out"),
+            url="https://paper-api.alpaca.markets/v2/account",
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+        assert "timed out" in result.error.message.lower()
+
+    async def test_get_account_connection_error(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Connection error returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection refused"),
+            url="https://paper-api.alpaca.markets/v2/account",
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_account_invalid_json(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Invalid JSON response returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            content=b"not valid json",
+            status_code=200,
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_account_unexpected_list_response(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """List response (expected dict) returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            json=[{"account_number": "PA123"}],  # List instead of dict
+            status_code=200,
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_account_404_not_found(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """404 response returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=404,
+            json={"message": "Not found"},
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_account_unexpected_status_code(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Unexpected status code returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=418,  # I'm a teapot
+            json={"message": "Unexpected"},
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_positions_timeout(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Positions timeout returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.TimeoutException("Connection timed out"),
+            url="https://paper-api.alpaca.markets/v2/positions",
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_positions_connection_error(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Positions connection error returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection refused"),
+            url="https://paper-api.alpaca.markets/v2/positions",
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_positions_invalid_json(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Positions invalid JSON returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/positions",
+            content=b"not valid json",
+            status_code=200,
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_positions_dict_response_wrapped_as_list(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Dict response is wrapped as single-item list."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/positions",
+            json={"symbol": "AAPL", "qty": "100"},  # Single dict instead of list
+            status_code=200,
+        )
+
+        result = await accounts_api.get_positions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 1
+        assert result.value[0]["symbol"] == "AAPL"
+
+    async def test_get_account_rate_limited_no_retry_after(
+        self,
+        accounts_api: AlpacaAccountsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """429 without Retry-After header returns None for retry_after."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url="https://paper-api.alpaca.markets/v2/account",
+            status_code=429,
+            # No Retry-After header
+        )
+
+        result = await accounts_api.get_account(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderRateLimitError)
+        assert result.error.retry_after is None
+
+
+# =============================================================================
+# AlpacaTransactionsAPI - Error Handling Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAlpacaTransactionsAPIErrorHandling:
+    """Tests for AlpacaTransactionsAPI error handling."""
+
+    async def test_get_transactions_timeout(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Timeout returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.TimeoutException("Connection timed out"),
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_transactions_connection_error(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Connection error returns ProviderUnavailableError."""
+        import httpx
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection refused"),
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_get_transactions_invalid_json(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Invalid JSON returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            content=b"not valid json",
+            status_code=200,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_transactions_unexpected_status_code(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Unexpected status code returns ProviderInvalidResponseError."""
+        from src.domain.errors import ProviderInvalidResponseError
+
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            status_code=418,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderInvalidResponseError)
+
+    async def test_get_transactions_dict_response_wrapped_as_list(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """Dict response is wrapped as single-item list."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            json={"id": "txn123", "activity_type": "DIV"},  # Single dict
+            status_code=200,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 1
+
+    async def test_get_transactions_rate_limited_no_retry_after(
+        self,
+        transactions_api: AlpacaTransactionsAPI,
+        api_credentials: tuple[str, str],
+        httpx_mock,
+    ):
+        """429 without Retry-After returns None."""
+        api_key, api_secret = api_credentials
+        httpx_mock.add_response(
+            url=re.compile(
+                r"https://paper-api\.alpaca\.markets/v2/account/activities.*"
+            ),
+            status_code=429,
+        )
+
+        result = await transactions_api.get_transactions(api_key, api_secret)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderRateLimitError)
+        assert result.error.retry_after is None

--- a/tests/unit/test_infrastructure_alpaca_mappers.py
+++ b/tests/unit/test_infrastructure_alpaca_mappers.py
@@ -1,0 +1,884 @@
+"""Unit tests for Alpaca mappers.
+
+Tests for:
+- AlpacaAccountMapper: JSON → ProviderAccountData
+- AlpacaHoldingMapper: JSON → ProviderHoldingData
+- AlpacaTransactionMapper: JSON → ProviderTransactionData
+
+These mappers contain Alpaca-specific knowledge and are critical
+for accurate data transformation.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.infrastructure.providers.alpaca.mappers.account_mapper import (
+    AlpacaAccountMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.holding_mapper import (
+    AlpacaHoldingMapper,
+)
+from src.infrastructure.providers.alpaca.mappers.transaction_mapper import (
+    AlpacaTransactionMapper,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def account_mapper() -> AlpacaAccountMapper:
+    """Create AlpacaAccountMapper instance."""
+    return AlpacaAccountMapper()
+
+
+@pytest.fixture
+def holding_mapper() -> AlpacaHoldingMapper:
+    """Create AlpacaHoldingMapper instance."""
+    return AlpacaHoldingMapper()
+
+
+@pytest.fixture
+def transaction_mapper() -> AlpacaTransactionMapper:
+    """Create AlpacaTransactionMapper instance."""
+    return AlpacaTransactionMapper()
+
+
+# =============================================================================
+# Account Mapper Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAlpacaAccountMapper:
+    """Tests for AlpacaAccountMapper."""
+
+    def test_map_account_valid_data(self, account_mapper: AlpacaAccountMapper):
+        """Map valid Alpaca account JSON to ProviderAccountData."""
+        data = {
+            "account_number": "PA3CRCJ7QUIR",
+            "status": "ACTIVE",
+            "currency": "USD",
+            "equity": "150000.50",
+            "buying_power": "300000.00",
+            "cash": "50000.00",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.provider_account_id == "PA3CRCJ7QUIR"
+        assert result.account_number_masked == "****QUIR"
+        assert result.balance == Decimal("150000.50")
+        assert result.available_balance == Decimal("300000.00")
+        assert result.currency == "USD"
+        assert result.is_active is True
+        assert "Paper" in result.name  # PA prefix = Paper account
+
+    def test_map_account_live_account(self, account_mapper: AlpacaAccountMapper):
+        """Map live account (non-PA prefix) correctly."""
+        data = {
+            "account_number": "123456789ABC",
+            "status": "ACTIVE",
+            "equity": "100000",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert "Live" in result.name  # Non-PA prefix = Live account
+
+    def test_map_account_inactive_status(self, account_mapper: AlpacaAccountMapper):
+        """Map inactive account status correctly."""
+        data = {
+            "account_number": "PA123",
+            "status": "INACTIVE",
+            "equity": "0",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.is_active is False
+
+    def test_map_account_missing_account_number(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Return None when account_number is missing."""
+        data = {
+            "status": "ACTIVE",
+            "equity": "100000",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is None
+
+    def test_map_account_empty_account_number(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Return None when account_number is empty string."""
+        data = {
+            "account_number": "",
+            "status": "ACTIVE",
+            "equity": "100000",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is None
+
+    def test_map_account_handles_missing_optional_fields(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Handle missing optional fields gracefully."""
+        data = {
+            "account_number": "PA123",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.balance == Decimal("0")
+        assert result.currency == "USD"
+
+    def test_map_account_invalid_decimal_values(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Handle invalid decimal values gracefully."""
+        data = {
+            "account_number": "PA123",
+            "equity": "not_a_number",
+            "buying_power": None,
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.balance == Decimal("0")
+
+    def test_map_account_preserves_raw_data(self, account_mapper: AlpacaAccountMapper):
+        """Preserve raw JSON data in result."""
+        data = {
+            "account_number": "PA123",
+            "equity": "100000",
+            "extra_field": "extra_value",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.raw_data == data
+
+    def test_map_account_short_account_number(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Handle short account numbers (less than 4 chars) in masking."""
+        data = {
+            "account_number": "PA1",
+            "equity": "100",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.account_number_masked == "****PA1"
+
+    def test_map_account_uses_cash_when_no_buying_power(
+        self, account_mapper: AlpacaAccountMapper
+    ):
+        """Use cash as available_balance when buying_power is missing."""
+        data = {
+            "account_number": "PA123",
+            "equity": "100000",
+            "cash": "25000.50",
+        }
+
+        result = account_mapper.map_account(data)
+
+        assert result is not None
+        assert result.available_balance == Decimal("25000.50")
+
+    def test_map_account_exception_handling(self, account_mapper: AlpacaAccountMapper):
+        """Return None when mapping raises exception (catches TypeError, etc.)."""
+        # Pass None as dict to trigger AttributeError on .get()
+        # This tests the try/except block in map_account
+        result = account_mapper.map_account(None)  # type: ignore
+
+        # Should return None due to exception handling, not crash
+        assert result is None
+
+
+# =============================================================================
+# Holding Mapper Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAlpacaHoldingMapper:
+    """Tests for AlpacaHoldingMapper."""
+
+    def test_map_holding_valid_data(self, holding_mapper: AlpacaHoldingMapper):
+        """Map valid Alpaca position JSON to ProviderHoldingData."""
+        data = {
+            "asset_id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+            "symbol": "AAPL",
+            "asset_class": "us_equity",
+            "qty": "100",
+            "avg_entry_price": "150.25",
+            "market_value": "15500.00",
+            "cost_basis": "15025.00",
+            "current_price": "155.00",
+            "side": "long",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.provider_holding_id == "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415"
+        assert result.symbol == "AAPL"
+        assert result.quantity == Decimal("100")
+        assert result.cost_basis == Decimal("15025.00")
+        assert result.market_value == Decimal("15500.00")
+        assert result.current_price == Decimal("155.00")
+        assert result.asset_type == "equity"
+
+    def test_map_holding_short_position(self, holding_mapper: AlpacaHoldingMapper):
+        """Map short position with negative quantity."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "TSLA",
+            "qty": "50",
+            "side": "short",
+            "cost_basis": "10000",
+            "market_value": "9000",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.quantity == Decimal("-50")  # Negative for short
+
+    def test_map_holding_crypto_asset(self, holding_mapper: AlpacaHoldingMapper):
+        """Map cryptocurrency holding with correct asset type."""
+        data = {
+            "asset_id": "crypto123",
+            "symbol": "BTC/USD",
+            "asset_class": "crypto",
+            "qty": "0.5",
+            "cost_basis": "25000",
+            "market_value": "30000",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.asset_type == "cryptocurrency"
+
+    def test_map_holding_zero_quantity_skipped(
+        self, holding_mapper: AlpacaHoldingMapper
+    ):
+        """Skip positions with zero quantity."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "AAPL",
+            "qty": "0",
+            "cost_basis": "0",
+            "market_value": "0",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is None
+
+    def test_map_holding_missing_symbol(self, holding_mapper: AlpacaHoldingMapper):
+        """Return None when symbol is missing."""
+        data = {
+            "asset_id": "abc123",
+            "qty": "100",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is None
+
+    def test_map_holding_unknown_asset_class(self, holding_mapper: AlpacaHoldingMapper):
+        """Map unknown asset class to 'other'."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "UNKNOWN",
+            "asset_class": "future_asset_type",
+            "qty": "10",
+            "cost_basis": "1000",
+            "market_value": "1100",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.asset_type == "other"
+
+    def test_map_holdings_list(self, holding_mapper: AlpacaHoldingMapper):
+        """Map list of positions, skipping invalid ones."""
+        data_list = [
+            {
+                "asset_id": "1",
+                "symbol": "AAPL",
+                "qty": "100",
+                "cost_basis": "15000",
+                "market_value": "16000",
+            },
+            {"asset_id": "2", "symbol": "", "qty": "50"},  # Invalid - no symbol
+            {
+                "asset_id": "3",
+                "symbol": "GOOGL",
+                "qty": "10",
+                "cost_basis": "28000",
+                "market_value": "29000",
+            },
+        ]
+
+        results = holding_mapper.map_holdings(data_list)
+
+        assert len(results) == 2
+        assert results[0].symbol == "AAPL"
+        assert results[1].symbol == "GOOGL"
+
+    def test_map_holding_fallback_asset_id(self, holding_mapper: AlpacaHoldingMapper):
+        """Use symbol as asset_id fallback when asset_id is missing."""
+        data = {
+            "symbol": "MSFT",
+            "qty": "25",
+            "cost_basis": "10000",
+            "market_value": "11000",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.provider_holding_id == "alpaca_MSFT"
+
+    def test_map_holding_empty_asset_class(self, holding_mapper: AlpacaHoldingMapper):
+        """Handle empty asset class string."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "TEST",
+            "asset_class": "",
+            "qty": "10",
+            "cost_basis": "1000",
+            "market_value": "1100",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.asset_type == "other"
+
+    def test_map_holding_invalid_decimal_value(
+        self, holding_mapper: AlpacaHoldingMapper
+    ):
+        """Handle invalid decimal values in holding data."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "AAPL",
+            "qty": "100",
+            "cost_basis": "not_a_number",  # Invalid decimal
+            "market_value": "invalid",  # Invalid decimal
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.cost_basis == Decimal("0")
+        assert result.market_value == Decimal("0")
+
+    def test_map_holding_invalid_optional_decimal(
+        self, holding_mapper: AlpacaHoldingMapper
+    ):
+        """Handle invalid optional decimal values (returns None)."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "AAPL",
+            "qty": "100",
+            "cost_basis": "15000",
+            "market_value": "16000",
+            "avg_entry_price": "not_a_number",  # Invalid optional
+            "current_price": "also_invalid",  # Invalid optional
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        assert result is not None
+        assert result.average_price is None
+        assert result.current_price is None
+
+    def test_map_holding_exception_handling(self, holding_mapper: AlpacaHoldingMapper):
+        """Return None when mapping raises exception."""
+        # Pass None as dict to trigger AttributeError on .get()
+        # This tests the try/except block in map_holding
+        result = holding_mapper.map_holding(None)  # type: ignore
+
+        # Should return None due to exception handling
+        assert result is None
+
+    def test_map_holding_none_quantity(self, holding_mapper: AlpacaHoldingMapper):
+        """Handle None quantity value."""
+        data = {
+            "asset_id": "abc123",
+            "symbol": "AAPL",
+            "qty": None,
+            "cost_basis": "15000",
+            "market_value": "16000",
+        }
+
+        result = holding_mapper.map_holding(data)
+
+        # Zero quantity should be skipped
+        assert result is None
+
+
+# =============================================================================
+# Transaction Mapper Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAlpacaTransactionMapper:
+    """Tests for AlpacaTransactionMapper."""
+
+    def test_map_trade_fill(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map trade fill activity to ProviderTransactionData."""
+        data = {
+            "id": "20210301000000000::8c51c51d-2ccb-4a7c-9bc1-f31b0a7b0ae9",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T09:30:00Z",
+            "symbol": "AAPL",
+            "side": "buy",
+            "qty": "100",
+            "price": "150.25",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.provider_transaction_id == data["id"]
+        assert result.transaction_type == "trade"
+        assert result.subtype == "buy"
+        assert result.symbol == "AAPL"
+        assert result.quantity == Decimal("100")
+        assert result.unit_price == Decimal("150.25")
+        assert result.amount < 0  # Buy = negative (cash outflow)
+        assert result.transaction_date == date(2021, 3, 1)
+
+    def test_map_trade_sell(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map sell trade with positive amount."""
+        data = {
+            "id": "sell123",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T10:00:00Z",
+            "symbol": "AAPL",
+            "side": "sell",
+            "qty": "50",
+            "price": "160.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.subtype == "sell"
+        assert result.amount > 0  # Sell = positive (cash inflow)
+        assert result.amount == Decimal("8000")  # 50 * 160
+
+    def test_map_dividend_activity(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map dividend activity to ProviderTransactionData."""
+        data = {
+            "id": "div123",
+            "activity_type": "DIV",
+            "date": "2021-06-15",
+            "net_amount": "125.50",
+            "symbol": "AAPL",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "income"
+        assert result.subtype == "dividend"
+        assert result.amount == Decimal("125.50")
+        assert result.transaction_date == date(2021, 6, 15)
+
+    def test_map_journal_cash_transfer(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Map journal cash transfer activity."""
+        data = {
+            "id": "jnl123",
+            "activity_type": "JNLC",
+            "date": "2021-10-25",
+            "net_amount": "100000.00",
+            "status": "executed",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "transfer"
+        assert result.subtype == "journal_cash"
+        assert result.amount == Decimal("100000.00")
+
+    def test_map_interest_activity(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map interest activity to ProviderTransactionData."""
+        data = {
+            "id": "int123",
+            "activity_type": "INT",
+            "date": "2021-12-31",
+            "net_amount": "15.75",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "income"
+        assert result.subtype == "interest"
+
+    def test_map_transaction_missing_id(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Return None when transaction ID is missing."""
+        data = {
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T09:30:00Z",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is None
+
+    def test_map_transaction_missing_date(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Return None when date cannot be parsed."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            # No date fields
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is None
+
+    def test_map_transaction_unknown_activity_type(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Map unknown activity type to 'other'."""
+        data = {
+            "id": "txn123",
+            "activity_type": "FUTURE_TYPE",
+            "date": "2021-12-01",
+            "net_amount": "50.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "other"
+
+    def test_map_transactions_list(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map list of activities, skipping invalid ones."""
+        data_list = [
+            {
+                "id": "1",
+                "activity_type": "DIV",
+                "date": "2021-06-15",
+                "net_amount": "100",
+            },
+            {"activity_type": "DIV", "date": "2021-06-16"},  # Invalid - no ID
+            {
+                "id": "3",
+                "activity_type": "INT",
+                "date": "2021-06-17",
+                "net_amount": "25",
+            },
+        ]
+
+        results = transaction_mapper.map_transactions(data_list)
+
+        assert len(results) == 2
+        assert results[0].provider_transaction_id == "1"
+        assert results[1].provider_transaction_id == "3"
+
+    def test_map_trade_short_sell(self, transaction_mapper: AlpacaTransactionMapper):
+        """Map short sell trade correctly."""
+        data = {
+            "id": "short123",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T10:00:00Z",
+            "symbol": "TSLA",
+            "side": "sell_short",
+            "qty": "20",
+            "price": "700.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.subtype == "short_sell"
+        assert result.amount > 0  # Short sell = cash inflow
+
+    def test_map_transaction_preserves_raw_data(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Preserve raw JSON data in result."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "date": "2021-06-15",
+            "net_amount": "100",
+            "extra_field": "extra_value",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.raw_data == data
+
+    def test_map_trade_commission_is_zero(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Alpaca is commission-free, verify commission is zero."""
+        data = {
+            "id": "trade123",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T09:30:00Z",
+            "symbol": "AAPL",
+            "side": "buy",
+            "qty": "10",
+            "price": "100.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.commission == Decimal("0")
+
+    def test_map_transaction_empty_activity_type(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle empty activity type string."""
+        data = {
+            "id": "txn123",
+            "activity_type": "",
+            "date": "2021-06-15",
+            "net_amount": "100",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "other"
+
+    def test_map_transaction_empty_side(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle empty trade side string."""
+        data = {
+            "id": "trade123",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T09:30:00Z",
+            "symbol": "AAPL",
+            "side": "",  # Empty side
+            "qty": "10",
+            "price": "100.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.subtype is None  # Empty side returns None
+
+    def test_map_transaction_invalid_decimal(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle invalid decimal in transaction amount."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "date": "2021-06-15",
+            "net_amount": "not_a_number",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.amount == Decimal("0")
+
+    def test_map_transaction_created_at_fallback(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Parse date from created_at field as fallback."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "created_at": "2021-06-15T12:00:00Z",  # Use created_at as fallback
+            "net_amount": "100",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_date == date(2021, 6, 15)
+
+    def test_map_transaction_invalid_date_format(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle invalid date format returns None."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "date": "not-a-date",
+            "net_amount": "100",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is None  # Invalid date, no fallback
+
+    def test_map_transaction_invalid_transaction_time(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle invalid transaction_time format falls through to date field."""
+        data = {
+            "id": "trade123",
+            "activity_type": "FILL",
+            "transaction_time": "invalid-timestamp",
+            "date": "2021-03-01",  # Falls through to date field
+            "symbol": "AAPL",
+            "side": "buy",
+            "qty": "10",
+            "price": "100.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_date == date(2021, 3, 1)
+
+    def test_map_transaction_buy_to_cover(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Map buy_to_cover trade as negative amount."""
+        data = {
+            "id": "cover123",
+            "activity_type": "FILL",
+            "transaction_time": "2021-03-01T10:00:00Z",
+            "symbol": "TSLA",
+            "side": "buy_to_cover",
+            "qty": "20",
+            "price": "650.00",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.subtype == "buy_to_cover"
+        assert result.amount < 0  # Buy to cover = cash outflow
+
+    def test_map_transaction_generates_description(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Generate description when none provided."""
+        data = {
+            "id": "jnl123",
+            "activity_type": "JNLC",
+            "date": "2021-10-25",
+            "net_amount": "5000.00",
+            # No description field
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert "Journal entry (cash)" in result.description
+
+    def test_map_transaction_generates_negative_description(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Generate description for negative amount."""
+        data = {
+            "id": "wire123",
+            "activity_type": "WIRE",
+            "date": "2021-10-25",
+            "net_amount": "-1000.00",
+            # No description field
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert "Wire transfer" in result.description
+        assert "-$" in result.description
+
+    def test_map_transaction_exception_handling(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Return None when mapping raises exception."""
+        # Pass None as dict to trigger AttributeError on .get()
+        # This tests the try/except block in map_transaction
+        result = transaction_mapper.map_transaction(None)  # type: ignore
+
+        # Should return None due to exception handling
+        assert result is None
+
+    def test_map_transaction_journal_stock(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Map journal stock transfer activity."""
+        data = {
+            "id": "jnls123",
+            "activity_type": "JNLS",
+            "date": "2021-10-25",
+            "net_amount": "0",  # Stock transfers have no cash amount
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.transaction_type == "transfer"
+        assert result.subtype == "journal_stock"
+
+    def test_map_transaction_invalid_created_at_fallback(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Invalid created_at date falls through, returns None."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "created_at": "invalid-date",  # Invalid created_at
+            "net_amount": "100",
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        # No valid date found, returns None
+        assert result is None
+
+    def test_map_transaction_none_net_amount(
+        self, transaction_mapper: AlpacaTransactionMapper
+    ):
+        """Handle None net_amount value."""
+        data = {
+            "id": "txn123",
+            "activity_type": "DIV",
+            "date": "2021-06-15",
+            "net_amount": None,  # Explicit None
+        }
+
+        result = transaction_mapper.map_transaction(data)
+
+        assert result is not None
+        assert result.amount == Decimal("0")

--- a/tests/unit/test_infrastructure_alpaca_provider.py
+++ b/tests/unit/test_infrastructure_alpaca_provider.py
@@ -1,0 +1,492 @@
+"""Unit tests for AlpacaProvider.
+
+Tests for:
+- fetch_accounts: Fetching account data via API
+- fetch_transactions: Fetching transaction data via API
+- fetch_holdings: Fetching holdings data via API
+- validate_credentials: Validating API credentials
+
+Uses mocked API clients to test provider orchestration logic.
+"""
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.core.config import Settings
+from src.core.result import Failure, Success
+from src.domain.errors import ProviderAuthenticationError, ProviderUnavailableError
+from src.domain.protocols.provider_protocol import (
+    ProviderAccountData,
+    ProviderHoldingData,
+    ProviderTransactionData,
+)
+from src.infrastructure.providers.alpaca.alpaca_provider import AlpacaProvider
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_settings() -> MagicMock:
+    """Create mock settings."""
+    settings = MagicMock(spec=Settings)
+    settings.alpaca_api_base_url = "https://paper-api.alpaca.markets"
+    return settings
+
+
+@pytest.fixture
+def mock_accounts_api() -> AsyncMock:
+    """Create mock AlpacaAccountsAPI."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_transactions_api() -> AsyncMock:
+    """Create mock AlpacaTransactionsAPI."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def provider(
+    mock_settings: MagicMock,
+    mock_accounts_api: AsyncMock,
+    mock_transactions_api: AsyncMock,
+) -> AlpacaProvider:
+    """Create AlpacaProvider with mocked dependencies."""
+    provider = AlpacaProvider(settings=mock_settings)
+    # Inject mocked API clients
+    provider._accounts_api = mock_accounts_api
+    provider._transactions_api = mock_transactions_api
+    return provider
+
+
+@pytest.fixture
+def valid_credentials() -> dict:
+    """Valid API credentials dict."""
+    return {"api_key": "PKTEST123", "api_secret": "secret456"}
+
+
+@pytest.fixture
+def sample_account_json() -> dict:
+    """Sample Alpaca account JSON response."""
+    return {
+        "account_number": "PA3CRCJ7QUIR",
+        "status": "ACTIVE",
+        "currency": "USD",
+        "equity": "150000.50",
+        "buying_power": "300000.00",
+        "cash": "50000.00",
+    }
+
+
+@pytest.fixture
+def sample_position_json() -> dict:
+    """Sample Alpaca position JSON response."""
+    return {
+        "asset_id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+        "symbol": "AAPL",
+        "asset_class": "us_equity",
+        "qty": "100",
+        "avg_entry_price": "150.25",
+        "market_value": "15500.00",
+        "cost_basis": "15025.00",
+        "current_price": "155.00",
+        "side": "long",
+    }
+
+
+@pytest.fixture
+def sample_activity_json() -> dict:
+    """Sample Alpaca activity JSON response."""
+    return {
+        "id": "20210301000000000::8c51c51d-2ccb-4a7c-9bc1-f31b0a7b0ae9",
+        "activity_type": "FILL",
+        "transaction_time": "2021-03-01T09:30:00Z",
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100",
+        "price": "150.25",
+    }
+
+
+# =============================================================================
+# Provider Slug Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestProviderSlug:
+    """Tests for provider slug property."""
+
+    def test_slug_is_alpaca(self, provider: AlpacaProvider):
+        """Provider slug should be 'alpaca'."""
+        assert provider.slug == "alpaca"
+
+
+# =============================================================================
+# Fetch Accounts Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFetchAccounts:
+    """Tests for AlpacaProvider.fetch_accounts."""
+
+    async def test_fetch_accounts_success(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+        sample_account_json: dict,
+    ):
+        """Successfully fetch accounts returns ProviderAccountData."""
+        mock_accounts_api.get_account.return_value = Success(value=sample_account_json)
+
+        result = await provider.fetch_accounts(valid_credentials)
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 1
+        account = result.value[0]
+        assert isinstance(account, ProviderAccountData)
+        assert account.provider_account_id == "PA3CRCJ7QUIR"
+        assert account.balance == Decimal("150000.50")
+
+    async def test_fetch_accounts_api_auth_failure(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """API authentication failure returns Failure."""
+        error = ProviderAuthenticationError(
+            code="PROVIDER_AUTH_FAILED",
+            message="Invalid credentials",
+            provider_name="alpaca",
+            is_token_expired=False,
+        )
+        mock_accounts_api.get_account.return_value = Failure(error=error)
+
+        result = await provider.fetch_accounts(valid_credentials)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+    async def test_fetch_accounts_api_unavailable(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """API unavailable returns Failure."""
+        error = ProviderUnavailableError(
+            code="PROVIDER_UNAVAILABLE",
+            message="API timeout",
+            provider_name="alpaca",
+            is_transient=True,
+        )
+        mock_accounts_api.get_account.return_value = Failure(error=error)
+
+        result = await provider.fetch_accounts(valid_credentials)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderUnavailableError)
+
+    async def test_fetch_accounts_empty_credentials(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+    ):
+        """Empty credentials dict is passed to API."""
+        mock_accounts_api.get_account.return_value = Success(
+            value={"account_number": "PA123", "status": "ACTIVE", "equity": "0"}
+        )
+
+        await provider.fetch_accounts({})
+
+        # API should be called with empty strings
+        mock_accounts_api.get_account.assert_called_once_with(api_key="", api_secret="")
+
+    async def test_fetch_accounts_invalid_response_returns_empty_list(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Invalid account data returns empty list (mapper returns None)."""
+        # Response with no account_number will fail mapping
+        mock_accounts_api.get_account.return_value = Success(
+            value={"status": "ACTIVE", "equity": "100000"}
+        )
+
+        result = await provider.fetch_accounts(valid_credentials)
+
+        assert isinstance(result, Success)
+        assert result.value == []
+
+
+# =============================================================================
+# Fetch Holdings Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFetchHoldings:
+    """Tests for AlpacaProvider.fetch_holdings."""
+
+    async def test_fetch_holdings_success(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+        sample_position_json: dict,
+    ):
+        """Successfully fetch holdings returns ProviderHoldingData."""
+        mock_accounts_api.get_positions.return_value = Success(
+            value=[sample_position_json]
+        )
+
+        result = await provider.fetch_holdings(valid_credentials, "PA123")
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 1
+        holding = result.value[0]
+        assert isinstance(holding, ProviderHoldingData)
+        assert holding.symbol == "AAPL"
+        assert holding.quantity == Decimal("100")
+
+    async def test_fetch_holdings_empty_positions(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Empty positions returns empty list."""
+        mock_accounts_api.get_positions.return_value = Success(value=[])
+
+        result = await provider.fetch_holdings(valid_credentials, "PA123")
+
+        assert isinstance(result, Success)
+        assert result.value == []
+
+    async def test_fetch_holdings_api_failure(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """API failure returns Failure."""
+        error = ProviderAuthenticationError(
+            code="PROVIDER_AUTH_FAILED",
+            message="Invalid credentials",
+            provider_name="alpaca",
+            is_token_expired=False,
+        )
+        mock_accounts_api.get_positions.return_value = Failure(error=error)
+
+        result = await provider.fetch_holdings(valid_credentials, "PA123")
+
+        assert isinstance(result, Failure)
+
+    async def test_fetch_holdings_multiple_positions(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Multiple positions are all mapped."""
+        positions = [
+            {
+                "asset_id": "1",
+                "symbol": "AAPL",
+                "qty": "100",
+                "cost_basis": "15000",
+                "market_value": "16000",
+            },
+            {
+                "asset_id": "2",
+                "symbol": "GOOGL",
+                "qty": "50",
+                "cost_basis": "70000",
+                "market_value": "75000",
+            },
+        ]
+        mock_accounts_api.get_positions.return_value = Success(value=positions)
+
+        result = await provider.fetch_holdings(valid_credentials, "PA123")
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 2
+
+
+# =============================================================================
+# Fetch Transactions Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFetchTransactions:
+    """Tests for AlpacaProvider.fetch_transactions."""
+
+    async def test_fetch_transactions_success(
+        self,
+        provider: AlpacaProvider,
+        mock_transactions_api: AsyncMock,
+        valid_credentials: dict,
+        sample_activity_json: dict,
+    ):
+        """Successfully fetch transactions returns ProviderTransactionData."""
+        mock_transactions_api.get_transactions.return_value = Success(
+            value=[sample_activity_json]
+        )
+
+        result = await provider.fetch_transactions(valid_credentials, "PA123")
+
+        assert isinstance(result, Success)
+        assert len(result.value) == 1
+        txn = result.value[0]
+        assert isinstance(txn, ProviderTransactionData)
+        assert txn.symbol == "AAPL"
+        assert txn.transaction_type == "trade"
+
+    async def test_fetch_transactions_with_date_range(
+        self,
+        provider: AlpacaProvider,
+        mock_transactions_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Date range is passed to API."""
+        mock_transactions_api.get_transactions.return_value = Success(value=[])
+        start = date(2021, 1, 1)
+        end = date(2021, 12, 31)
+
+        await provider.fetch_transactions(
+            valid_credentials, "PA123", start_date=start, end_date=end
+        )
+
+        mock_transactions_api.get_transactions.assert_called_once()
+        call_kwargs = mock_transactions_api.get_transactions.call_args[1]
+        assert call_kwargs["start_date"] == start
+        assert call_kwargs["end_date"] == end
+
+    async def test_fetch_transactions_empty(
+        self,
+        provider: AlpacaProvider,
+        mock_transactions_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Empty transactions returns empty list."""
+        mock_transactions_api.get_transactions.return_value = Success(value=[])
+
+        result = await provider.fetch_transactions(valid_credentials, "PA123")
+
+        assert isinstance(result, Success)
+        assert result.value == []
+
+    async def test_fetch_transactions_api_failure(
+        self,
+        provider: AlpacaProvider,
+        mock_transactions_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """API failure returns Failure."""
+        error = ProviderUnavailableError(
+            code="PROVIDER_UNAVAILABLE",
+            message="Timeout",
+            provider_name="alpaca",
+            is_transient=True,
+        )
+        mock_transactions_api.get_transactions.return_value = Failure(error=error)
+
+        result = await provider.fetch_transactions(valid_credentials, "PA123")
+
+        assert isinstance(result, Failure)
+
+
+# =============================================================================
+# Validate Credentials Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestValidateCredentials:
+    """Tests for AlpacaProvider.validate_credentials."""
+
+    async def test_validate_credentials_success(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+        sample_account_json: dict,
+    ):
+        """Valid credentials return Success(True)."""
+        mock_accounts_api.get_account.return_value = Success(value=sample_account_json)
+
+        result = await provider.validate_credentials(valid_credentials)
+
+        assert isinstance(result, Success)
+        assert result.value is True
+
+    async def test_validate_credentials_failure(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+        valid_credentials: dict,
+    ):
+        """Invalid credentials return Failure."""
+        error = ProviderAuthenticationError(
+            code="PROVIDER_AUTH_FAILED",
+            message="Invalid API credentials",
+            provider_name="alpaca",
+            is_token_expired=False,
+        )
+        mock_accounts_api.get_account.return_value = Failure(error=error)
+
+        result = await provider.validate_credentials(valid_credentials)
+
+        assert isinstance(result, Failure)
+        assert isinstance(result.error, ProviderAuthenticationError)
+
+
+# =============================================================================
+# Credentials Extraction Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCredentialsExtraction:
+    """Tests for credential extraction from dict."""
+
+    async def test_extracts_api_key_from_credentials(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+    ):
+        """API key is extracted from credentials dict."""
+        mock_accounts_api.get_account.return_value = Success(
+            value={"account_number": "PA123", "status": "ACTIVE", "equity": "0"}
+        )
+
+        await provider.fetch_accounts({"api_key": "MY_KEY", "api_secret": "MY_SECRET"})
+
+        mock_accounts_api.get_account.assert_called_once_with(
+            api_key="MY_KEY", api_secret="MY_SECRET"
+        )
+
+    async def test_missing_credentials_default_to_empty_string(
+        self,
+        provider: AlpacaProvider,
+        mock_accounts_api: AsyncMock,
+    ):
+        """Missing credentials default to empty strings."""
+        mock_accounts_api.get_account.return_value = Success(
+            value={"account_number": "PA123", "status": "ACTIVE", "equity": "0"}
+        )
+
+        await provider.fetch_accounts({"other_field": "value"})
+
+        mock_accounts_api.get_account.assert_called_once_with(api_key="", api_secret="")

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "dashtam"
-version = "1.2.1"
+version = "1.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Implement Alpaca Trading API provider with API Key authentication - the first non-OAuth provider in Dashtam.

## Changes

### Infrastructure
- `AlpacaProvider` adapter implementing auth-agnostic `ProviderProtocol`
- `AlpacaAccountsAPI` client for account and positions endpoints
- `AlpacaTransactionsAPI` client for activities endpoint
- Account, Holding, Transaction mappers with comprehensive field mapping

### Features
- API Key authentication via custom headers (`APCA-API-KEY-ID`, `APCA-API-SECRET-KEY`)
- Paper (`paper-api.alpaca.markets`) and Live (`api.alpaca.markets`) environment support
- Account sync (single account per API key)
- Holdings/positions sync with asset type mapping
- Transaction/activities sync with activity type classification

### Tests
- 101 tests with **100% coverage** on all Alpaca provider code
- Unit tests for mappers (account, holding, transaction)
- Unit tests for provider (fetch_accounts, fetch_transactions, fetch_holdings, validate_credentials)
- Integration tests for API clients with pytest-httpx

### Documentation
- Added "Phase 3b: API-Key Provider Implementation" section to `adding-new-providers.md`
- Complete Alpaca provider example as reference implementation
- Key differences table comparing OAuth vs API-Key providers

### Version & Release
- Bumped version to v1.3.0 (minor - new feature)
- Updated CHANGELOG.md with release notes
- Updated WARP.md with F7.1 completion status

## Coverage

| Component | Target | Actual |
|-----------|--------|--------|
| Provider adapter | 90% | **100%** |
| Account mapper | 95% | **100%** |
| Holding mapper | 95% | **100%** |
| Transaction mapper | 95% | **100%** |
| API clients | 85% | **100%** |

## Verification

- [x] `make lint` - All checks passed
- [x] `make format` - Applied
- [x] `make type-check` - No issues
- [x] `make test` - 101 Alpaca tests pass (100% coverage)
- [x] `make lint-md` - Zero violations
- [x] `make docs-build` - Zero warnings

Co-Authored-By: Warp <agent@warp.dev>