### PR TITLE
docs(architecture): add core architecture documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2025-12-30
+
+### Documentation
+
+- **Core Architecture Documentation Completion**
+  - Created `docs/architecture/hexagonal-architecture.md` (1,451 lines) - Complete hexagonal architecture theory including dependency rule, layer boundaries, ports & adapters pattern, benefits vs monolithic architecture, testing strategies, and integration with CQRS/DDD/Protocol patterns
+  - Created `docs/architecture/protocol-based-architecture.md` (1,340 lines) - Comprehensive Protocol pattern guide covering structural vs nominal typing, why Protocol over ABC, Protocol implementations across Dashtam (repositories, services, providers), testing with Protocols, mypy type checking, common pitfalls and solutions
+  - Created `docs/architecture/domain-driven-design-architecture.md` (1,268 lines) - Pragmatic DDD philosophy including what "pragmatic" means for Dashtam, DDD patterns used (entities, value objects, domain events, repositories), DDD patterns NOT used and why, integration with hexagonal/CQRS/Protocol/Event Registry, when to emit domain events, entity vs value object decision tree, domain vs application services boundary
+  - Updated `docs/architecture/directory-structure.md` - Synchronized with v1.5.1 state including modularized container structure, complete event registry (69 events), and updated schemas section (3 new schema files)
+  - Updated `docs/index.md` - Reorganized "Core Architecture" section to highlight 5 core architectures: Hexagonal, Protocol-Based, Domain-Driven Design, CQRS, Event Registry (updated last modified: 2025-12-30)
+  - Updated `mkdocs.yml` - Added 3 new architecture docs to navigation in alphabetical order
+  - Updated `WARP.md` Section 21 (Key Technical Decisions) - Added cross-references to new architecture docs with explanations (updated last modified: 2025-12-30)
+
+### Changed
+
+- Total architecture documentation now covers 5 core architectural patterns with comprehensive standalone docs for each
+- All new architecture docs follow Dashtam documentation patterns: Overview with Purpose/Problem/Solution, horizontal rules between sections, Mermaid diagrams, real code examples, references to related docs, metadata at bottom
+
 ## [1.5.1] - 2025-12-28
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ keys-validate:
 
 dev-up: _check-traefik _ensure-env-dev
 	@echo "🚀 Starting DEVELOPMENT environment..."
-	@docker compose -f compose/docker-compose.dev.yml up -d
+	@docker compose -f compose/docker-compose.dev.yml up -d --remove-orphans
 	@echo ""
 	@echo "📦 Syncing dependencies (including MkDocs)..."
 	@docker compose -f compose/docker-compose.dev.yml exec -T app uv sync --all-groups > /dev/null 2>&1 || docker compose -f compose/docker-compose.dev.yml exec app uv sync --all-groups
@@ -215,7 +215,7 @@ dev-rebuild: _check-traefik _ensure-env-dev
 	@docker compose -f compose/docker-compose.dev.yml build --no-cache
 	@echo "📦 Restarting with fresh dependencies..."
 	@docker compose -f compose/docker-compose.dev.yml down
-	@docker compose -f compose/docker-compose.dev.yml up -d
+	@docker compose -f compose/docker-compose.dev.yml up -d --remove-orphans
 	@echo "📦 Syncing dependencies (including MkDocs)..."
 	@docker compose -f compose/docker-compose.dev.yml exec -T app uv sync --all-groups > /dev/null 2>&1 || docker compose -f compose/docker-compose.dev.yml exec app uv sync --all-groups
 	@echo "✅ Development containers rebuilt"
@@ -226,7 +226,7 @@ dev-rebuild: _check-traefik _ensure-env-dev
 
 test-up: _check-traefik _ensure-env-test
 	@echo "🧪 Starting TEST environment..."
-	@docker compose -f compose/docker-compose.test.yml up -d
+	@docker compose -f compose/docker-compose.test.yml up -d --remove-orphans
 	@sleep 3
 	@echo ""
 	@echo "✅ Test services started!"
@@ -319,7 +319,7 @@ ci-test-local: _ensure-env-ci
 	@echo "🤖 Running FULL CI suite locally (tests + lint + type-check)..."
 	@echo ""
 	@echo "📝 Step 1: Starting CI environment..."
-	@docker compose -f compose/docker-compose.ci.yml up -d --build
+	@docker compose -f compose/docker-compose.ci.yml up -d --build --remove-orphans
 	@echo ""
 	@echo "⏳ Step 2: Waiting for services..."
 	@sleep 3
@@ -352,7 +352,7 @@ ci-test: _ensure-env-ci
 	@echo "🤖 Running CI tests (matches GitHub Actions test-main job)..."
 	@echo ""
 	@echo "📝 Starting CI environment..."
-	@docker compose -f compose/docker-compose.ci.yml up -d --build
+	@docker compose -f compose/docker-compose.ci.yml up -d --build --remove-orphans
 	@echo ""
 	@echo "⏳ Waiting for services..."
 	@sleep 3
@@ -376,7 +376,7 @@ ci-lint: _ensure-env-ci
 	@echo "🔍 Running CI linting (matches GitHub Actions lint job)..."
 	@echo ""
 	@echo "📝 Starting CI environment..."
-	@docker compose -f compose/docker-compose.ci.yml up -d --build
+	@docker compose -f compose/docker-compose.ci.yml up -d --build --remove-orphans
 	@echo ""
 	@echo "⏳ Waiting for app container..."
 	@sleep 3
@@ -403,7 +403,7 @@ ci-docs: _ensure-env-ci
 	@echo "📚 Running CI docs build (matches GitHub Actions docs job)..."
 	@echo ""
 	@echo "📝 Starting CI environment..."
-	@docker compose -f compose/docker-compose.ci.yml up -d --build
+	@docker compose -f compose/docker-compose.ci.yml up -d --build --remove-orphans
 	@echo ""
 	@echo "⏳ Waiting for app container..."
 	@sleep 3

--- a/WARP.md
+++ b/WARP.md
@@ -7,11 +7,17 @@
 - `~/references/starter/dashtam-feature-roadmap.md` - Feature roadmap with Phase 2-6 implementation details
 - `~/references/dashtam-production-deployment-options.md` - Production deployment options, costs, TLS/auth, CI/CD, IaC
 
+**Architecture Documentation**:
+
+- `docs/architecture/hexagonal-architecture.md` - Hexagonal architecture theory, ports & adapters, dependency rule
+- `docs/architecture/protocol-based-architecture.md` - Protocol-based design, structural typing, testing with protocols
+- `docs/architecture/domain-driven-design-architecture.md` - Pragmatic DDD, entities vs value objects, domain events, patterns used/skipped
+
 ---
 
-## Part 1: Project Context
+**Last Updated**: 2025-12-30
 
-### 1. Project Overview
+## 1. Project Overview
 
 **Dashtam** is a secure, modern financial data aggregation platform built from the ground up with clean architecture principles.
 
@@ -43,7 +49,7 @@
 
 ---
 
-### 2. Current Status
+## 2. Current Status
 
 **For detailed feature history, PRs, version releases, and implementation details**: See `CHANGELOG.md`
 
@@ -1286,6 +1292,8 @@ async def create_user(
 - **Maintainability**: Clear boundaries, explicit dependencies
 - **Longevity**: Framework-agnostic domain survives upgrades
 
+**See**: `docs/architecture/hexagonal-architecture.md` for complete architectural details, layer responsibilities, ports & adapters pattern, and integration with other patterns.
+
 #### Why CQRS?
 
 - **Performance**: Optimize reads separately from writes
@@ -1297,6 +1305,8 @@ async def create_user(
 - **Pythonic**: Structural typing (duck typing with safety)
 - **Flexible**: No inheritance required, easier testing
 - **Modern**: Python 3.8+ feature, type checkers understand
+
+**See**: `docs/architecture/protocol-based-architecture.md` for structural vs nominal typing, protocol implementations across Dashtam, testing strategies, and common pitfalls.
 
 #### Why Result Types?
 

--- a/docs/architecture/domain-driven-design-architecture.md
+++ b/docs/architecture/domain-driven-design-architecture.md
@@ -1,0 +1,1268 @@
+# Domain-Driven Design Architecture
+
+## Overview
+
+**Purpose**: Apply Domain-Driven Design (DDD) principles pragmatically to model complex business domains, focusing on ubiquitous language, bounded contexts, and domain integrity.
+
+**Problem**: Business logic scattered across layers:
+
+- Domain concepts mixed with infrastructure code
+- No clear separation between business rules and technical details
+- Lack of shared language between developers and domain experts
+- Difficult to understand and maintain business logic
+- Tight coupling between domain and frameworks
+
+**Solution**: Pragmatic DDD in Dashtam:
+
+- **Ubiquitous Language**: Shared vocabulary between code and business
+- **Domain at Core**: Business logic in pure domain layer (no framework deps)
+- **Tactical Patterns**: Entities, Value Objects, Domain Events, Repositories
+- **Strategic Patterns**: Bounded Contexts (planned for multi-provider future)
+- **Pragmatic Approach**: Use patterns when they add value, skip when they don't
+
+---
+
+## What "Pragmatic DDD" Means in Dashtam
+
+**DDD can be dogmatic** — full implementation requires significant infrastructure (aggregates, domain services, specifications, factories, etc.). Many DDD books advocate for patterns that add complexity without clear ROI in smaller systems.
+
+**Dashtam's Pragmatic Approach**:
+
+✅ **Use DDD patterns that provide clear value**:
+
+- Entities (identity-based domain objects)
+- Value Objects (immutable, equality-based)
+- Domain Events (communication within bounded context)
+- Repository Protocols (persistence abstraction)
+- Ubiquitous Language (consistent naming)
+
+❌ **Skip DDD patterns with unclear ROI for current scale**:
+
+- Aggregates (one-to-many relationships are simple enough)
+- Domain Services (application layer handles this)
+- Specifications (query logic is straightforward)
+- Factories (dataclass constructors suffice)
+
+**Key Principle**: **Start simple, add complexity only when pain points emerge.**
+
+---
+
+## Core DDD Concepts
+
+### 1. Ubiquitous Language
+
+**Definition**: A shared vocabulary between developers, domain experts, and business stakeholders that is reflected consistently in code.
+
+**Example from Dashtam**:
+
+| Business Term | Code Representation | Explanation |
+|---------------|---------------------|-------------|
+| User Registration | `RegisterUser` command | User intent to create account |
+| Account Sync | `SyncAccounts` command | Fetch latest account data |
+| Provider Token | `ProviderToken` entity | OAuth credentials for provider |
+| Transaction | `Transaction` entity | Financial transaction |
+| Balance Snapshot | `BalanceSnapshot` value object | Point-in-time account balance |
+
+**Consistency**:
+
+- ✅ Domain entities named after business concepts
+- ✅ Commands named after user actions (verbs)
+- ✅ Domain events describe what happened (past tense)
+- ❌ NO technical jargon in domain layer (`UserDTO`, `UserDAO`)
+
+**Example**:
+
+```python
+# ✅ GOOD: Ubiquitous language
+class User:
+    """Domain entity representing a registered user."""
+    id: UUID
+    email: str
+    is_verified: bool
+    
+    def verify_email(self) -> None:
+        """Mark user's email as verified."""
+        self.is_verified = True
+
+# ❌ BAD: Technical language
+class UserRecord:  # "Record" is technical
+    user_pk: int  # "pk" is database term
+    email_addr: str
+    verified_flag: int  # "flag" is technical
+```
+
+### 2. Domain Layer (Pure Business Logic)
+
+**Core Principle**: Domain layer depends on NOTHING — no frameworks, no infrastructure, no external libraries.
+
+**Domain Layer Structure**:
+
+```text
+src/domain/
+├── entities/           # Identity-based objects (User, Account, Transaction)
+├── value_objects/      # Immutable, equality-based (Money, DateRange)
+├── events/             # Domain events (UserRegistered, AccountSynced)
+├── protocols/          # Ports for infrastructure (UserRepository, CacheProtocol)
+├── enums/              # Domain enums (UserRole, AccountType)
+├── errors/             # Domain errors (ValidationError, BusinessRuleError)
+├── types.py            # Annotated types (Email, Password, Money)
+└── validators.py       # Validation functions
+```
+
+**What Lives in Domain**:
+
+✅ **Business rules**: "User must verify email before login"  
+✅ **Domain logic**: "Calculate account balance from transactions"  
+✅ **Domain concepts**: `User`, `Account`, `Transaction`, `ProviderToken`  
+✅ **Domain events**: `UserRegistered`, `AccountSynced`
+
+❌ **NOT in domain**:
+
+- Database queries
+- HTTP requests
+- Framework imports (FastAPI, SQLAlchemy)
+- External API calls
+- Infrastructure concerns
+
+**Example**:
+
+```python
+# ✅ CORRECT: Pure domain entity
+from dataclasses import dataclass
+from uuid import UUID
+
+@dataclass
+class User:
+    """Domain entity for registered user."""
+    id: UUID
+    email: str
+    is_verified: bool
+    
+    def verify_email(self) -> None:
+        """Mark email as verified."""
+        if self.is_verified:
+            raise BusinessRuleError("Email already verified")
+        self.is_verified = True
+
+# ❌ WRONG: Framework imports in domain
+from sqlalchemy.orm import Mapped  # NO!
+from fastapi import HTTPException   # NO!
+
+@dataclass
+class User:
+    id: Mapped[UUID]  # SQLAlchemy in domain - WRONG!
+```
+
+### 3. Entities (Identity-Based)
+
+**Definition**: Objects with unique identity that persists over time, even as their attributes change.
+
+**Characteristics**:
+
+- ✅ Has unique ID (UUID, int, etc.)
+- ✅ Mutable (attributes can change)
+- ✅ Equality based on ID, NOT attributes
+- ✅ Encapsulates business logic
+
+**Example from Dashtam**:
+
+```python
+# src/domain/entities/user.py
+from dataclasses import dataclass
+from uuid import UUID
+
+@dataclass
+class User:
+    """Registered user entity.
+    
+    Identity: user_id (UUID)
+    Lifecycle: Created → Email Verified → Active → Deleted
+    """
+    id: UUID
+    email: str
+    is_verified: bool
+    is_active: bool
+    
+    def verify_email(self) -> None:
+        """Mark user's email as verified.
+        
+        Business Rule: User must verify email before login.
+        """
+        if self.is_verified:
+            raise BusinessRuleError("Email already verified")
+        self.is_verified = True
+    
+    def deactivate(self) -> None:
+        """Deactivate user account.
+        
+        Business Rule: Deactivated users cannot login.
+        """
+        if not self.is_active:
+            raise BusinessRuleError("User already deactivated")
+        self.is_active = False
+    
+    def __eq__(self, other: object) -> bool:
+        """Equality based on ID."""
+        if not isinstance(other, User):
+            return False
+        return self.id == other.id
+    
+    def __hash__(self) -> int:
+        """Hash based on ID."""
+        return hash(self.id)
+```
+
+**Entity Lifecycle**:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created: User registers
+    Created --> EmailVerified: Email verification
+    EmailVerified --> Active: Login
+    Active --> Deactivated: Deactivate
+    Deactivated --> Active: Reactivate
+    Active --> [*]: Delete
+    Deactivated --> [*]: Delete
+```
+
+### 4. Value Objects (Immutable, Equality-Based)
+
+**Definition**: Objects without identity, defined only by their attributes. Two value objects with same attributes are considered equal.
+
+**Characteristics**:
+
+- ✅ Immutable (`frozen=True`)
+- ✅ Equality based on ALL attributes
+- ✅ No unique ID
+- ✅ Represent domain concepts (Money, DateRange, Address)
+
+**When to Use**:
+
+- ✅ **Descriptive concepts**: Money, DateRange, EmailAddress
+- ✅ **Measurements**: Weight, Distance, Temperature
+- ✅ **Immutable data**: Address, Coordinates
+
+**Example from Dashtam**:
+
+```python
+# src/domain/value_objects/money.py
+from dataclasses import dataclass
+from decimal import Decimal
+
+@dataclass(frozen=True, kw_only=True)
+class Money:
+    """Value object representing monetary amount.
+    
+    Immutable: Once created, cannot be modified.
+    Equality: Two Money instances with same amount and currency are equal.
+    """
+    amount: Decimal
+    currency: str  # ISO 4217 code (USD, EUR, etc.)
+    
+    def add(self, other: "Money") -> "Money":
+        """Add two Money values.
+        
+        Business Rule: Can only add money with same currency.
+        
+        Args:
+            other: Money to add.
+            
+        Returns:
+            New Money instance with sum.
+            
+        Raises:
+            BusinessRuleError: If currencies don't match.
+        """
+        if self.currency != other.currency:
+            raise BusinessRuleError(
+                f"Cannot add {self.currency} and {other.currency}"
+            )
+        return Money(amount=self.amount + other.amount, currency=self.currency)
+    
+    def multiply(self, factor: Decimal) -> "Money":
+        """Multiply money by scalar factor.
+        
+        Args:
+            factor: Multiplication factor.
+            
+        Returns:
+            New Money instance with result.
+        """
+        return Money(amount=self.amount * factor, currency=self.currency)
+```
+
+**Value Object Example 2**:
+
+```python
+# src/domain/value_objects/date_range.py
+from dataclasses import dataclass
+from datetime import date
+
+@dataclass(frozen=True, kw_only=True)
+class DateRange:
+    """Value object representing date range.
+    
+    Business Rule: start_date must be <= end_date.
+    """
+    start_date: date
+    end_date: date
+    
+    def __post_init__(self) -> None:
+        """Validate business rule."""
+        if self.start_date > self.end_date:
+            raise ValidationError("start_date must be <= end_date")
+    
+    def contains(self, target: date) -> bool:
+        """Check if date is within range.
+        
+        Args:
+            target: Date to check.
+            
+        Returns:
+            True if target is within range.
+        """
+        return self.start_date <= target <= self.end_date
+    
+    def days(self) -> int:
+        """Calculate number of days in range.
+        
+        Returns:
+            Number of days (inclusive).
+        """
+        return (self.end_date - self.start_date).days + 1
+```
+
+### 5. Entity vs Value Object: Decision Tree
+
+**How to decide**:
+
+```text
+Does the object need a unique identity?
+│
+├─ YES ──→ Entity
+│          Examples: User, Account, Transaction
+│          Why: User with ID=1 is SAME user even if email changes
+│
+└─ NO ──→ Does it represent a descriptive concept?
+           │
+           ├─ YES ──→ Value Object
+           │          Examples: Money, DateRange, Address
+           │          Why: Two Money(100, USD) are identical
+           │
+           └─ NO ──→ Simple data type or Pydantic schema
+                      Examples: UserCreate (request), UserResponse (response)
+                      Why: No domain logic, just data transfer
+```
+
+**Examples**:
+
+| Concept | Type | Reasoning |
+|---------|------|-----------|
+| User | **Entity** | Has unique ID, lifecycle, mutable |
+| Account | **Entity** | Has unique account_id, balance changes |
+| Transaction | **Entity** | Has unique transaction_id |
+| ProviderToken | **Entity** | Has unique token, expires over time |
+| Money | **Value Object** | No ID, immutable, equality by value |
+| DateRange | **Value Object** | No ID, immutable, descriptive |
+| Address | **Value Object** | No ID, immutable, descriptive |
+| UserCreate | **Pydantic Schema** | Request DTO, no domain logic |
+
+---
+
+## DDD Patterns Used in Dashtam
+
+### 1. Entities
+
+**All entities in `src/domain/entities/`**:
+
+- `user.py` - Registered user
+- `account.py` - Financial account (brokerage, bank, etc.)
+- `transaction.py` - Financial transaction
+- `provider_token.py` - OAuth token for provider
+- `balance_snapshot.py` - Point-in-time account balance
+- `holding.py` - Asset holding (stocks, bonds, etc.)
+
+**Common Entity Pattern**:
+
+```python
+from dataclasses import dataclass
+from uuid import UUID
+
+@dataclass
+class Account:
+    """Financial account entity."""
+    id: UUID
+    user_id: UUID
+    provider_id: UUID
+    account_type: AccountType
+    balance: Money
+    is_active: bool
+    
+    def update_balance(self, new_balance: Money) -> None:
+        """Update account balance.
+        
+        Business Rule: Balance currency must match account currency.
+        """
+        if new_balance.currency != self.balance.currency:
+            raise BusinessRuleError("Currency mismatch")
+        self.balance = new_balance
+    
+    def deactivate(self) -> None:
+        """Deactivate account."""
+        self.is_active = False
+```
+
+### 2. Value Objects
+
+**All value objects in `src/domain/value_objects/`**:
+
+- `money.py` - Monetary amount with currency
+- `date_range.py` - Date range (start/end)
+
+**Note**: Dashtam currently has few value objects because most domain concepts are entities. As complexity grows, more value objects will emerge (Address, PhoneNumber, AccountNumber, etc.).
+
+### 3. Domain Events
+
+**All domain events in `src/domain/events/`**:
+
+Domain events represent **something that happened** in the domain that other parts of the system care about.
+
+**3-State Pattern** (ATTEMPT → OUTCOME):
+
+1. `*Attempted` - Before business logic (audit: ATTEMPTED)
+2. `*Succeeded` - After successful commit (audit: outcome)
+3. `*Failed` - After failure (audit: FAILED)
+
+**Example Events**:
+
+```python
+# src/domain/events/auth_events.py
+from dataclasses import dataclass
+from uuid import UUID
+from datetime import datetime
+from src.domain.events.base import DomainEvent
+
+@dataclass(frozen=True, kw_only=True)
+class UserRegistrationAttempted(DomainEvent):
+    """Emitted when user registration is attempted."""
+    email: str
+    ip_address: str | None
+
+@dataclass(frozen=True, kw_only=True)
+class UserRegistrationSucceeded(DomainEvent):
+    """Emitted after successful user registration."""
+    user_id: UUID
+    email: str
+
+@dataclass(frozen=True, kw_only=True)
+class UserRegistrationFailed(DomainEvent):
+    """Emitted when user registration fails."""
+    email: str
+    reason: str
+```
+
+**When to Emit Domain Events**:
+
+✅ **Emit when**:
+
+- Critical workflow needs audit trail (registration, login, sync)
+- Multiple side effects needed (logging, audit, email, session management)
+- Cross-cutting concerns (security monitoring, rate limiting)
+
+❌ **Don't emit when**:
+
+- Simple CRUD operations (find_by_id, list users)
+- Internal calculations (no side effects)
+- Performance-critical paths (avoid overhead)
+
+**See**: [Event Registry Pattern Architecture](registry-pattern-architecture.md) for complete event system details.
+
+### 4. Repository Protocols
+
+**All repository protocols in `src/domain/protocols/`**:
+
+Repositories abstract persistence, allowing domain to define what it needs without knowing HOW data is stored.
+
+**Repository Protocol Pattern**:
+
+```python
+# src/domain/protocols/user_repository.py
+from typing import Protocol
+from uuid import UUID
+from src.domain.entities.user import User
+
+class UserRepository(Protocol):
+    """Repository port for user persistence.
+    
+    Domain defines WHAT it needs, infrastructure provides HOW.
+    """
+    
+    async def find_by_id(self, user_id: UUID) -> User | None:
+        """Find user by ID."""
+        ...
+    
+    async def find_by_email(self, email: str) -> User | None:
+        """Find user by email."""
+        ...
+    
+    async def save(self, user: User) -> None:
+        """Persist user entity."""
+        ...
+    
+    async def delete(self, user_id: UUID) -> None:
+        """Delete user."""
+        ...
+```
+
+**Key Points**:
+
+- ✅ Protocol in domain layer (port)
+- ✅ Implementation in infrastructure layer (adapter)
+- ✅ Returns domain entities, NOT database models
+- ✅ No SQL, no framework imports
+
+**See**: [Protocol-Based Architecture](protocol-based-architecture.md) for complete protocol details.
+
+### 5. Domain Services (Minimal Use)
+
+**Domain Services** handle domain logic that doesn't belong to a single entity.
+
+**When to Use**:
+
+✅ **Use domain service when**:
+
+- Logic spans multiple entities
+- No clear "home" entity for the logic
+- Complex calculation involving multiple domain objects
+
+**Dashtam's Approach**: **Application layer handles most "service" logic.**
+
+**Example (NOT currently in Dashtam, but illustrative)**:
+
+```python
+# Hypothetical: Portfolio value calculation
+class PortfolioService:
+    """Domain service for portfolio calculations.
+    
+    Doesn't fit in Account entity (spans multiple holdings).
+    """
+    
+    def calculate_total_value(
+        self,
+        holdings: list[Holding],
+        market_prices: dict[str, Money],
+    ) -> Money:
+        """Calculate total portfolio value.
+        
+        Business Rule: Sum of (quantity * market_price) for all holdings.
+        """
+        total = Money(amount=Decimal("0"), currency="USD")
+        
+        for holding in holdings:
+            price = market_prices.get(holding.symbol)
+            if price:
+                value = price.multiply(Decimal(holding.quantity))
+                total = total.add(value)
+        
+        return total
+```
+
+**Why minimal use in Dashtam**: Most calculations fit in handlers or entities, keeping domain layer simple.
+
+---
+
+## DDD Patterns NOT Used (And Why)
+
+### 1. Aggregates (Not Used)
+
+**What They Are**: Cluster of entities and value objects with a single root entity. Only the root can be accessed from outside.
+
+**Why We Skip**:
+
+- ❌ Current one-to-many relationships are simple enough
+- ❌ No complex invariants spanning multiple entities yet
+- ❌ Adds complexity without clear ROI at current scale
+
+**When We'll Add**:
+
+- ✅ If we need transactional consistency across entities
+- ✅ If business rules span multiple entities (e.g., Order → OrderLine)
+
+**Example (NOT in Dashtam)**:
+
+```python
+# Aggregate: Order (root) + OrderLines
+class Order:
+    """Aggregate root."""
+    id: UUID
+    lines: list[OrderLine]  # Child entities
+    
+    def add_line(self, item: Item, quantity: int) -> None:
+        """Add order line (enforces invariant)."""
+        # Business rule: No duplicate items
+        if any(line.item_id == item.id for line in self.lines):
+            raise BusinessRuleError("Item already in order")
+        self.lines.append(OrderLine(item_id=item.id, quantity=quantity))
+```
+
+### 2. Specifications (Not Used)
+
+**What They Are**: Reusable query criteria encapsulated as objects.
+
+**Why We Skip**:
+
+- ❌ Query logic is straightforward (no complex filtering)
+- ❌ Repository methods are specific enough
+- ❌ Adds abstraction layer without clear benefit
+
+**When We'll Add**:
+
+- ✅ If we need complex, composable query logic
+- ✅ If filtering logic is reused across multiple contexts
+
+**Example (NOT in Dashtam)**:
+
+```python
+# Specification pattern
+class ActiveUserSpecification:
+    def is_satisfied_by(self, user: User) -> bool:
+        return user.is_active and user.is_verified
+
+class EmailDomainSpecification:
+    def __init__(self, domain: str):
+        self.domain = domain
+    
+    def is_satisfied_by(self, user: User) -> bool:
+        return user.email.endswith(f"@{self.domain}")
+```
+
+### 3. Factories (Not Used)
+
+**What They Are**: Objects that encapsulate complex entity creation logic.
+
+**Why We Skip**:
+
+- ❌ Entity creation is simple (dataclass constructors)
+- ❌ No complex initialization logic yet
+- ❌ Handlers can create entities directly
+
+**When We'll Add**:
+
+- ✅ If entity creation involves complex business rules
+- ✅ If multiple creation paths need consistency
+
+**Example (NOT in Dashtam)**:
+
+```python
+# Factory pattern
+class UserFactory:
+    def create_user(
+        self,
+        email: str,
+        password: str,
+        role: UserRole = UserRole.USER,
+    ) -> User:
+        """Create user with default values and validation."""
+        hashed_password = self._hash_password(password)
+        
+        return User(
+            id=uuid7(),
+            email=email.lower(),
+            hashed_password=hashed_password,
+            role=role,
+            is_verified=False,
+            is_active=True,
+            created_at=utc_now(),
+        )
+```
+
+**Current Approach**: Handlers create entities directly, keeping code simple.
+
+---
+
+## Integration with Other Architectures
+
+### 1. DDD + Hexagonal Architecture
+
+**How They Fit**:
+
+- **Domain layer** = Core hexagon (business logic)
+- **Repository Protocols** = Ports (interfaces domain needs)
+- **Repository Implementations** = Adapters (infrastructure provides)
+
+```text
+┌───────────────────────────────────────────────┐
+│ Domain Layer (DDD Core)                       │
+│ - Entities (User, Account, Transaction)      │
+│ - Value Objects (Money, DateRange)           │
+│ - Domain Events (UserRegistered, etc.)       │
+│ - Repository Protocols (Ports)               │
+└───────────────────────────────────────────────┘
+          ↑ implements                          
+          │                                     
+┌───────────────────────────────────────────────┐
+│ Infrastructure Layer (Adapters)               │
+│ - PostgreSQL Repository Implementations      │
+│ - Redis Cache Adapter                        │
+│ - Schwab Provider Adapter                    │
+└───────────────────────────────────────────────┘
+```
+
+**Key Point**: DDD defines WHAT (domain concepts), Hexagonal defines WHERE (layer placement).
+
+**See**: [Hexagonal Architecture](hexagonal-architecture.md)
+
+### 2. DDD + CQRS
+
+**How They Fit**:
+
+- **Commands** = Write operations that modify domain entities
+- **Queries** = Read operations that fetch data
+- **Domain Events** = Side effects after command execution
+
+```text
+Command (RegisterUser)
+    ↓
+Handler creates User entity (DDD)
+    ↓
+Save via UserRepository protocol (DDD)
+    ↓
+Emit UserRegistrationSucceeded event (DDD)
+    ↓
+Event handlers react (logging, audit, email)
+```
+
+**Key Point**: CQRS defines HOW (command/query separation), DDD defines WHAT (domain entities/events).
+
+**See**: [CQRS Pattern](cqrs-pattern.md)
+
+### 3. DDD + Protocol-Based Architecture
+
+**How They Fit**:
+
+- **Domain** defines Repository protocols (ports)
+- **Infrastructure** implements protocols without inheritance (adapters)
+- **Protocol** = Interface abstraction (structural typing)
+
+```python
+# Domain defines protocol (DDD port)
+class UserRepository(Protocol):
+    async def save(self, user: User) -> None: ...
+
+# Infrastructure implements (Hexagonal adapter)
+class PostgresUserRepository:  # No inheritance!
+    async def save(self, user: User) -> None:
+        # Map User entity → UserModel (database)
+        ...
+```
+
+**Key Point**: Protocol provides TYPE-SAFE abstraction for DDD repositories.
+
+**See**: [Protocol-Based Architecture](protocol-based-architecture.md)
+
+### 4. DDD + Event Registry Pattern
+
+**How They Fit**:
+
+- **Domain Events** = DDD tactical pattern
+- **Event Registry** = Single source of truth for all events
+- **Event Handlers** = Side effects after domain changes
+
+**Event Lifecycle**:
+
+1. Domain entity state changes
+2. Domain event emitted (`UserRegistrationSucceeded`)
+3. Event bus dispatches to registered handlers
+4. Handlers react (logging, audit, email, session)
+
+**Key Point**: Event Registry manages HOW events are dispatched, DDD defines WHAT events mean.
+
+**See**: [Event Registry Pattern Architecture](registry-pattern-architecture.md)
+
+---
+
+## Domain vs Application Services
+
+**Core Question**: Where does business logic go?
+
+### Domain Services
+
+**Lives in**: `src/domain/` (rare in Dashtam)
+
+**Use when**:
+
+- Logic spans multiple entities
+- Pure domain calculation (no side effects)
+- Reusable across multiple use cases
+
+**Example (Hypothetical)**:
+
+```python
+# src/domain/services/portfolio_service.py
+class PortfolioService:
+    """Domain service for portfolio calculations."""
+    
+    def calculate_total_value(
+        self,
+        holdings: list[Holding],
+        market_prices: dict[str, Money],
+    ) -> Money:
+        """Calculate total portfolio value (pure calculation)."""
+        # Pure domain logic, no side effects
+        ...
+```
+
+### Application Services (Handlers)
+
+**Lives in**: `src/application/commands/handlers/`, `src/application/queries/handlers/`
+
+**Use when** (most common):
+
+- Orchestrating domain entities
+- Coordinating multiple repositories
+- Emitting domain events
+- Side effects (logging, email, etc.)
+
+**Example (Current Dashtam Pattern)**:
+
+```python
+# src/application/commands/handlers/register_user_handler.py
+class RegisterUserHandler:
+    """Application service for user registration."""
+    
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        event_bus: EventBusProtocol,
+    ):
+        self._user_repo = user_repo
+        self._event_bus = event_bus
+    
+    async def handle(self, cmd: RegisterUser) -> Result[UUID, DomainError]:
+        """Handle user registration command.
+        
+        Orchestrates:
+        1. Create User entity (domain logic)
+        2. Save via repository (infrastructure)
+        3. Emit domain event (side effect)
+        """
+        # Emit ATTEMPT event
+        await self._event_bus.publish(
+            UserRegistrationAttempted(email=cmd.email, ...)
+        )
+        
+        # Create domain entity
+        user = User(
+            id=uuid7(),
+            email=cmd.email,
+            is_verified=False,
+            is_active=True,
+        )
+        
+        # Persist
+        await self._user_repo.save(user)
+        
+        # Emit SUCCESS event
+        await self._event_bus.publish(
+            UserRegistrationSucceeded(user_id=user.id, email=user.email)
+        )
+        
+        return Success(value=user.id)
+```
+
+**Decision Rule**: **Default to application handlers**, only extract domain service if logic is pure and reusable.
+
+---
+
+## Testing Strategy for DDD Components
+
+### 1. Entity Tests (Unit)
+
+**Test**: Business logic in entities.
+
+```python
+# tests/unit/test_domain_user_entity.py
+def test_user_verify_email():
+    """Test email verification business rule."""
+    user = User(
+        id=uuid7(),
+        email="test@example.com",
+        is_verified=False,
+    )
+    
+    user.verify_email()
+    
+    assert user.is_verified
+
+def test_user_verify_email_already_verified():
+    """Test cannot verify email twice."""
+    user = User(id=uuid7(), email="test@example.com", is_verified=True)
+    
+    with pytest.raises(BusinessRuleError, match="already verified"):
+        user.verify_email()
+```
+
+### 2. Value Object Tests (Unit)
+
+**Test**: Immutability, equality, domain logic.
+
+```python
+# tests/unit/test_domain_money_value_object.py
+def test_money_add_same_currency():
+    """Test adding money with same currency."""
+    m1 = Money(amount=Decimal("100.00"), currency="USD")
+    m2 = Money(amount=Decimal("50.00"), currency="USD")
+    
+    result = m1.add(m2)
+    
+    assert result.amount == Decimal("150.00")
+    assert result.currency == "USD"
+
+def test_money_add_different_currency_raises():
+    """Test cannot add different currencies."""
+    m1 = Money(amount=Decimal("100.00"), currency="USD")
+    m2 = Money(amount=Decimal("50.00"), currency="EUR")
+    
+    with pytest.raises(BusinessRuleError, match="Cannot add"):
+        m1.add(m2)
+```
+
+### 3. Repository Tests (Integration)
+
+**Test**: Repository implementation satisfies protocol, entity ↔ model mapping.
+
+```python
+# tests/integration/test_user_repository.py
+@pytest.mark.asyncio
+async def test_user_repository_save_and_find(db_session: AsyncSession):
+    """Test repository saves and retrieves entity."""
+    repo = UserRepository(session=db_session)
+    
+    user = User(
+        id=uuid7(),
+        email="test@example.com",
+        is_verified=False,
+    )
+    
+    # Save entity
+    await repo.save(user)
+    await db_session.commit()
+    
+    # Retrieve entity
+    found = await repo.find_by_email("test@example.com")
+    
+    assert found is not None
+    assert found.id == user.id
+    assert found.email == user.email
+```
+
+### 4. Handler Tests (Unit with Mocks)
+
+**Test**: Command/query handler orchestration with mocked repositories.
+
+```python
+# tests/unit/test_application_register_user_handler.py
+@pytest.mark.asyncio
+async def test_register_user_success():
+    """Test user registration handler."""
+    mock_repo = AsyncMock(spec=UserRepository)
+    mock_repo.find_by_email.return_value = None
+    
+    mock_event_bus = AsyncMock(spec=EventBusProtocol)
+    
+    handler = RegisterUserHandler(
+        user_repo=mock_repo,
+        event_bus=mock_event_bus,
+    )
+    
+    result = await handler.handle(
+        RegisterUser(email="test@example.com", password="SecurePass123!")
+    )
+    
+    assert isinstance(result, Success)
+    mock_repo.save.assert_called_once()
+    assert mock_event_bus.publish.call_count == 2  # ATTEMPT + SUCCESS
+```
+
+---
+
+## Best Practices
+
+### 1. Keep Domain Pure
+
+**DO**:
+
+✅ Domain depends on NOTHING (no framework imports)  
+✅ Entities encapsulate business logic  
+✅ Repository protocols in domain, implementations in infrastructure  
+✅ Domain errors, not HTTP exceptions
+
+**DON'T**:
+
+❌ Import FastAPI, SQLAlchemy, Redis in domain  
+❌ Database queries in domain entities  
+❌ HTTP status codes in domain errors
+
+### 2. Use Ubiquitous Language Consistently
+
+**DO**:
+
+✅ Commands named after user actions (`RegisterUser`, `SyncAccounts`)  
+✅ Events describe what happened (past tense: `UserRegistered`)  
+✅ Entities named after business concepts (`User`, `Account`)
+
+**DON'T**:
+
+❌ Technical jargon (`UserDTO`, `UserRecord`, `UserDAO`)  
+❌ Generic names (`Manager`, `Service`, `Helper`)
+
+### 3. Start Simple, Add Complexity When Needed
+
+**DO**:
+
+✅ Start with entities and value objects  
+✅ Add domain events when side effects needed  
+✅ Extract domain services only when logic doesn't fit entities
+
+**DON'T**:
+
+❌ Implement all DDD patterns upfront  
+❌ Create factories, specifications, aggregates without clear need  
+❌ Over-engineer for hypothetical future requirements
+
+### 4. Separate Entity from Model
+
+**DO**:
+
+✅ Domain entity = business concept (`User` entity)  
+✅ Database model = persistence structure (`UserModel`)  
+✅ Repository maps entity ↔ model
+
+**DON'T**:
+
+❌ Mix domain entity with database model  
+❌ SQLAlchemy annotations in domain entities
+
+**Example**:
+
+```python
+# ✅ CORRECT: Separate entity and model
+
+# Domain entity (pure)
+@dataclass
+class User:
+    id: UUID
+    email: str
+
+# Database model (infrastructure)
+class UserModel(Base):
+    __tablename__ = "users"
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(unique=True)
+
+# Repository maps entity ↔ model
+class UserRepository:
+    def _to_entity(self, model: UserModel) -> User:
+        return User(id=model.id, email=model.email)
+    
+    def _to_model(self, user: User) -> UserModel:
+        return UserModel(id=user.id, email=user.email)
+```
+
+### 5. Emit Domain Events for Critical Workflows
+
+**DO**:
+
+✅ Emit events for audit-critical workflows (registration, login, sync)  
+✅ Use 3-state pattern (ATTEMPT → OUTCOME)  
+✅ Multiple handlers per event (logging, audit, email, session)
+
+**DON'T**:
+
+❌ Emit events for every CRUD operation  
+❌ Emit events for simple reads  
+❌ Emit events without clear side effects
+
+**See**: [Event Registry Pattern Architecture](registry-pattern-architecture.md)
+
+---
+
+## Common Pitfalls
+
+### ❌ Pitfall 1: Anemic Domain Model
+
+**Problem**: Entities are just data holders, all logic in services.
+
+```python
+# ❌ WRONG: Anemic entity
+@dataclass
+class User:
+    id: UUID
+    email: str
+    is_verified: bool
+    # No business logic!
+
+# All logic in service
+class UserService:
+    def verify_email(self, user: User) -> None:
+        if user.is_verified:
+            raise Error("Already verified")
+        user.is_verified = True
+```
+
+**Fix**: Move logic into entity.
+
+```python
+# ✅ CORRECT: Rich domain entity
+@dataclass
+class User:
+    id: UUID
+    email: str
+    is_verified: bool
+    
+    def verify_email(self) -> None:
+        """Business logic in entity."""
+        if self.is_verified:
+            raise BusinessRuleError("Already verified")
+        self.is_verified = True
+```
+
+### ❌ Pitfall 2: Framework Leakage into Domain
+
+**Problem**: Framework imports in domain layer.
+
+```python
+# ❌ WRONG: FastAPI in domain
+from fastapi import HTTPException
+
+@dataclass
+class User:
+    def verify_email(self) -> None:
+        if self.is_verified:
+            raise HTTPException(400, "Already verified")  # Framework!
+```
+
+**Fix**: Use domain errors.
+
+```python
+# ✅ CORRECT: Domain error
+from src.domain.errors.business_rule_error import BusinessRuleError
+
+@dataclass
+class User:
+    def verify_email(self) -> None:
+        if self.is_verified:
+            raise BusinessRuleError("Already verified")
+```
+
+### ❌ Pitfall 3: Entity/Model Confusion
+
+**Problem**: Using database models as domain entities.
+
+```python
+# ❌ WRONG: SQLAlchemy model used as domain entity
+from sqlalchemy.orm import Mapped
+
+class User(Base):  # SQLAlchemy model
+    __tablename__ = "users"
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    
+    def verify_email(self) -> None:
+        self.is_verified = True
+```
+
+**Fix**: Separate entity from model.
+
+```python
+# ✅ CORRECT: Separate concerns
+# Domain entity (pure)
+@dataclass
+class User:
+    id: UUID
+    email: str
+    
+    def verify_email(self) -> None:
+        self.is_verified = True
+
+# Database model (infrastructure)
+class UserModel(Base):
+    __tablename__ = "users"
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+```
+
+---
+
+## Benefits of Pragmatic DDD
+
+### 1. Business Logic Clarity
+
+**Before DDD**: Logic scattered across layers.
+
+```python
+# ❌ Business logic in router (BAD)
+@router.post("/users")
+async def create_user(data: UserCreate):
+    if not is_valid_email(data.email):  # Validation in router
+        raise HTTPException(400, "Invalid email")
+    # Database logic in router
+    user = UserModel(email=data.email, ...)
+    await db.add(user)
+```
+
+**With DDD**: Logic in domain.
+
+```python
+# ✅ Business logic in entity (GOOD)
+@dataclass
+class User:
+    def verify_email(self) -> None:
+        if self.is_verified:
+            raise BusinessRuleError("Already verified")
+```
+
+### 2. Testability
+
+**Before DDD**: Hard to test (coupled to database).
+
+**With DDD**: Easy unit tests (pure domain logic).
+
+```python
+def test_user_verify_email():
+    user = User(id=uuid7(), email="test@example.com", is_verified=False)
+    user.verify_email()
+    assert user.is_verified
+```
+
+### 3. Maintainability
+
+**Before DDD**: Changes ripple across layers.
+
+**With DDD**: Business rules centralized in domain entities.
+
+### 4. Framework Independence
+
+**Before DDD**: Tied to FastAPI, SQLAlchemy, etc.
+
+**With DDD**: Domain layer survives framework changes.
+
+---
+
+## References
+
+**Related Architecture Documents**:
+
+- [Hexagonal Architecture](hexagonal-architecture.md) - Domain as core hexagon
+- [Protocol-Based Architecture](protocol-based-architecture.md) - Repository protocols
+- [CQRS Pattern](cqrs-pattern.md) - Commands/queries with domain entities
+- [Event Registry Pattern](registry-pattern-architecture.md) - Domain events
+- [Directory Structure](directory-structure.md) - Domain layer organization
+
+**External Resources**:
+
+- [Domain-Driven Design (Eric Evans)](https://www.domainlanguage.com/ddd/)
+- [Implementing Domain-Driven Design (Vaughn Vernon)](https://vaughnvernon.co/)
+- [Domain-Driven Design Distilled (Vaughn Vernon)](https://www.oreilly.com/library/view/domain-driven-design-distilled/9780134434964/)
+
+---
+
+**Created**: 2025-12-30 | **Last Updated**: 2025-12-30

--- a/docs/architecture/hexagonal-architecture.md
+++ b/docs/architecture/hexagonal-architecture.md
@@ -1,0 +1,1451 @@
+# Hexagonal Architecture
+
+## Overview
+
+**Purpose**: Isolate business logic from infrastructure concerns, making the system testable, maintainable, and framework-independent.
+
+**Problem**: Traditional layered architectures create tight coupling:
+
+- Business logic depends on frameworks (FastAPI, SQLModel)
+- Database schema drives domain models
+- Hard to test without full infrastructure
+- Framework upgrades break business logic
+- Cannot swap implementations (PostgreSQL → MongoDB)
+
+**Solution**: Hexagonal Architecture (Ports & Adapters) inverts dependencies:
+
+- **Domain at center**: Pure business logic, zero infrastructure imports
+- **Ports**: Interfaces defined by domain (protocols)
+- **Adapters**: Infrastructure implements domain ports
+- **Dependency Rule**: All dependencies point inward toward domain
+
+---
+
+## Core Principles
+
+### 1. The Dependency Rule
+
+**CRITICAL**: Dependencies flow **inward** toward the domain. Domain depends on **NOTHING**.
+
+```mermaid
+graph TB
+    subgraph Outside["Outside World"]
+        HTTP[HTTP/REST]
+        DB[(Database)]
+        Cache[(Redis)]
+        ExtAPI[External APIs]
+    end
+    
+    subgraph Presentation["Presentation Layer<br/>(Adapters)"]
+        Routers[FastAPI Routers]
+    end
+    
+    subgraph Application["Application Layer"]
+        Commands[Commands]
+        Queries[Queries]
+        Handlers[Handlers]
+    end
+    
+    subgraph Domain["Domain Layer<br/>(Core - No Dependencies)"]
+        Entities[Entities]
+        ValueObjects[Value Objects]
+        Protocols[Protocols/Ports]
+        Events[Domain Events]
+    end
+    
+    subgraph Infrastructure["Infrastructure Layer<br/>(Adapters)"]
+        Repos[Repositories]
+        Providers[Provider Clients]
+        Services[External Services]
+    end
+    
+    HTTP --> Routers
+    Routers --> Handlers
+    Handlers --> Protocols
+    Handlers --> Entities
+    Repos -.implements.-> Protocols
+    Providers -.implements.-> Protocols
+    Services -.implements.-> Protocols
+    DB --> Repos
+    Cache --> Repos
+    ExtAPI --> Providers
+    
+    style Domain fill:#90EE90
+    style Protocols fill:#FFD700
+```
+
+**Rules**:
+
+- ✅ **Domain**: Depends on nothing (except standard library + core utilities)
+- ✅ **Application**: Depends on Domain
+- ✅ **Infrastructure**: Depends on Domain (implements protocols)
+- ✅ **Presentation**: Depends on Application
+- ❌ **NEVER**: Domain depends on Infrastructure or Presentation
+
+### 2. Ports and Adapters
+
+**Port** (Interface): Defined by domain, declares what domain needs.
+
+**Adapter** (Implementation): Infrastructure implements the port.
+
+```python
+# Domain defines PORT (protocol)
+# src/domain/protocols/user_repository.py
+from typing import Protocol
+from src.domain.entities.user import User
+
+class UserRepository(Protocol):
+    """Repository port for user persistence."""
+    
+    async def find_by_email(self, email: str) -> User | None:
+        """Find user by email address."""
+        ...
+    
+    async def save(self, user: User) -> None:
+        """Persist user entity."""
+        ...
+```
+
+```python
+# Infrastructure implements ADAPTER
+# src/infrastructure/persistence/repositories/user_repository.py
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain.entities.user import User
+from src.infrastructure.persistence.models.user import UserModel
+
+class UserRepository:  # No inheritance! Structural typing
+    """PostgreSQL adapter for UserRepository port."""
+    
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+    
+    async def find_by_email(self, email: str) -> User | None:
+        """Find user by email in PostgreSQL."""
+        result = await self._session.execute(
+            select(UserModel).where(UserModel.email == email)
+        )
+        model = result.scalar_one_or_none()
+        
+        if model is None:
+            return None
+        
+        # Map database model → domain entity
+        return User(
+            id=model.id,
+            email=model.email,
+            # ...
+        )
+    
+    async def save(self, user: User) -> None:
+        """Persist user entity to PostgreSQL."""
+        model = UserModel(
+            id=user.id,
+            email=user.email,
+            # ...
+        )
+        self._session.add(model)
+        await self._session.flush()
+```
+
+**Key Points**:
+
+- Domain defines **what** (port)
+- Infrastructure defines **how** (adapter)
+- No inheritance (structural typing via Protocol)
+- Easy to swap implementations (PostgreSQL → MongoDB, just implement the port)
+
+### 3. Inside-Out Design
+
+Traditional (Outside-In):
+
+```text
+Database schema → Models → Business logic → API
+(Infrastructure drives domain)
+```
+
+Hexagonal (Inside-Out):
+
+```text
+Domain entities → Protocols → Adapters → Infrastructure
+(Domain drives infrastructure)
+```
+
+**Benefits**:
+
+- Domain models reflect **business** reality, not database constraints
+- Can design domain first, defer infrastructure decisions
+- Business logic survives framework changes
+
+### 4. Framework Independence
+
+Domain layer has **zero** framework imports:
+
+```python
+# ✅ CORRECT: Domain entity (pure Python)
+from dataclasses import dataclass
+from uuid import UUID
+
+@dataclass
+class User:
+    id: UUID
+    email: str
+    is_verified: bool
+    
+    def verify_email(self) -> None:
+        """Mark user as verified."""
+        self.is_verified = True
+```
+
+```python
+# ❌ WRONG: Framework imports in domain
+from sqlalchemy.orm import DeclarativeBase  # NO!
+from fastapi import Depends  # NO!
+from redis import Redis  # NO!
+
+class User(DeclarativeBase):  # Domain coupled to SQLAlchemy
+    ...
+```
+
+**Benefits**:
+
+- Upgrade FastAPI without touching business logic
+- Migrate PostgreSQL → MongoDB without rewriting domain
+- Test domain in isolation (no database, no framework)
+
+---
+
+## Architecture Layers
+
+### Layer 1: Core (Shared Kernel)
+
+**Location**: `src/core/`
+
+**Purpose**: Shared utilities used across all layers.
+
+**Contents**:
+
+- `result.py` - Result types (Success/Failure)
+- `errors/` - Base error classes
+- `enums/` - Core enums
+- `config.py` - Settings
+- `container/` - Dependency injection
+
+**Dependencies**: None (pure Python)
+
+**Example**:
+
+```python
+# src/core/result.py
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+@dataclass(frozen=True, kw_only=True)
+class Success(Generic[T]):
+    value: T
+
+@dataclass(frozen=True, kw_only=True)
+class Failure(Generic[E]):
+    error: E
+
+type Result[T, E] = Success[T] | Failure[E]
+```
+
+### Layer 2: Domain (Business Logic Core)
+
+**Location**: `src/domain/`
+
+**Purpose**: Pure business logic - the heart of the application.
+
+**Contents**:
+
+- `entities/` - Business objects with identity (mutable)
+- `value_objects/` - Immutable values (no identity)
+- `protocols/` - ALL ports (interfaces) consolidated
+- `events/` - Domain events with Event Registry
+- `enums/` - Domain enums
+- `errors/` - Domain-specific errors
+- `types.py` - Annotated types
+- `validators.py` - Validation functions
+
+**Dependencies**: `src/core/` only
+
+**Rules**:
+
+- NO framework imports (FastAPI, SQLModel, Redis)
+- NO infrastructure imports (database, cache, external APIs)
+- Pure Python dataclasses and Protocol definitions
+- All business rules live here
+
+**Example - Entity**:
+
+```python
+# src/domain/entities/account.py
+from dataclasses import dataclass
+from uuid import UUID
+from src.domain.value_objects.money import Money
+from src.domain.enums.account_type import AccountType
+
+@dataclass
+class Account:
+    """Financial account entity."""
+    
+    id: UUID
+    user_id: UUID
+    provider_connection_id: UUID
+    account_type: AccountType
+    balance: Money
+    is_active: bool
+    
+    def deactivate(self) -> None:
+        """Deactivate account."""
+        self.is_active = False
+    
+    def update_balance(self, new_balance: Money) -> None:
+        """Update account balance."""
+        if new_balance.currency != self.balance.currency:
+            raise ValueError("Currency mismatch")
+        self.balance = new_balance
+```
+
+**Example - Port (Protocol)**:
+
+```python
+# src/domain/protocols/account_repository.py
+from typing import Protocol
+from uuid import UUID
+from src.domain.entities.account import Account
+
+class AccountRepository(Protocol):
+    """Repository port for account persistence."""
+    
+    async def find_by_id(self, account_id: UUID) -> Account | None:
+        """Find account by ID."""
+        ...
+    
+    async def find_by_user_id(self, user_id: UUID) -> list[Account]:
+        """Find all accounts for user."""
+        ...
+    
+    async def save(self, account: Account) -> None:
+        """Persist account entity."""
+        ...
+```
+
+### Layer 3: Application (Use Cases)
+
+**Location**: `src/application/`
+
+**Purpose**: Orchestrate use cases following CQRS pattern.
+
+**Contents**:
+
+- `commands/` - Write operations
+- `commands/handlers/` - Command handler implementations
+- `queries/` - Read operations
+- `queries/handlers/` - Query handler implementations
+- `events/handlers/` - Domain event handlers
+
+**Dependencies**: `src/domain/`, `src/core/`
+
+**Rules**:
+
+- Orchestrate domain entities
+- Depend ONLY on domain protocols (never infrastructure)
+- Use Result types for error handling
+- Emit domain events for critical workflows
+
+**Example - Command Handler**:
+
+```python
+# src/application/commands/handlers/sync_accounts_handler.py
+from uuid import UUID
+from src.core.result import Result, Success, Failure
+from src.domain.protocols.account_repository import AccountRepository
+from src.domain.protocols.provider_protocol import ProviderProtocol
+from src.domain.protocols.event_bus_protocol import EventBusProtocol
+from src.domain.events.data_events import (
+    AccountSyncAttempted,
+    AccountSyncSucceeded,
+    AccountSyncFailed,
+)
+
+class SyncAccountsHandler:
+    """Handler for syncing accounts from provider."""
+    
+    def __init__(
+        self,
+        account_repo: AccountRepository,  # Port, not adapter!
+        provider: ProviderProtocol,       # Port, not adapter!
+        event_bus: EventBusProtocol,      # Port, not adapter!
+    ) -> None:
+        self._account_repo = account_repo
+        self._provider = provider
+        self._event_bus = event_bus
+    
+    async def handle(
+        self,
+        connection_id: UUID,
+        credentials: dict[str, str],
+    ) -> Result[int, str]:
+        """Sync accounts from provider.
+        
+        Returns:
+            Success(account_count) on success
+            Failure(error_message) on failure
+        """
+        # 1. Emit ATTEMPTED event
+        await self._event_bus.publish(
+            AccountSyncAttempted(
+                provider_connection_id=connection_id,
+            )
+        )
+        
+        try:
+            # 2. Fetch accounts from provider (via port)
+            result = await self._provider.fetch_accounts(credentials)
+            
+            if isinstance(result, Failure):
+                await self._event_bus.publish(
+                    AccountSyncFailed(
+                        provider_connection_id=connection_id,
+                        reason=result.error.message,
+                    )
+                )
+                return Failure(error=result.error.message)
+            
+            accounts = result.value
+            
+            # 3. Save accounts (via port)
+            for account in accounts:
+                await self._account_repo.save(account)
+            
+            # 4. Emit SUCCEEDED event
+            await self._event_bus.publish(
+                AccountSyncSucceeded(
+                    provider_connection_id=connection_id,
+                    account_count=len(accounts),
+                )
+            )
+            
+            return Success(value=len(accounts))
+            
+        except Exception as e:
+            await self._event_bus.publish(
+                AccountSyncFailed(
+                    provider_connection_id=connection_id,
+                    reason=str(e),
+                )
+            )
+            return Failure(error=str(e))
+```
+
+**Note**: Handler depends on **protocols** (ports), not concrete implementations (adapters).
+
+### Layer 4: Infrastructure (Adapters)
+
+**Location**: `src/infrastructure/`
+
+**Purpose**: Implement domain ports with concrete technologies.
+
+**Contents**:
+
+- `persistence/` - Database adapters (PostgreSQL repositories)
+- `providers/` - Financial provider clients (Schwab, Alpaca, Chase)
+- `cache/` - Redis cache adapter
+- `secrets/` - Secrets management adapters (env, AWS)
+- `logging/` - Logging adapters (console, CloudWatch)
+- `events/` - Event bus implementation, event handlers
+- `authorization/` - Casbin RBAC adapter
+- `security/` - JWT service, encryption
+- `external/` - External API clients
+
+**Dependencies**: `src/domain/`, `src/core/`, external libraries
+
+**Rules**:
+
+- Implements domain protocols (ports)
+- Contains framework imports (SQLModel, Redis, boto3)
+- Database models live here (NOT in domain)
+- Mapping: domain entity ↔ database model
+
+**Example - Repository Adapter**:
+
+```python
+# src/infrastructure/persistence/repositories/account_repository.py
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from uuid import UUID
+
+from src.domain.entities.account import Account
+from src.domain.value_objects.money import Money
+from src.infrastructure.persistence.models.account import AccountModel
+
+class AccountRepository:  # Implements port via structural typing
+    """PostgreSQL adapter for AccountRepository port."""
+    
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+    
+    async def find_by_id(self, account_id: UUID) -> Account | None:
+        """Find account by ID in PostgreSQL."""
+        result = await self._session.execute(
+            select(AccountModel).where(AccountModel.id == account_id)
+        )
+        model = result.scalar_one_or_none()
+        
+        if model is None:
+            return None
+        
+        # Map database model → domain entity
+        return self._to_entity(model)
+    
+    async def find_by_user_id(self, user_id: UUID) -> list[Account]:
+        """Find all accounts for user in PostgreSQL."""
+        result = await self._session.execute(
+            select(AccountModel).where(AccountModel.user_id == user_id)
+        )
+        models = result.scalars().all()
+        
+        return [self._to_entity(model) for model in models]
+    
+    async def save(self, account: Account) -> None:
+        """Persist account entity to PostgreSQL."""
+        # Check if exists
+        existing = await self._session.get(AccountModel, account.id)
+        
+        if existing:
+            # Update
+            existing.balance_amount = account.balance.amount
+            existing.balance_currency = account.balance.currency
+            existing.is_active = account.is_active
+        else:
+            # Insert
+            model = self._to_model(account)
+            self._session.add(model)
+        
+        await self._session.flush()
+    
+    def _to_entity(self, model: AccountModel) -> Account:
+        """Map database model to domain entity."""
+        return Account(
+            id=model.id,
+            user_id=model.user_id,
+            provider_connection_id=model.provider_connection_id,
+            account_type=model.account_type,
+            balance=Money(
+                amount=model.balance_amount,
+                currency=model.balance_currency,
+            ),
+            is_active=model.is_active,
+        )
+    
+    def _to_model(self, account: Account) -> AccountModel:
+        """Map domain entity to database model."""
+        return AccountModel(
+            id=account.id,
+            user_id=account.user_id,
+            provider_connection_id=account.provider_connection_id,
+            account_type=account.account_type,
+            balance_amount=account.balance.amount,
+            balance_currency=account.balance.currency,
+            is_active=account.is_active,
+        )
+```
+
+**Key Points**:
+
+- Adapter has infrastructure dependencies (SQLAlchemy, AsyncSession)
+- Maps between domain entity and database model (boundary translation)
+- Implements port without inheritance (structural typing)
+
+### Layer 5: Presentation (API)
+
+**Location**: `src/presentation/`
+
+**Purpose**: HTTP API endpoints using FastAPI.
+
+**Contents**:
+
+- `routers/api/v1/` - Versioned API endpoints
+- `routers/api/middleware/` - Rate limiting, auth dependencies
+- `routers/oauth_callbacks.py` - OAuth callbacks
+
+**Dependencies**: `src/application/`, `src/core/`
+
+**Rules**:
+
+- Thin layer - NO business logic
+- Dispatches commands/queries to application layer
+- Translates HTTP → Command/Query → HTTP
+- RESTful URLs (resource-based)
+
+**Example**:
+
+```python
+# src/presentation/routers/api/v1/accounts.py
+from fastapi import APIRouter, Depends, HTTPException
+from uuid import UUID
+
+from src.application.commands.handlers.sync_accounts_handler import (
+    SyncAccountsHandler,
+)
+from src.application.queries.handlers.list_accounts_handler import (
+    ListAccountsHandler,
+)
+from src.schemas.account_schemas import AccountListResponse
+from src.core.container.data_handlers import (
+    get_sync_accounts_handler,
+    get_list_accounts_handler,
+)
+from src.core.result import Success, Failure
+
+router = APIRouter(prefix="/accounts", tags=["accounts"])
+
+@router.post("/{connection_id}/sync")
+async def sync_accounts(
+    connection_id: UUID,
+    handler: SyncAccountsHandler = Depends(get_sync_accounts_handler),
+) -> dict[str, int]:
+    """Sync accounts from provider."""
+    
+    # Application layer handles business logic
+    result = await handler.handle(connection_id=connection_id)
+    
+    # Presentation translates Result → HTTP
+    if isinstance(result, Failure):
+        raise HTTPException(status_code=400, detail=result.error)
+    
+    return {"synced_count": result.value}
+
+@router.get("/")
+async def list_accounts(
+    user_id: UUID,
+    handler: ListAccountsHandler = Depends(get_list_accounts_handler),
+) -> AccountListResponse:
+    """List all accounts for user."""
+    
+    result = await handler.handle(user_id=user_id)
+    
+    if isinstance(result, Failure):
+        raise HTTPException(status_code=400, detail=result.error)
+    
+    return result.value
+```
+
+---
+
+## Dependency Flow
+
+### Compile-Time Dependencies
+
+```mermaid
+graph LR
+    Presentation --> Application
+    Application --> Domain
+    Infrastructure --> Domain
+    Domain --> Core
+    
+    style Domain fill:#90EE90
+    style Core fill:#FFD700
+```
+
+**Rules**:
+
+- All arrows point toward Domain/Core
+- Domain has no outward arrows (zero dependencies)
+- Infrastructure depends on Domain (implements ports)
+
+### Runtime Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as Presentation<br/>(FastAPI)
+    participant Handler as Application<br/>(Handler)
+    participant Entity as Domain<br/>(Entity)
+    participant Port as Domain<br/>(Protocol)
+    participant Adapter as Infrastructure<br/>(Adapter)
+    participant DB as Database
+    
+    Client->>API: POST /accounts/sync
+    API->>Handler: handle(connection_id)
+    Handler->>Port: fetch_accounts()
+    Note over Port: Port defined by Domain
+    Port->>Adapter: (implements port)
+    Adapter->>DB: SELECT * FROM accounts
+    DB-->>Adapter: rows
+    Adapter-->>Port: List[Account]
+    Port-->>Handler: Success(accounts)
+    Handler->>Entity: validate business rules
+    Entity-->>Handler: validated
+    Handler->>Port: save(account)
+    Port->>Adapter: (implements port)
+    Adapter->>DB: INSERT INTO accounts
+    DB-->>Adapter: success
+    Adapter-->>Port: None
+    Port-->>Handler: Success
+    Handler-->>API: Success(account_count)
+    API-->>Client: 200 OK
+```
+
+**Key Points**:
+
+- Handler depends on **port** (protocol), not adapter
+- At runtime, DI container injects **adapter** that implements port
+- Handler doesn't know it's talking to PostgreSQL (could be MongoDB, in-memory, etc.)
+
+---
+
+## Testing Strategy
+
+### Unit Testing Domain (Isolated)
+
+**Goal**: Test business logic without infrastructure.
+
+```python
+# tests/unit/test_domain_account_entity.py
+from uuid import uuid7
+from src.domain.entities.account import Account
+from src.domain.value_objects.money import Money
+from src.domain.enums.account_type import AccountType
+
+def test_account_deactivate():
+    """Test account deactivation."""
+    account = Account(
+        id=uuid7(),
+        user_id=uuid7(),
+        provider_connection_id=uuid7(),
+        account_type=AccountType.CHECKING,
+        balance=Money(amount=1000.0, currency="USD"),
+        is_active=True,
+    )
+    
+    account.deactivate()
+    
+    assert account.is_active is False
+
+def test_account_update_balance_same_currency():
+    """Test balance update with same currency."""
+    account = Account(
+        id=uuid7(),
+        user_id=uuid7(),
+        provider_connection_id=uuid7(),
+        account_type=AccountType.CHECKING,
+        balance=Money(amount=1000.0, currency="USD"),
+        is_active=True,
+    )
+    
+    new_balance = Money(amount=2000.0, currency="USD")
+    account.update_balance(new_balance)
+    
+    assert account.balance.amount == 2000.0
+
+def test_account_update_balance_different_currency_raises():
+    """Test balance update with different currency raises error."""
+    account = Account(
+        id=uuid7(),
+        user_id=uuid7(),
+        provider_connection_id=uuid7(),
+        account_type=AccountType.CHECKING,
+        balance=Money(amount=1000.0, currency="USD"),
+        is_active=True,
+    )
+    
+    new_balance = Money(amount=2000.0, currency="EUR")
+    
+    with pytest.raises(ValueError, match="Currency mismatch"):
+        account.update_balance(new_balance)
+```
+
+**Benefits**:
+
+- No database required
+- No framework required
+- Fast (milliseconds)
+- Tests pure business logic
+
+### Unit Testing Application (Mocked Ports)
+
+**Goal**: Test handlers with mocked dependencies.
+
+```python
+# tests/unit/test_application_sync_accounts_handler.py
+from unittest.mock import AsyncMock
+from uuid import uuid7
+import pytest
+
+from src.application.commands.handlers.sync_accounts_handler import (
+    SyncAccountsHandler,
+)
+from src.domain.protocols.account_repository import AccountRepository
+from src.domain.protocols.provider_protocol import ProviderProtocol
+from src.domain.protocols.event_bus_protocol import EventBusProtocol
+from src.domain.entities.account import Account
+from src.core.result import Success, Failure
+
+@pytest.mark.asyncio
+async def test_sync_accounts_success():
+    """Test successful account sync."""
+    # Arrange - Mock ports
+    mock_repo = AsyncMock(spec=AccountRepository)
+    mock_provider = AsyncMock(spec=ProviderProtocol)
+    mock_event_bus = AsyncMock(spec=EventBusProtocol)
+    
+    # Mock provider returns accounts
+    mock_provider.fetch_accounts.return_value = Success(value=[
+        Account(...),
+        Account(...),
+    ])
+    
+    handler = SyncAccountsHandler(
+        account_repo=mock_repo,
+        provider=mock_provider,
+        event_bus=mock_event_bus,
+    )
+    
+    connection_id = uuid7()
+    credentials = {"access_token": "test_token"}
+    
+    # Act
+    result = await handler.handle(connection_id, credentials)
+    
+    # Assert
+    assert isinstance(result, Success)
+    assert result.value == 2  # 2 accounts synced
+    
+    # Verify events emitted
+    assert mock_event_bus.publish.call_count == 2  # Attempted + Succeeded
+    
+    # Verify repository called
+    assert mock_repo.save.call_count == 2
+```
+
+**Benefits**:
+
+- Tests handler logic without real database/provider
+- Fast (milliseconds)
+- Verifies port interactions
+
+### Integration Testing Infrastructure (Real Adapters)
+
+**Goal**: Test adapters with real infrastructure.
+
+```python
+# tests/integration/test_account_repository.py
+import pytest
+from uuid import uuid7
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.entities.account import Account
+from src.domain.value_objects.money import Money
+from src.domain.enums.account_type import AccountType
+from src.infrastructure.persistence.repositories.account_repository import (
+    AccountRepository,
+)
+
+@pytest.mark.asyncio
+async def test_save_and_find_account(db_session: AsyncSession):
+    """Test saving and retrieving account."""
+    repo = AccountRepository(session=db_session)
+    
+    # Create account
+    account = Account(
+        id=uuid7(),
+        user_id=uuid7(),
+        provider_connection_id=uuid7(),
+        account_type=AccountType.CHECKING,
+        balance=Money(amount=1000.0, currency="USD"),
+        is_active=True,
+    )
+    
+    # Save
+    await repo.save(account)
+    await db_session.commit()
+    
+    # Retrieve
+    found = await repo.find_by_id(account.id)
+    
+    # Assert
+    assert found is not None
+    assert found.id == account.id
+    assert found.balance.amount == 1000.0
+    assert found.balance.currency == "USD"
+```
+
+**Benefits**:
+
+- Tests real database operations
+- Verifies entity ↔ model mapping
+- Catches SQL errors, schema issues
+
+### API Testing (End-to-End)
+
+**Goal**: Test complete flow through all layers.
+
+```python
+# tests/api/test_accounts_endpoints.py
+import pytest
+from fastapi.testclient import TestClient
+from uuid import uuid7
+
+@pytest.mark.asyncio
+async def test_sync_accounts_endpoint(client: TestClient, auth_headers: dict):
+    """Test POST /accounts/{connection_id}/sync endpoint."""
+    connection_id = uuid7()
+    
+    response = client.post(
+        f"/api/v1/accounts/{connection_id}/sync",
+        headers=auth_headers,
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "synced_count" in data
+    assert data["synced_count"] >= 0
+```
+
+### Test Pyramid
+
+```text
+           ▲
+          ╱ ╲ 10% API Tests
+         ╱───╲ - Complete flows
+        ╱     ╲
+       ╱       ╲ 20% Integration Tests
+      ╱─────────╲ - Real adapters
+     ╱           ╲
+    ╱             ╲ 70% Unit Tests
+   ╱───────────────╲ - Domain + Application
+```
+
+**Coverage Targets**:
+
+| Layer | Test Type | Coverage Target |
+|-------|-----------|-----------------|
+| Domain | Unit | 95%+ |
+| Application | Unit (mocked ports) | 90%+ |
+| Infrastructure | Integration | 70%+ |
+| Presentation | API | 85%+ |
+
+---
+
+## Benefits
+
+### 1. Testability
+
+**Problem Solved**: Can't test business logic without database/framework.
+
+**Hexagonal Solution**: Test domain in complete isolation.
+
+```python
+# Domain test - NO database, NO framework
+def test_account_deactivate():
+    account = Account(...)
+    account.deactivate()
+    assert account.is_active is False
+```
+
+### 2. Maintainability
+
+**Problem Solved**: Business logic scattered across layers.
+
+**Hexagonal Solution**: All business logic centralized in domain.
+
+```text
+Before: Business logic in controllers, services, models, utilities
+After: Business logic ONLY in domain entities
+```
+
+### 3. Flexibility
+
+**Problem Solved**: Can't swap implementations (PostgreSQL → MongoDB).
+
+**Hexagonal Solution**: Swap adapters without touching domain.
+
+```python
+# Domain depends on port
+class SyncAccountsHandler:
+    def __init__(self, account_repo: AccountRepository):  # Port
+        ...
+
+# Swap adapters via DI
+# Development: In-memory adapter
+# Production: PostgreSQL adapter
+# Testing: Mock adapter
+```
+
+### 4. Framework Independence
+
+**Problem Solved**: Framework upgrade breaks business logic.
+
+**Hexagonal Solution**: Domain survives framework changes.
+
+```text
+FastAPI 0.100 → 0.110: Domain unchanged
+PostgreSQL → MongoDB: Domain unchanged
+Redis → Memcached: Domain unchanged
+```
+
+### 5. Team Scalability
+
+**Problem Solved**: Multiple developers cause merge conflicts.
+
+**Hexagonal Solution**: Clear boundaries enable parallel work.
+
+```text
+Team A: Works on domain (entities, protocols)
+Team B: Works on adapters (PostgreSQL repository)
+Team C: Works on API (FastAPI routers)
+
+No conflicts - different layers!
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ Pitfall 1: Domain Imports Infrastructure
+
+```python
+# WRONG: Domain imports infrastructure
+from sqlalchemy.orm import DeclarativeBase
+
+@dataclass
+class User(DeclarativeBase):  # Domain coupled to SQLAlchemy!
+    ...
+```
+
+**Fix**: Keep domain pure.
+
+```python
+# CORRECT: Pure domain entity
+@dataclass
+class User:
+    id: UUID
+    email: str
+```
+
+### ❌ Pitfall 2: Application Imports Infrastructure
+
+```python
+# WRONG: Handler imports concrete adapter
+from src.infrastructure.persistence.repositories.user_repository import (
+    UserRepository as PostgresUserRepository
+)
+
+class RegisterUserHandler:
+    def __init__(self, user_repo: PostgresUserRepository):  # Concrete!
+        ...
+```
+
+**Fix**: Depend on port.
+
+```python
+# CORRECT: Handler depends on port
+from src.domain.protocols.user_repository import UserRepository
+
+class RegisterUserHandler:
+    def __init__(self, user_repo: UserRepository):  # Protocol!
+        ...
+```
+
+### ❌ Pitfall 3: Leaking Infrastructure into Domain
+
+```python
+# WRONG: Domain entity returns database model
+class Account:
+    def to_model(self) -> AccountModel:  # Domain knows about database!
+        ...
+```
+
+**Fix**: Mapping in adapter.
+
+```python
+# CORRECT: Adapter handles mapping
+class AccountRepository:
+    def _to_entity(self, model: AccountModel) -> Account:
+        # Adapter responsibility
+        ...
+```
+
+---
+
+## Integration with Other Patterns
+
+### Hexagonal + CQRS
+
+**CQRS**: Separates commands (write) from queries (read)  
+**Hexagonal**: Separates domain from infrastructure
+
+```text
+Presentation Layer
+    ↓
+Application Layer (CQRS)
+    ├─ Commands → Write side
+    └─ Queries → Read side
+    ↓
+Domain Layer (Hexagonal Core)
+    ├─ Entities
+    └─ Protocols (Ports)
+    ↑ (implements)
+Infrastructure Layer (Adapters)
+    ├─ Repositories
+    └─ Provider Clients
+```
+
+**See**: `cqrs-pattern.md` for CQRS details.
+
+### Hexagonal + Protocol-Based
+
+**Protocol-Based**: Use Python `Protocol` for ports (structural typing)  
+**Hexagonal**: Ports defined by domain, adapters implement
+
+```python
+# Domain defines port (Protocol)
+class UserRepository(Protocol):
+    async def save(self, user: User) -> None: ...
+
+# Infrastructure implements adapter (no inheritance)
+class PostgresUserRepository:
+    async def save(self, user: User) -> None:
+        # PostgreSQL implementation
+        ...
+```
+
+**See**: `protocol-based-architecture.md` for Protocol details.
+
+### Hexagonal + DDD
+
+**DDD**: Domain-Driven Design patterns (entities, value objects, events)  
+**Hexagonal**: Isolates domain from infrastructure
+
+```text
+Hexagonal Architecture (Structure)
+    ↓
+Domain Layer contains:
+    - Entities (DDD)
+    - Value Objects (DDD)
+    - Domain Events (DDD)
+    - Repositories (DDD - as protocols/ports)
+```
+
+**See**: `domain-driven-design-architecture.md` for DDD details.
+
+### Hexagonal + Event Registry
+
+**Event Registry**: Single source of truth for domain events  
+**Hexagonal**: Domain events live in domain layer, handlers in infrastructure
+
+```python
+# Domain: Define events
+class AccountSyncSucceeded(DomainEvent):
+    ...
+
+# Domain: Event Registry (single source of truth)
+EVENT_REGISTRY = [...]
+
+# Infrastructure: Event handlers (adapters)
+class AuditEventHandler:
+    async def handle_account_sync_succeeded(self, event):
+        # Audit infrastructure
+        ...
+```
+
+**See**: `registry-pattern-architecture.md` for Event Registry details.
+
+---
+
+## Comparison: Hexagonal vs Traditional Layered
+
+### Traditional Layered Architecture
+
+```text
+Presentation → Business Logic → Data Access → Database
+(All layers know about each other, tight coupling)
+```
+
+**Problems**:
+
+- Business logic depends on database schema
+- Can't test without database
+- Framework changes break business logic
+- Hard to swap implementations
+
+### Hexagonal Architecture
+
+```text
+        Presentation (Adapter)
+              ↓
+        Application Layer
+              ↓
+        Domain Layer (Core)
+              ↑ (implements)
+        Infrastructure (Adapters)
+              ↑
+        Database, Redis, External APIs
+```
+
+**Benefits**:
+
+- Domain drives design, not database
+- Test domain without infrastructure
+- Framework-independent
+- Easy to swap adapters
+
+### Side-by-Side
+
+| Aspect | Traditional Layered | Hexagonal |
+|--------|---------------------|-----------|
+| **Dependency Direction** | Top-down (Presentation → DB) | Inside-out (All → Domain) |
+| **Business Logic** | Scattered across layers | Centralized in domain |
+| **Testing** | Requires full stack | Domain tests isolated |
+| **Framework** | Tightly coupled | Independent |
+| **Swapping** | Hard (rewrites) | Easy (swap adapters) |
+| **Team Work** | Conflicts common | Parallel work enabled |
+
+---
+
+## Adding New Features (Hexagonal Way)
+
+### Example: Add "Transfer Money" Feature
+
+**Step 1**: Define domain entities/value objects
+
+```python
+# src/domain/entities/transaction.py
+@dataclass
+class Transaction:
+    id: UUID
+    from_account_id: UUID
+    to_account_id: UUID
+    amount: Money
+    status: TransactionStatus
+```
+
+**Step 2**: Define domain protocol (port)
+
+```python
+# src/domain/protocols/transaction_repository.py
+class TransactionRepository(Protocol):
+    async def save(self, transaction: Transaction) -> None: ...
+    async def find_by_id(self, transaction_id: UUID) -> Transaction | None: ...
+```
+
+**Step 3**: Create application handler
+
+```python
+# src/application/commands/handlers/transfer_money_handler.py
+class TransferMoneyHandler:
+    def __init__(
+        self,
+        account_repo: AccountRepository,  # Port
+        transaction_repo: TransactionRepository,  # Port
+    ):
+        self._account_repo = account_repo
+        self._transaction_repo = transaction_repo
+    
+    async def handle(self, cmd: TransferMoney) -> Result[UUID, str]:
+        # Business logic using domain entities
+        ...
+```
+
+**Step 4**: Implement infrastructure adapter
+
+```python
+# src/infrastructure/persistence/repositories/transaction_repository.py
+class TransactionRepository:  # Implements port
+    def __init__(self, session: AsyncSession):
+        self._session = session
+    
+    async def save(self, transaction: Transaction) -> None:
+        # PostgreSQL implementation
+        ...
+```
+
+**Step 5**: Create API endpoint
+
+```python
+# src/presentation/routers/api/v1/transactions.py
+@router.post("/transfers")
+async def transfer_money(
+    data: TransferRequest,
+    handler: TransferMoneyHandler = Depends(get_transfer_money_handler),
+):
+    result = await handler.handle(TransferMoney(...))
+    # ...
+```
+
+**Step 6**: Write tests
+
+```python
+# tests/unit/test_domain_transaction.py - Domain tests (no infrastructure)
+# tests/unit/test_application_transfer_handler.py - Handler tests (mocked ports)
+# tests/integration/test_transaction_repository.py - Adapter tests (real DB)
+# tests/api/test_transactions_endpoints.py - API tests (end-to-end)
+```
+
+**Key Points**:
+
+- Start with domain (entities, protocols)
+- Application depends on domain protocols
+- Infrastructure implements protocols last
+- API layer is thin (dispatch only)
+- Test each layer independently
+
+---
+
+## Real-World Example from Dashtam
+
+### Feature: Sync Accounts from Provider
+
+**Domain Layer** (`src/domain/`):
+
+```python
+# entities/account.py - Business entity
+@dataclass
+class Account:
+    id: UUID
+    provider_connection_id: UUID
+    balance: Money
+    # ...
+
+# protocols/account_repository.py - Port
+class AccountRepository(Protocol):
+    async def save(self, account: Account) -> None: ...
+
+# protocols/provider_protocol.py - Port
+class ProviderProtocol(Protocol):
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, str],
+    ) -> Result[list[Account], ProviderError]: ...
+
+# events/data_events.py - Domain events
+@dataclass(frozen=True, kw_only=True)
+class AccountSyncSucceeded(DomainEvent):
+    provider_connection_id: UUID
+    account_count: int
+```
+
+**Application Layer** (`src/application/`):
+
+```python
+# commands/handlers/sync_accounts_handler.py
+class SyncAccountsHandler:
+    def __init__(
+        self,
+        account_repo: AccountRepository,  # Port!
+        provider: ProviderProtocol,  # Port!
+        event_bus: EventBusProtocol,  # Port!
+    ):
+        self._account_repo = account_repo
+        self._provider = provider
+        self._event_bus = event_bus
+    
+    async def handle(
+        self,
+        connection_id: UUID,
+        credentials: dict[str, str],
+    ) -> Result[int, str]:
+        # Fetch from provider
+        result = await self._provider.fetch_accounts(credentials)
+        
+        if isinstance(result, Failure):
+            return result
+        
+        accounts = result.value
+        
+        # Save to repository
+        for account in accounts:
+            await self._account_repo.save(account)
+        
+        # Emit event
+        await self._event_bus.publish(
+            AccountSyncSucceeded(
+                provider_connection_id=connection_id,
+                account_count=len(accounts),
+            )
+        )
+        
+        return Success(value=len(accounts))
+```
+
+**Infrastructure Layer** (`src/infrastructure/`):
+
+```python
+# persistence/repositories/account_repository.py - Adapter
+class AccountRepository:  # Implements port (no inheritance)
+    def __init__(self, session: AsyncSession):
+        self._session = session
+    
+    async def save(self, account: Account) -> None:
+        # PostgreSQL logic
+        model = AccountModel(...)
+        self._session.add(model)
+        await self._session.flush()
+
+# providers/schwab/schwab_provider.py - Adapter
+class SchwabProvider:  # Implements port (no inheritance)
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, str],
+    ) -> Result[list[Account], ProviderError]:
+        # Schwab API logic
+        response = await self._api_client.get_accounts(
+            access_token=credentials["access_token"]
+        )
+        # Map Schwab response → domain Account entities
+        accounts = [self._mapper.map(acc) for acc in response]
+        return Success(value=accounts)
+```
+
+**Presentation Layer** (`src/presentation/`):
+
+```python
+# routers/api/v1/accounts.py - API endpoint
+@router.post("/{connection_id}/sync")
+async def sync_accounts(
+    connection_id: UUID,
+    handler: SyncAccountsHandler = Depends(get_sync_accounts_handler),
+) -> dict[str, int]:
+    # Thin layer - dispatch to handler
+    result = await handler.handle(connection_id=connection_id)
+    
+    if isinstance(result, Failure):
+        raise HTTPException(400, detail=result.error)
+    
+    return {"synced_count": result.value}
+```
+
+**Key Points**:
+
+- ✅ Handler depends on **ports** (AccountRepository, ProviderProtocol)
+- ✅ Infrastructure implements **adapters** (PostgresAccountRepository, SchwabProvider)
+- ✅ Domain has zero infrastructure imports
+- ✅ Easy to test (mock ports in unit tests)
+- ✅ Easy to swap (Schwab → Alpaca, just change adapter)
+
+---
+
+## References
+
+**Related Architecture Documents**:
+
+- [CQRS Pattern](cqrs-pattern.md) - Command/Query separation
+- [Protocol-Based Architecture](protocol-based-architecture.md) - Structural typing with Protocol
+- [Domain-Driven Design](domain-driven-design-architecture.md) - Pragmatic DDD patterns
+- [Event Registry Pattern](registry-pattern-architecture.md) - Single source of truth for events
+- [Directory Structure](directory-structure.md) - File organization following hexagonal architecture
+- [Dependency Injection](dependency-injection-architecture.md) - Container pattern for ports/adapters
+
+**External Resources**:
+
+- [Hexagonal Architecture (Alistair Cockburn)](https://alistair.cockburn.us/hexagonal-architecture/)
+- [Clean Architecture (Robert Martin)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+
+---
+
+**Created**: 2025-12-30 | **Last Updated**: 2025-12-30

--- a/docs/architecture/protocol-based-architecture.md
+++ b/docs/architecture/protocol-based-architecture.md
@@ -1,0 +1,1340 @@
+# Protocol-Based Architecture
+
+## Overview
+
+**Purpose**: Use Python `Protocol` for structural typing to define interfaces without inheritance, enabling flexible, testable, and Pythonic code.
+
+**Problem**: Traditional ABC (Abstract Base Classes) create tight coupling:
+
+- Concrete classes must inherit from ABC (nominal typing)
+- Hard to test (must inherit to satisfy type checker)
+- Not Pythonic (duck typing is preferred in Python)
+- Difficult to adapt third-party code
+- Coupling between interface definition and implementation
+
+**Solution**: Protocol-based architecture using Python 3.8+ `Protocol`:
+
+- **Structural typing**: Classes satisfy protocols by shape, not inheritance
+- **No inheritance required**: Duck typing with type safety
+- **Easy testing**: Mock objects don't need inheritance
+- **Pythonic**: Aligns with Python's philosophy
+- **Framework independence**: Third-party code can satisfy protocols
+
+---
+
+## Core Concepts
+
+### 1. Structural Typing vs Nominal Typing
+
+**Nominal Typing** (ABC): Class must explicitly inherit to satisfy interface.
+
+```python
+# Nominal typing with ABC
+from abc import ABC, abstractmethod
+
+class CacheBackend(ABC):
+    @abstractmethod
+    async def get(self, key: str) -> str | None:
+        pass
+
+class RedisCache(CacheBackend):  # MUST inherit
+    async def get(self, key: str) -> str | None:
+        return await self.redis.get(key)
+```
+
+**Structural Typing** (Protocol): Class satisfies interface by having correct method signatures.
+
+```python
+# Structural typing with Protocol
+from typing import Protocol
+
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> str | None:
+        """Get value by key."""
+        ...
+
+class RedisCache:  # NO inheritance needed!
+    async def get(self, key: str) -> str | None:
+        return await self.redis.get(key)
+
+# RedisCache satisfies CacheProtocol automatically (duck typing)
+```
+
+**Key Difference**: Protocol checks **shape** (method signatures), ABC checks **inheritance** (class hierarchy).
+
+### 2. Why Protocol Over ABC?
+
+#### Pythonic Philosophy
+
+Python embraces **duck typing**: "If it walks like a duck and quacks like a duck, it's a duck."
+
+```python
+# Duck typing in Python
+def process(items):
+    for item in items:
+        print(item)
+
+# Works with list, tuple, set, generator - no inheritance needed!
+process([1, 2, 3])
+process((1, 2, 3))
+process({1, 2, 3})
+```
+
+**Protocol extends duck typing with type safety**:
+
+```python
+from typing import Protocol
+
+class Iterable(Protocol):
+    def __iter__(self):
+        ...
+
+def process(items: Iterable):  # Type-checked duck typing
+    for item in items:
+        print(item)
+```
+
+#### No Inheritance Required
+
+**ABC Problem**:
+
+```python
+class CacheBackend(ABC):
+    @abstractmethod
+    async def get(self, key: str) -> str | None:
+        pass
+
+# MUST inherit to satisfy type checker
+class RedisCache(CacheBackend):
+    ...
+
+# Can't adapt third-party library without wrapper
+from third_party import TheirCache  # Can't make this inherit CacheBackend
+```
+
+**Protocol Solution**:
+
+```python
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> str | None:
+        ...
+
+# NO inheritance needed
+class RedisCache:
+    async def get(self, key: str) -> str | None:
+        ...
+
+# Third-party code works if it has correct shape
+from third_party import TheirCache  # Works if it has get() method!
+```
+
+#### Easy Testing
+
+**ABC Problem**:
+
+```python
+# Mock MUST inherit to satisfy mypy
+class MockCache(CacheBackend):  # Inheritance required
+    async def get(self, key: str) -> str | None:
+        return "mocked"
+```
+
+**Protocol Solution**:
+
+```python
+# Mock doesn't need inheritance
+class MockCache:  # No inheritance!
+    async def get(self, key: str) -> str | None:
+        return "mocked"
+
+# Or use unittest.mock.AsyncMock with spec
+mock = AsyncMock(spec=CacheProtocol)
+```
+
+#### Framework Independence
+
+**Protocol allows domain to define interfaces without coupling to implementation**:
+
+```python
+# Domain defines port (Protocol)
+class UserRepository(Protocol):
+    async def save(self, user: User) -> None: ...
+
+# Infrastructure implements adapter (no inheritance)
+class PostgresUserRepository:  # No coupling to domain!
+    async def save(self, user: User) -> None:
+        # PostgreSQL implementation
+        ...
+```
+
+**This is the foundation of Hexagonal Architecture**: Domain defines ports, infrastructure provides adapters.
+
+### 3. Protocol Syntax
+
+**Basic Protocol**:
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    """Protocol for objects that can be drawn."""
+    
+    def draw(self) -> None:
+        """Draw the object."""
+        ...
+```
+
+**Protocol with Methods and Properties**:
+
+```python
+from typing import Protocol
+
+class Sized(Protocol):
+    """Protocol for objects with size."""
+    
+    @property
+    def size(self) -> int:
+        """Object size."""
+        ...
+    
+    def resize(self, new_size: int) -> None:
+        """Resize object."""
+        ...
+```
+
+**Generic Protocol**:
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Container(Protocol[T]):
+    """Generic container protocol."""
+    
+    def add(self, item: T) -> None:
+        """Add item to container."""
+        ...
+    
+    def get(self, index: int) -> T:
+        """Get item by index."""
+        ...
+```
+
+**Protocol with Async Methods**:
+
+```python
+from typing import Protocol
+
+class AsyncRepository(Protocol):
+    """Protocol for async repository operations."""
+    
+    async def find_by_id(self, id: str) -> object | None:
+        """Find entity by ID."""
+        ...
+    
+    async def save(self, entity: object) -> None:
+        """Save entity."""
+        ...
+```
+
+---
+
+## Protocol Implementations in Dashtam
+
+### Repository Protocols
+
+**Port (Domain Layer)**:
+
+```python
+# src/domain/protocols/user_repository.py
+from typing import Protocol
+from uuid import UUID
+from src.domain.entities.user import User
+
+class UserRepository(Protocol):
+    """Repository port for user persistence.
+    
+    Implementations must provide async methods for user CRUD operations.
+    All methods return domain entities, not database models.
+    """
+    
+    async def find_by_id(self, user_id: UUID) -> User | None:
+        """Find user by ID.
+        
+        Args:
+            user_id: User identifier.
+            
+        Returns:
+            User entity if found, None otherwise.
+        """
+        ...
+    
+    async def find_by_email(self, email: str) -> User | None:
+        """Find user by email address.
+        
+        Args:
+            email: User's email address.
+            
+        Returns:
+            User entity if found, None otherwise.
+        """
+        ...
+    
+    async def save(self, user: User) -> None:
+        """Persist user entity.
+        
+        Args:
+            user: User entity to persist.
+        """
+        ...
+    
+    async def delete(self, user_id: UUID) -> None:
+        """Delete user by ID.
+        
+        Args:
+            user_id: User identifier.
+        """
+        ...
+```
+
+**Adapter (Infrastructure Layer)**:
+
+```python
+# src/infrastructure/persistence/repositories/user_repository.py
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, delete
+from uuid import UUID
+
+from src.domain.entities.user import User
+from src.infrastructure.persistence.models.user import UserModel
+
+class UserRepository:  # NO inheritance!
+    """PostgreSQL adapter for UserRepository port.
+    
+    Implements UserRepository protocol via structural typing.
+    Handles mapping between domain entities and database models.
+    """
+    
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository.
+        
+        Args:
+            session: SQLAlchemy async session.
+        """
+        self._session = session
+    
+    async def find_by_id(self, user_id: UUID) -> User | None:
+        """Find user by ID in PostgreSQL."""
+        result = await self._session.execute(
+            select(UserModel).where(UserModel.id == user_id)
+        )
+        model = result.scalar_one_or_none()
+        
+        if model is None:
+            return None
+        
+        return self._to_entity(model)
+    
+    async def find_by_email(self, email: str) -> User | None:
+        """Find user by email in PostgreSQL."""
+        result = await self._session.execute(
+            select(UserModel).where(UserModel.email == email)
+        )
+        model = result.scalar_one_or_none()
+        
+        if model is None:
+            return None
+        
+        return self._to_entity(model)
+    
+    async def save(self, user: User) -> None:
+        """Persist user entity to PostgreSQL."""
+        existing = await self._session.get(UserModel, user.id)
+        
+        if existing:
+            # Update
+            existing.email = user.email
+            existing.is_verified = user.is_verified
+        else:
+            # Insert
+            model = self._to_model(user)
+            self._session.add(model)
+        
+        await self._session.flush()
+    
+    async def delete(self, user_id: UUID) -> None:
+        """Delete user from PostgreSQL."""
+        await self._session.execute(
+            delete(UserModel).where(UserModel.id == user_id)
+        )
+        await self._session.flush()
+    
+    def _to_entity(self, model: UserModel) -> User:
+        """Map database model to domain entity."""
+        return User(
+            id=model.id,
+            email=model.email,
+            is_verified=model.is_verified,
+        )
+    
+    def _to_model(self, user: User) -> UserModel:
+        """Map domain entity to database model."""
+        return UserModel(
+            id=user.id,
+            email=user.email,
+            is_verified=user.is_verified,
+        )
+```
+
+**Key Points**:
+
+- ✅ `UserRepository` class has NO inheritance
+- ✅ Satisfies `UserRepository` protocol by having correct method signatures
+- ✅ mypy verifies compatibility at type-check time
+- ✅ Easy to swap implementations (PostgreSQL → MongoDB)
+
+### Service Protocols
+
+**Cache Protocol**:
+
+```python
+# src/domain/protocols/cache_protocol.py
+from typing import Protocol
+from src.core.result import Result
+from src.core.errors import DomainError
+
+class CacheProtocol(Protocol):
+    """Protocol for cache operations.
+    
+    Implementations provide key-value storage with TTL support.
+    All operations return Result types for explicit error handling.
+    """
+    
+    async def get(self, key: str) -> Result[str | None, DomainError]:
+        """Get value by key.
+        
+        Args:
+            key: Cache key.
+            
+        Returns:
+            Success(value) if key exists, Success(None) if not found,
+            Failure(error) on cache failure.
+        """
+        ...
+    
+    async def set(
+        self,
+        key: str,
+        value: str,
+        ttl: int | None = None,
+    ) -> Result[None, DomainError]:
+        """Set key-value pair with optional TTL.
+        
+        Args:
+            key: Cache key.
+            value: Value to cache.
+            ttl: Time-to-live in seconds (None = no expiry).
+            
+        Returns:
+            Success(None) on success, Failure(error) on cache failure.
+        """
+        ...
+    
+    async def delete(self, key: str) -> Result[None, DomainError]:
+        """Delete key from cache.
+        
+        Args:
+            key: Cache key.
+            
+        Returns:
+            Success(None) on success, Failure(error) on cache failure.
+        """
+        ...
+    
+    async def delete_pattern(self, pattern: str) -> Result[int, DomainError]:
+        """Delete all keys matching pattern.
+        
+        Args:
+            pattern: Pattern to match (e.g., "user:*").
+            
+        Returns:
+            Success(deleted_count), Failure(error) on cache failure.
+        """
+        ...
+```
+
+**Redis Adapter**:
+
+```python
+# src/infrastructure/cache/redis_adapter.py
+from redis.asyncio import Redis
+from src.core.result import Result, Success, Failure
+from src.core.errors import DomainError
+
+class RedisAdapter:  # NO inheritance!
+    """Redis implementation of CacheProtocol."""
+    
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+    
+    async def get(self, key: str) -> Result[str | None, DomainError]:
+        """Get value from Redis."""
+        try:
+            value = await self._redis.get(key)
+            return Success(value=value.decode() if value else None)
+        except Exception as e:
+            return Failure(error=DomainError(message=str(e)))
+    
+    async def set(
+        self,
+        key: str,
+        value: str,
+        ttl: int | None = None,
+    ) -> Result[None, DomainError]:
+        """Set value in Redis."""
+        try:
+            await self._redis.set(key, value, ex=ttl)
+            return Success(value=None)
+        except Exception as e:
+            return Failure(error=DomainError(message=str(e)))
+    
+    async def delete(self, key: str) -> Result[None, DomainError]:
+        """Delete key from Redis."""
+        try:
+            await self._redis.delete(key)
+            return Success(value=None)
+        except Exception as e:
+            return Failure(error=DomainError(message=str(e)))
+    
+    async def delete_pattern(self, pattern: str) -> Result[int, DomainError]:
+        """Delete keys matching pattern from Redis."""
+        try:
+            keys = []
+            async for key in self._redis.scan_iter(match=pattern):
+                keys.append(key)
+            
+            if keys:
+                deleted = await self._redis.delete(*keys)
+            else:
+                deleted = 0
+            
+            return Success(value=deleted)
+        except Exception as e:
+            return Failure(error=DomainError(message=str(e)))
+```
+
+### Provider Protocols
+
+**Provider Protocol**:
+
+```python
+# src/domain/protocols/provider_protocol.py
+from typing import Protocol
+from src.core.result import Result
+from src.domain.entities.account import Account
+from src.domain.entities.transaction import Transaction
+from src.domain.errors.provider_error import ProviderError
+
+class ProviderProtocol(Protocol):
+    """Protocol for financial provider adapters.
+    
+    Implementations integrate with financial institutions (brokerages, banks)
+    to fetch account and transaction data. All methods return Result types.
+    """
+    
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, str],
+    ) -> Result[list[Account], ProviderError]:
+        """Fetch all accounts from provider.
+        
+        Args:
+            credentials: Provider-specific credentials (OAuth tokens, API keys, etc.).
+            
+        Returns:
+            Success(accounts) with domain Account entities,
+            Failure(error) on provider API failure.
+        """
+        ...
+    
+    async def fetch_transactions(
+        self,
+        credentials: dict[str, str],
+        account_id: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> Result[list[Transaction], ProviderError]:
+        """Fetch transactions for account.
+        
+        Args:
+            credentials: Provider-specific credentials.
+            account_id: Provider's account identifier.
+            start_date: Start date (ISO format, optional).
+            end_date: End date (ISO format, optional).
+            
+        Returns:
+            Success(transactions) with domain Transaction entities,
+            Failure(error) on provider API failure.
+        """
+        ...
+```
+
+**Schwab Provider Adapter**:
+
+```python
+# src/infrastructure/providers/schwab/schwab_provider.py
+from src.core.result import Result, Success, Failure
+from src.domain.entities.account import Account
+from src.domain.entities.transaction import Transaction
+from src.domain.errors.provider_error import ProviderError
+from src.infrastructure.providers.schwab.api_client import SchwabAPIClient
+from src.infrastructure.providers.schwab.mappers import (
+    SchwabAccountMapper,
+    SchwabTransactionMapper,
+)
+
+class SchwabProvider:  # NO inheritance!
+    """Charles Schwab provider adapter.
+    
+    Implements ProviderProtocol for Schwab brokerage integration.
+    """
+    
+    def __init__(
+        self,
+        api_client: SchwabAPIClient,
+        account_mapper: SchwabAccountMapper,
+        transaction_mapper: SchwabTransactionMapper,
+    ) -> None:
+        self._api_client = api_client
+        self._account_mapper = account_mapper
+        self._transaction_mapper = transaction_mapper
+    
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, str],
+    ) -> Result[list[Account], ProviderError]:
+        """Fetch accounts from Schwab API."""
+        access_token = credentials.get("access_token")
+        
+        if not access_token:
+            return Failure(
+                error=ProviderError(message="Missing access_token")
+            )
+        
+        # Call Schwab API
+        result = await self._api_client.get_accounts(access_token)
+        
+        if isinstance(result, Failure):
+            return result
+        
+        # Map Schwab response → domain Account entities
+        schwab_accounts = result.value
+        accounts = [
+            self._account_mapper.map(acc) for acc in schwab_accounts
+        ]
+        
+        return Success(value=accounts)
+    
+    async def fetch_transactions(
+        self,
+        credentials: dict[str, str],
+        account_id: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> Result[list[Transaction], ProviderError]:
+        """Fetch transactions from Schwab API."""
+        access_token = credentials.get("access_token")
+        
+        if not access_token:
+            return Failure(
+                error=ProviderError(message="Missing access_token")
+            )
+        
+        # Call Schwab API
+        result = await self._api_client.get_transactions(
+            access_token=access_token,
+            account_id=account_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        
+        if isinstance(result, Failure):
+            return result
+        
+        # Map Schwab response → domain Transaction entities
+        schwab_transactions = result.value
+        transactions = [
+            self._transaction_mapper.map(txn) for txn in schwab_transactions
+        ]
+        
+        return Success(value=transactions)
+```
+
+---
+
+## Protocol vs Inheritance: Decision Matrix
+
+### When to Use Protocol
+
+**Use Protocol for**:
+
+✅ **Interfaces with multiple implementations**
+
+```python
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> str | None: ...
+
+# Multiple implementations
+class RedisCache: ...
+class MemcachedCache: ...
+class InMemoryCache: ...
+```
+
+✅ **Domain ports (Hexagonal Architecture)**
+
+```python
+# Domain defines port
+class UserRepository(Protocol):
+    async def save(self, user: User) -> None: ...
+
+# Infrastructure provides adapter
+class PostgresUserRepository: ...
+```
+
+✅ **Third-party integration**
+
+```python
+# Adapt third-party library without wrapper
+class FileSystem(Protocol):
+    def read(self, path: str) -> str: ...
+
+# Works with any object that has read()
+import os  # os module satisfies protocol!
+```
+
+✅ **Testing with mocks**
+
+```python
+# Easy mocking without inheritance
+mock = AsyncMock(spec=CacheProtocol)
+```
+
+### When to Use Inheritance
+
+**Use Inheritance for**:
+
+✅ **Data structures sharing fields**
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class DomainError:
+    code: ErrorCode
+    message: str
+
+class ValidationError(DomainError):  # Inherits fields
+    field: str | None = None
+```
+
+✅ **Domain events**
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class DomainEvent:
+    event_id: UUID
+    occurred_at: datetime
+
+class UserRegistered(DomainEvent):  # Inherits event metadata
+    user_id: UUID
+    email: str
+```
+
+✅ **Commands/Queries (shared structure)**
+
+```python
+# Base structure for all commands
+@dataclass(frozen=True, kw_only=True)
+class Command:
+    pass
+
+class RegisterUser(Command):
+    email: str
+    password: str
+```
+
+### Decision Table
+
+| Use Case | Pattern | Example |
+|----------|---------|---------|
+| Repository interfaces | **Protocol** | UserRepository, AccountRepository |
+| Service interfaces | **Protocol** | CacheProtocol, LoggerProtocol |
+| Provider adapters | **Protocol** | ProviderProtocol |
+| Error hierarchies | **Inheritance** | DomainError → ValidationError |
+| Domain events | **Inheritance** | DomainEvent → UserRegistered |
+| Commands/Queries | **Inheritance** | Command → RegisterUser |
+
+---
+
+## Testing with Protocols
+
+### Unit Testing with Mocks
+
+#### Example: Test handler with mocked repository protocol
+
+```python
+# tests/unit/test_application_register_user_handler.py
+from unittest.mock import AsyncMock
+import pytest
+from uuid import uuid7
+
+from src.application.commands.handlers.register_user_handler import (
+    RegisterUserHandler,
+)
+from src.domain.protocols.user_repository import UserRepository
+from src.domain.entities.user import User
+from src.core.result import Success
+
+@pytest.mark.asyncio
+async def test_register_user_success():
+    """Test successful user registration."""
+    # Mock protocol - NO inheritance needed!
+    mock_repo = AsyncMock(spec=UserRepository)
+    mock_repo.find_by_email.return_value = None  # User doesn't exist
+    
+    handler = RegisterUserHandler(user_repo=mock_repo)
+    
+    result = await handler.handle(
+        email="test@example.com",
+        password="SecurePass123!",
+    )
+    
+    assert isinstance(result, Success)
+    
+    # Verify repository called
+    mock_repo.save.assert_called_once()
+    saved_user = mock_repo.save.call_args[0][0]
+    assert isinstance(saved_user, User)
+    assert saved_user.email == "test@example.com"
+```
+
+**Key Benefits**:
+
+- ✅ `AsyncMock(spec=UserRepository)` verifies mock has correct methods
+- ✅ NO inheritance required for mock
+- ✅ Type-safe (mypy checks mock usage)
+
+### Integration Testing with Real Adapters
+
+#### Example: Test real adapter implements protocol correctly
+
+```python
+# tests/integration/test_user_repository.py
+import pytest
+from uuid import uuid7
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.entities.user import User
+from src.infrastructure.persistence.repositories.user_repository import (
+    UserRepository,
+)
+
+@pytest.mark.asyncio
+async def test_user_repository_implements_protocol(db_session: AsyncSession):
+    """Verify UserRepository implements protocol correctly."""
+    repo = UserRepository(session=db_session)
+    
+    # Create user
+    user = User(
+        id=uuid7(),
+        email="test@example.com",
+        is_verified=False,
+    )
+    
+    # Test save (protocol method)
+    await repo.save(user)
+    await db_session.commit()
+    
+    # Test find_by_email (protocol method)
+    found = await repo.find_by_email("test@example.com")
+    
+    assert found is not None
+    assert found.id == user.id
+    assert found.email == user.email
+```
+
+### Type Checking with mypy
+
+**mypy verifies protocol compatibility**:
+
+```python
+# Domain handler depends on protocol
+class RegisterUserHandler:
+    def __init__(self, user_repo: UserRepository):  # Protocol!
+        self._user_repo = user_repo
+
+# mypy verifies adapter satisfies protocol
+repo = PostgresUserRepository(session=session)
+handler = RegisterUserHandler(user_repo=repo)  # ✅ Type-safe
+
+# mypy catches mismatches
+class BrokenRepo:
+    async def save(self, user: User, extra: int) -> None:  # Wrong signature!
+        pass
+
+handler = RegisterUserHandler(user_repo=BrokenRepo())  # ❌ mypy error!
+```
+
+---
+
+## Common Pitfalls and Solutions
+
+### ❌ Pitfall 1: Forgetting `...` in Protocol Methods
+
+```python
+# WRONG: No implementation marker
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> str | None:
+        pass  # Should be `...`
+
+# CORRECT: Use `...` (ellipsis)
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> str | None:
+        ...
+```
+
+**Why**: `...` signals "no implementation" (protocol definition), `pass` is valid but less clear.
+
+### ❌ Pitfall 2: Incorrect Method Signature
+
+```python
+# Protocol defines method
+class UserRepository(Protocol):
+    async def find_by_id(self, user_id: UUID) -> User | None:
+        ...
+
+# WRONG: Missing async
+class PostgresUserRepository:
+    def find_by_id(self, user_id: UUID) -> User | None:  # Not async!
+        ...
+
+# mypy error: Method signature doesn't match protocol
+```
+
+**Fix**: Match signatures exactly (including `async`, parameters, return type).
+
+### ❌ Pitfall 3: Protocol with `kw_only` and mypy
+
+```python
+# Protocol uses kw_only
+@dataclass(frozen=True, kw_only=True)
+class Success:
+    value: Any
+
+# mypy reports error with positional pattern matching
+match result:
+    case Success(value):  # Error: requires keyword argument
+        ...
+
+# Fix: Use isinstance() instead
+if isinstance(result, Failure):
+    # Handle failure
+    ...
+
+# Type narrowing gives us Success
+value = result.value
+```
+
+**See**: WARP.md Section 4 (Pattern Matching with kw_only Dataclasses).
+
+### ❌ Pitfall 4: Protocol Import Cycles
+
+```python
+# domain/protocols/user_repository.py
+from src.domain.entities.user import User  # Import entity
+
+class UserRepository(Protocol):
+    async def save(self, user: User) -> None:
+        ...
+
+# domain/entities/user.py
+from src.domain.protocols.user_repository import UserRepository  # Cycle!
+```
+
+**Fix**: Don't import protocols into entities. Entities don't need repository references.
+
+### ❌ Pitfall 5: Not Using `spec` in Mocks
+
+```python
+# WRONG: No spec, no type safety
+mock_repo = AsyncMock()  # Any method call accepted!
+mock_repo.non_existent_method()  # No error!
+
+# CORRECT: Use spec
+mock_repo = AsyncMock(spec=UserRepository)
+mock_repo.non_existent_method()  # AttributeError!
+```
+
+---
+
+## Protocol Best Practices
+
+### 1. Keep Protocols Focused
+
+**Good**: Single responsibility
+
+```python
+class UserRepository(Protocol):
+    """User persistence only."""
+    async def find_by_id(self, user_id: UUID) -> User | None: ...
+    async def save(self, user: User) -> None: ...
+```
+
+**Bad**: Mixed responsibilities
+
+```python
+class UserManager(Protocol):  # Too broad!
+    async def find_by_id(self, user_id: UUID) -> User | None: ...
+    async def send_email(self, user: User) -> None: ...  # Different concern!
+    async def log_activity(self, user: User) -> None: ...  # Different concern!
+```
+
+### 2. Use Google-Style Docstrings
+
+**Every protocol method should document**:
+
+- Purpose
+- Parameters
+- Return value
+- Expected behavior
+
+```python
+class CacheProtocol(Protocol):
+    """Protocol for cache operations."""
+    
+    async def get(self, key: str) -> Result[str | None, DomainError]:
+        """Get value by key.
+        
+        Args:
+            key: Cache key.
+            
+        Returns:
+            Success(value) if key exists, Success(None) if key not found,
+            Failure(error) on cache system failure.
+        """
+        ...
+```
+
+### 3. Location: `src/domain/protocols/`
+
+**ALL protocols in one place** (Protocol consolidation):
+
+```text
+src/domain/protocols/
+├── user_repository.py
+├── account_repository.py
+├── cache_protocol.py
+├── logger_protocol.py
+├── provider_protocol.py
+└── ...
+```
+
+**See**: `directory-structure.md` for protocol consolidation rationale.
+
+### 4. Naming Convention
+
+**Repositories**: `{Entity}Repository` (e.g., `UserRepository`, `AccountRepository`)  
+**Services**: `{Service}Protocol` (e.g., `CacheProtocol`, `LoggerProtocol`)  
+**Adapters**: `{Provider}Protocol` (e.g., `ProviderProtocol`, `EmailProtocol`)
+
+### 5. Result Types for Error Handling
+
+**Protocols return Result types** (Railway-Oriented Programming):
+
+```python
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> Result[str | None, DomainError]:
+        """Return Success or Failure, never raise."""
+        ...
+```
+
+**See**: `error-handling-architecture.md` for Result types.
+
+### 6. Protocol Exports
+
+**Export all protocols from `__init__.py`**:
+
+```python
+# src/domain/protocols/__init__.py
+from src.domain.protocols.user_repository import UserRepository
+from src.domain.protocols.cache_protocol import CacheProtocol
+from src.domain.protocols.logger_protocol import LoggerProtocol
+
+__all__ = [
+    "UserRepository",
+    "CacheProtocol",
+    "LoggerProtocol",
+]
+```
+
+---
+
+## Integration with Hexagonal Architecture
+
+**Protocols are the "Ports" in Hexagonal Architecture**:
+
+```text
+┌─────────────────────────────────────────┐
+│ Domain Layer (Core)                     │
+│                                         │
+│ Protocols (Ports) ←─────────────┐      │
+│ - UserRepository                 │      │
+│ - CacheProtocol                  │      │
+│ - ProviderProtocol               │      │
+└─────────────────────────────────────────┘
+          ↑ implements                      
+          │                                 
+┌─────────────────────────────────────────┐
+│ Infrastructure Layer (Adapters)         │
+│                                         │
+│ Adapters (Implementations)              │
+│ - PostgresUserRepository                │
+│ - RedisCache                            │
+│ - SchwabProvider                        │
+└─────────────────────────────────────────┘
+```
+
+**Flow**:
+
+1. Domain defines **port** (Protocol)
+2. Infrastructure implements **adapter** (concrete class)
+3. Application depends on **port**, receives **adapter** via DI
+4. No coupling: Domain doesn't know about infrastructure
+
+**See**: `hexagonal-architecture.md` for complete hexagonal architecture details.
+
+---
+
+## Real-World Examples from Dashtam
+
+### Example 1: Cache Protocol
+
+**Port**:
+
+```python
+# src/domain/protocols/cache_protocol.py
+class CacheProtocol(Protocol):
+    async def get(self, key: str) -> Result[str | None, DomainError]: ...
+    async def set(self, key: str, value: str, ttl: int | None) -> Result[None, DomainError]: ...
+```
+
+**Adapter**:
+
+```python
+# src/infrastructure/cache/redis_adapter.py
+class RedisAdapter:  # Implements CacheProtocol
+    async def get(self, key: str) -> Result[str | None, DomainError]:
+        # Redis implementation
+        ...
+```
+
+**Usage**:
+
+```python
+# Handler depends on protocol
+class SyncAccountsHandler:
+    def __init__(self, cache: CacheProtocol):  # Port!
+        self._cache = cache
+
+# DI container injects adapter
+from src.core.container import get_cache
+cache = get_cache()  # Returns RedisAdapter
+```
+
+### Example 2: Authorization Protocol
+
+**Port**:
+
+```python
+# src/domain/protocols/authorization_protocol.py
+class AuthorizationProtocol(Protocol):
+    async def check_permission(
+        self,
+        user_id: UUID,
+        permission: Permission,
+    ) -> Result[bool, DomainError]:
+        ...
+```
+
+**Adapter**:
+
+```python
+# src/infrastructure/authorization/casbin_adapter.py
+class CasbinAdapter:  # Implements AuthorizationProtocol
+    async def check_permission(
+        self,
+        user_id: UUID,
+        permission: Permission,
+    ) -> Result[bool, DomainError]:
+        # Casbin RBAC implementation
+        ...
+```
+
+### Example 3: Provider Protocol (Multi-Provider)
+
+**Port**:
+
+```python
+# src/domain/protocols/provider_protocol.py
+class ProviderProtocol(Protocol):
+    async def fetch_accounts(
+        self,
+        credentials: dict[str, str],
+    ) -> Result[list[Account], ProviderError]:
+        ...
+```
+
+**Multiple Adapters**:
+
+```python
+# Schwab adapter
+class SchwabProvider:  # OAuth-based
+    async def fetch_accounts(self, credentials):
+        access_token = credentials["access_token"]
+        # Schwab API call
+        ...
+
+# Alpaca adapter
+class AlpacaProvider:  # API Key-based
+    async def fetch_accounts(self, credentials):
+        api_key = credentials["api_key"]
+        api_secret = credentials["api_secret"]
+        # Alpaca API call
+        ...
+
+# Chase adapter
+class ChaseFileProvider:  # File-based
+    async def fetch_accounts(self, credentials):
+        file_content = credentials["file_content"]
+        # Parse QFX/CSV file
+        ...
+```
+
+**All three adapters satisfy the same protocol** — application code doesn't know which provider is used!
+
+---
+
+## Benefits
+
+### 1. Flexibility
+
+**Easy to swap implementations**:
+
+```python
+# Development: In-memory cache
+cache: CacheProtocol = InMemoryCache()
+
+# Production: Redis cache
+cache: CacheProtocol = RedisCache()
+
+# Testing: Mock cache
+cache: CacheProtocol = AsyncMock(spec=CacheProtocol)
+```
+
+**Same interface, different implementations** — no code changes needed.
+
+### 2. Testability
+
+**Mock without inheritance**:
+
+```python
+# NO inheritance required for mock
+mock_repo = AsyncMock(spec=UserRepository)
+
+handler = RegisterUserHandler(user_repo=mock_repo)
+```
+
+**Fast unit tests** — no database, no framework.
+
+### 3. Type Safety
+
+**mypy verifies protocol compatibility**:
+
+```python
+def process(repo: UserRepository):
+    ...
+
+# mypy checks
+process(PostgresUserRepository(...))  # ✅ OK
+process(MongoUserRepository(...))     # ✅ OK
+process(SomeRandomClass(...))          # ❌ mypy error!
+```
+
+### 4. Pythonic
+
+**Aligns with Python philosophy**:
+
+- Duck typing (if it walks like a duck...)
+- No forced inheritance
+- Structural typing
+- EAFP (Easier to Ask Forgiveness than Permission)
+
+### 5. Framework Independence
+
+**Third-party code can satisfy protocols**:
+
+```python
+class Logger(Protocol):
+    def log(self, message: str) -> None: ...
+
+# Standard library logger satisfies protocol!
+import logging
+logger = logging.getLogger()  # Works!
+```
+
+---
+
+## Comparison: Protocol vs ABC
+
+### Side-by-Side
+
+| Aspect | ABC (Nominal) | Protocol (Structural) |
+|--------|---------------|----------------------|
+| **Type Checking** | Inheritance-based | Shape-based |
+| **Inheritance Required** | Yes | No |
+| **Third-Party Adaptation** | Hard (wrapper needed) | Easy (duck typing) |
+| **Testing** | Mock must inherit | Mock doesn't inherit |
+| **Pythonic** | Less Pythonic | More Pythonic |
+| **Runtime Overhead** | Minimal | None |
+| **Framework Independence** | Tight coupling | Loose coupling |
+
+### When ABC is Appropriate
+
+**ABC is fine for**:
+
+- Python standard library (already uses ABC)
+- When you control all implementations
+- When inheritance is semantically correct
+
+**But Protocol is preferred in Dashtam** for flexibility and testability.
+
+---
+
+## References
+
+**Related Architecture Documents**:
+
+- [Hexagonal Architecture](hexagonal-architecture.md) - Protocols as ports
+- [Domain-Driven Design](domain-driven-design-architecture.md) - Repository protocols
+- [CQRS Pattern](cqrs-pattern.md) - Handler dependencies
+- [Directory Structure](directory-structure.md) - Protocol consolidation
+- [Dependency Injection](dependency-injection-architecture.md) - Protocol-based DI
+
+**External Resources**:
+
+- [PEP 544 – Protocols](https://peps.python.org/pep-0544/)
+- [mypy Protocols](https://mypy.readthedocs.io/en/stable/protocols.html)
+- [Python Type Checking Guide](https://realpython.com/python-type-checking/)
+
+---
+
+**Created**: 2025-12-30 | **Last Updated**: 2025-12-30

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,15 +8,26 @@ principles from the ground up.
 
 ### Core Architecture
 
+- **[Hexagonal Architecture](architecture/hexagonal-architecture.md)** -
+  Ports & adapters pattern, dependency rule, layer boundaries,
+  domain at core with zero framework dependencies
+- **[Protocol-Based Architecture](architecture/protocol-based-architecture.md)** -
+  Structural typing with Python Protocol, why Protocol over ABC,
+  repository protocols, testing with protocols
+- **[Domain-Driven Design](architecture/domain-driven-design-architecture.md)** -
+  Pragmatic DDD approach, entities vs value objects, domain events,
+  ubiquitous language, patterns used and skipped
+- **[CQRS Pattern](architecture/cqrs-pattern.md)** -
+  Command Query Responsibility Segregation with separate handlers
+- **[Event Registry Pattern](architecture/registry-pattern-architecture.md)** -
+  Metadata-driven auto-wiring pattern for eliminating manual drift,
+  zero-maintenance component registration
 - **[Directory Structure](architecture/directory-structure.md)** -
   Hexagonal architecture organization, layer responsibilities,
   file naming conventions
 - **[Dependency Injection](architecture/dependency-injection-architecture.md)** -
   Centralized container pattern for managing application and
   request-scoped dependencies
-- **[Registry Pattern](architecture/registry-pattern-architecture.md)** -
-  Metadata-driven auto-wiring pattern for eliminating manual drift,
-  zero-maintenance component registration
 - **[Error Handling](architecture/error-handling-architecture.md)** -
   Railway-oriented programming with Result types, RFC 7807 compliance
 - **[Testing Architecture](architecture/testing-architecture.md)** -
@@ -227,4 +238,4 @@ See `~/starter/development-checklist.md` for the complete feature development wo
 
 ---
 
-**Created**: 2025-11-13 | **Last Updated**: 2025-12-27
+**Created**: 2025-11-13 | **Last Updated**: 2025-12-30

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,6 @@ plugins:
 # Navigation
 nav:
   - Home: index.md
-  - Code Reference: reference/
   - API Reference:
     - Account Operations: api/account-operations.md
     - Authentication: api/authentication.md
@@ -149,8 +148,11 @@ nav:
     - Dependency Injection: architecture/dependency-injection-architecture.md
     - Directory Structure: architecture/directory-structure.md
     - Domain Events: architecture/domain-events-architecture.md
+    - Domain-Driven Design: architecture/domain-driven-design-architecture.md
     - Error Handling: architecture/error-handling-architecture.md
+    - Hexagonal Architecture: architecture/hexagonal-architecture.md
     - Holding Domain: architecture/holding-domain-model.md
+    - Protocol-Based Architecture: architecture/protocol-based-architecture.md
     - Provider Domain: architecture/provider-domain-model.md
     - Provider Integration: architecture/provider-integration-architecture.md
     - Provider OAuth: architecture/provider-oauth-architecture.md
@@ -158,6 +160,7 @@ nav:
     - Registry Pattern: architecture/registry-pattern-architecture.md
     - Repository Pattern: architecture/repository-pattern.md
     - Secrets Management: architecture/secrets-management-architecture.md
+    - Session Management: architecture/session-management-architecture.md
     - Structured Logging: architecture/structured-logging-architecture.md
     - Testing: architecture/testing-architecture.md
     - Token Breach Rotation: architecture/token-breach-rotation-architecture.md
@@ -182,4 +185,6 @@ nav:
     - Local CI Testing: guides/local-ci-testing.md
     - Rate Limit Usage: guides/rate-limit-usage.md
     - Secrets Management Usage: guides/secrets-management-usage.md
+    - Session Management Usage: guides/session-management-usage.md
     - Structured Logging Usage: guides/structured-logging-usage.md
+  - Code Reference: reference/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dashtam"
-version = "1.5.1"
+version = "1.5.2"
 description = "A secure financial data aggregation platform built with hexagonal architecture, CQRS, and domain-driven design"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "dashtam"
-version = "1.5.1"
+version = "1.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
- Created hexagonal-architecture.md (1,451 lines): Complete hexagonal architecture theory including dependency rule, layer boundaries, ports & adapters pattern, benefits vs monolithic architecture, testing strategies, and integration with CQRS/DDD/Protocol patterns
- Created protocol-based-architecture.md (1,340 lines): Comprehensive Protocol pattern guide covering structural vs nominal typing, why Protocol over ABC, Protocol implementations across Dashtam (repositories, services, providers), testing with Protocols, mypy type checking, common pitfalls and solutions
- Created domain-driven-design-architecture.md (1,268 lines): Pragmatic DDD philosophy including what "pragmatic" means for Dashtam, DDD patterns used (entities, value objects, domain events, repositories), DDD patterns NOT used and why, integration with hexagonal/CQRS/Protocol/Event Registry, when to emit domain events, entity vs value object decision tree, domain vs application services boundary
- Updated directory-structure.md: Synchronized with v1.5.1 state including modularized container structure, complete event registry (69 events), and updated schemas section
- Updated docs/index.md: Reorganized Core Architecture section to highlight 5 core architectures
- Updated mkdocs.yml: Added 3 new architecture docs to navigation + fixed missing nav entries
- Updated WARP.md Section 21: Added cross-references to new architecture docs, fixed heading levels for markdown linting
- Updated Makefile: Added --remove-orphans flag to all docker compose up commands
- Updated CHANGELOG.md: Added v1.5.2 release entry
- Bumped version to 1.5.2 in pyproject.toml and updated uv.lock