### PR TITLE
feat(api): implement route metadata registry with generated routes (F8.2)

### DIFF
--- a/docs/architecture/route-registry-architecture.md
+++ b/docs/architecture/route-registry-architecture.md
@@ -1,0 +1,780 @@
+# Route Registry Architecture
+
+## Overview
+
+The Route Metadata Registry is Dashtam's **single source of truth** for all API endpoints. It eliminates decorator sprawl by declaratively defining all 36 routes with their metadata (auth policies, rate limits, error specs, OpenAPI metadata) in a single registry. FastAPI routes, auth dependencies, rate limit rules, and OpenAPI documentation are **auto-generated** from this registry at startup.
+
+This is a **specific implementation** of Dashtam's general [Registry Pattern](registry-pattern-architecture.md), applied to API route management.
+
+---
+
+## Problem Statement
+
+### Decorator Sprawl and Manual Drift
+
+**Before F8.2**, API routes were defined using FastAPI decorators scattered across 12 router files:
+
+```python
+# src/presentation/routers/api/v1/users.py
+@router.post("/users", status_code=201, summary="Create user", tags=["Users"])
+async def create_user(data: UserCreate):
+    ...
+
+# src/presentation/routers/api/v1/sessions.py
+@router.post("/sessions", status_code=201, summary="Login", tags=["Authentication"])
+async def create_session(data: LoginRequest):
+    ...
+
+# ... 34 more endpoints across 12 files
+```
+
+**Manual coordination required**:
+
+1. Define route with `@router` decorator
+2. Add auth dependency (`Depends(get_current_user)`)
+3. Add rate limit rule in `src/infrastructure/rate_limit/config.py`
+4. Add OpenAPI metadata (summary, tags, operation_id)
+5. Add error specs for OpenAPI docs
+6. Update tests for new endpoint
+
+**Problems**:
+
+- ❌ **Drift**: Easy to forget rate limit rules or auth dependencies
+- ❌ **Inconsistency**: Auth policies vary by endpoint (some missing)
+- ❌ **Duplication**: Metadata repeated in decorators, rate limits, tests
+- ❌ **Hard to audit**: No single place to see all endpoints
+- ❌ **Fragile**: Changing endpoint requires updates in 3+ files
+
+---
+
+## Solution Overview
+
+**Route Metadata Registry** centralizes ALL route metadata in `src/presentation/routers/api/v1/routes/registry.py`:
+
+```python
+RouteMetadata(
+    method=HTTPMethod.POST,
+    path="/users",
+    handler=create_user,
+    resource="users",
+    tags=["Users"],
+    summary="Create user",
+    operation_id="create_user",
+    response_model=UserCreateResponse,
+    status_code=201,
+    errors=[
+        ErrorSpec(status=400, description="Validation failed"),
+        ErrorSpec(status=409, description="User already exists"),
+    ],
+    idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+    auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+    rate_limit_policy=RateLimitPolicy.AUTH_REGISTER,
+)
+```
+
+**Auto-generated from registry**:
+
+1. ✅ FastAPI routes registered with `router.add_api_route()`
+2. ✅ Auth dependencies injected based on `auth_policy`
+3. ✅ Rate limit rules generated from `rate_limit_policy`
+4. ✅ OpenAPI metadata (summary, tags, operation_id, error specs)
+5. ✅ Self-enforcing tests prevent drift
+
+**Benefits**:
+
+- ✅ **Single source of truth**: All 36 endpoints in one file
+- ✅ **Zero drift**: Tests fail if metadata incomplete
+- ✅ **Consistency**: Auth/rate limits enforced for all endpoints
+- ✅ **Auditability**: See all API surface area in one place
+- ✅ **Maintainability**: Change once, updates everywhere
+
+---
+
+## Architecture Components
+
+### Component 1: Registry File
+
+**Location**: `src/presentation/routers/api/v1/routes/registry.py`
+
+**Structure**:
+
+```python
+from src.presentation.routers.api.v1.routes.metadata import (
+    RouteMetadata,
+    HTTPMethod,
+    AuthPolicy,
+    AuthLevel,
+    RateLimitPolicy,
+    IdempotencyLevel,
+    ErrorSpec,
+)
+from src.presentation.routers.api.v1.users import create_user
+from src.presentation.routers.api.v1.sessions import (
+    create_session,
+    delete_current_session,
+    list_sessions,
+    # ... other handlers
+)
+
+ROUTE_REGISTRY: list[RouteMetadata] = [
+    # Users (1 endpoint)
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/users",
+        handler=create_user,
+        resource="users",
+        tags=["Users"],
+        summary="Create user",
+        operation_id="create_user",
+        response_model=UserCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Validation failed"),
+            ErrorSpec(status=409, description="User already exists"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_REGISTER,
+    ),
+    
+    # Sessions (6 endpoints)
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/sessions",
+        handler=create_session,
+        resource="sessions",
+        tags=["Authentication"],
+        summary="Login user",
+        operation_id="create_session",
+        response_model=SessionResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid credentials"),
+            ErrorSpec(status=429, description="Rate limit exceeded"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Sessions endpoint handles auth manually (creates tokens)",
+        ),
+        rate_limit_policy=RateLimitPolicy.AUTH_LOGIN,
+    ),
+    
+    # ... 34 more endpoints (total 36)
+]
+```
+
+**Key Properties**:
+
+- **Exhaustive**: All 36 endpoints registered
+- **Type-safe**: `RouteMetadata` dataclass with type hints
+- **Immutable**: `frozen=True` prevents accidental modification
+- **Centralized**: Single file, easy to audit
+
+### Component 2: Metadata Types
+
+**Location**: `src/presentation/routers/api/v1/routes/metadata.py`
+
+**RouteMetadata Dataclass**:
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class RouteMetadata:
+    """Metadata for a single API route."""
+    
+    # Core routing
+    method: HTTPMethod
+    path: str
+    handler: Callable
+    
+    # OpenAPI documentation
+    resource: str
+    tags: list[str]
+    summary: str
+    operation_id: str
+    description: str | None = None
+    
+    # Request/Response
+    request_model: type[BaseModel] | None = None
+    response_model: type[BaseModel] | None = None
+    status_code: int = 200
+    
+    # Error handling (RFC 7807)
+    errors: list[ErrorSpec] = field(default_factory=list)
+    
+    # Policies
+    auth_policy: AuthPolicy
+    rate_limit_policy: RateLimitPolicy
+    idempotency: IdempotencyLevel
+```
+
+**Supporting Enums**:
+
+```python
+class HTTPMethod(str, Enum):
+    """HTTP methods for API routes."""
+    GET = "GET"
+    POST = "POST"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
+class AuthLevel(str, Enum):
+    """Authentication/authorization levels."""
+    PUBLIC = "public"              # No auth required
+    AUTHENTICATED = "authenticated"  # Requires valid token
+    ADMIN = "admin"                # Requires admin role
+    MANUAL_AUTH = "manual_auth"    # Handler manages auth
+
+class RateLimitPolicy(str, Enum):
+    """Rate limit policies for endpoints."""
+    AUTH_LOGIN = "auth_login"              # 5 req/min (IP scope)
+    AUTH_REGISTER = "auth_register"        # 3 req/hour (IP scope)
+    AUTH_TOKEN_REFRESH = "auth_token_refresh"  # 10 req/min (USER scope)
+    AUTH_PASSWORD_RESET = "auth_password_reset"  # 3 req/hour (IP scope)
+    API_READ = "api_read"                  # 100 req/min (USER scope)
+    API_WRITE = "api_write"                # 50 req/min (USER scope)
+    PROVIDER_CONNECT = "provider_connect"  # 5 req/hour (USER scope)
+    PROVIDER_SYNC = "provider_sync"        # 10 req/min (USER_PROVIDER scope)
+
+class IdempotencyLevel(str, Enum):
+    """HTTP idempotency semantics."""
+    SAFE = "safe"                  # GET (no side effects)
+    IDEMPOTENT = "idempotent"      # PUT, DELETE (same result if repeated)
+    NON_IDEMPOTENT = "non_idempotent"  # POST (creates new resource)
+
+@dataclass(frozen=True, kw_only=True)
+class ErrorSpec:
+    """Error specification for OpenAPI documentation."""
+    status: int
+    description: str
+    model: type[BaseModel] | None = None
+```
+
+### Component 3: Route Generator
+
+**Location**: `src/presentation/routers/api/v1/routes/generator.py`
+
+**Purpose**: Convert registry entries into FastAPI routes.
+
+```python
+def register_routes_from_registry(
+    router: APIRouter,
+    registry: list[RouteMetadata]
+) -> None:
+    """Generate FastAPI routes from registry metadata.
+    
+    For each registry entry:
+    1. Generate auth dependencies from auth_policy
+    2. Create FastAPI route with router.add_api_route()
+    3. Inject metadata (summary, tags, operation_id, errors)
+    """
+    for entry in registry:
+        # Build dependencies (auth, rate limit, etc.)
+        dependencies = _build_dependencies(entry)
+        
+        # Register route with FastAPI
+        router.add_api_route(
+            path=entry.path,
+            endpoint=entry.handler,
+            methods=[entry.method.value],
+            response_model=entry.response_model,
+            status_code=entry.status_code,
+            summary=entry.summary,
+            description=entry.description,
+            operation_id=entry.operation_id,
+            tags=entry.tags,
+            dependencies=dependencies,
+            responses=_build_error_responses(entry.errors),
+        )
+
+def _build_dependencies(entry: RouteMetadata) -> list[Depends]:
+    """Build FastAPI dependencies from metadata."""
+    deps = []
+    
+    # Auth dependencies
+    if entry.auth_policy.level == AuthLevel.AUTHENTICATED:
+        deps.append(Depends(get_current_user))
+    elif entry.auth_policy.level == AuthLevel.ADMIN:
+        deps.append(Depends(require_role(UserRole.ADMIN)))
+    # MANUAL_AUTH and PUBLIC have no injected dependencies
+    
+    return deps
+```
+
+### Component 4: Rate Limit Generation
+
+**Two-Tier Configuration Pattern** (like CSS classes):
+
+**Tier 1: Policy Assignment** (`registry.py`):
+
+```python
+RouteMetadata(
+    path="/sessions",
+    rate_limit_policy=RateLimitPolicy.AUTH_LOGIN,  # ← Assign policy
+    ...
+)
+```
+
+**Tier 2: Policy Implementation** (`derivations.py`):
+
+```python
+def build_rate_limit_rules(registry: list[RouteMetadata]) -> dict[str, RateLimitRule]:
+    """Generate rate limit rules from registry."""
+    
+    # Define what each policy means
+    policy_rules = {
+        RateLimitPolicy.AUTH_LOGIN: RateLimitRule(
+            max_tokens=5,
+            refill_rate=5.0,
+            cost=1,
+            scope=RateLimitScope.IP,
+            enabled=True,
+        ),
+        RateLimitPolicy.API_READ: RateLimitRule(
+            max_tokens=100,
+            refill_rate=100.0,
+            cost=1,
+            scope=RateLimitScope.USER,
+            enabled=True,
+        ),
+        # ... other policies
+    }
+    
+    # Map each endpoint to its rule
+    rules = {}
+    for entry in registry:
+        endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+        rules[endpoint_key] = policy_rules[entry.rate_limit_policy]
+    
+    return rules
+```
+
+**Auto-Generated Rules** (`from_registry.py`):
+
+```python
+from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+from src.presentation.routers.api.v1.routes.derivations import build_rate_limit_rules
+
+# Generated at module load time
+RATE_LIMIT_RULES = build_rate_limit_rules(ROUTE_REGISTRY)
+```
+
+**Benefits**:
+
+- ✅ Modify rate limits in **one place** (derivations.py)
+- ✅ Apply same policy to **multiple endpoints** (like CSS class)
+- ✅ Registry stays clean (just policy name, not full config)
+- ✅ Type-safe (enum ensures valid policies)
+
+### Component 5: Handler Pattern (Pure Functions)
+
+**Old Pattern** (decorator-based):
+
+```python
+# ❌ OLD: Router created, decorators applied
+router = APIRouter()
+
+@router.post("/users", status_code=201, summary="Create user")
+async def create_user(data: UserCreate):
+    ...
+```
+
+**New Pattern** (pure functions):
+
+```python
+# ✅ NEW: Pure function, NO decorators
+async def create_user(
+    data: UserCreate,
+    handler: RegisterUserHandler = Depends(get_register_handler),
+) -> UserCreateResponse:
+    """Create new user account.
+    
+    Handler registered in ROUTE_REGISTRY, not via decorator.
+    """
+    result = await handler.handle(RegisterUser(**data.model_dump()))
+    
+    if isinstance(result, Failure):
+        return ErrorResponseBuilder.from_application_error(
+            error=result.error,
+            request_path="/api/v1/users"
+        )
+    
+    user_id = result.value
+    return UserCreateResponse(id=user_id, email=data.email)
+```
+
+**Benefits**:
+
+- ✅ **Testable**: Pure functions easy to test (no FastAPI mocks)
+- ✅ **Reusable**: Can call from multiple routes if needed
+- ✅ **No coupling**: No dependency on FastAPI decorators
+- ✅ **Clean**: Handler signature is just function parameters
+
+---
+
+## Self-Enforcing Tests
+
+**Location**: `tests/api/test_route_metadata_registry_compliance.py`
+
+**Test Classes** (18 tests total):
+
+### 1. Registry Completeness (6 tests)
+
+```python
+def test_all_routes_are_registered():
+    """Every FastAPI route must have a registry entry."""
+    # Introspect v1_router.routes
+    actual_routes = {f"{method} {path}" for route in v1_router.routes}
+    
+    # Compare with registry
+    expected_routes = {f"{e.method.value} /api/v1{e.path}" for e in ROUTE_REGISTRY}
+    
+    assert actual_routes == expected_routes, "Drift detected!"
+
+def test_operation_ids_are_unique():
+    """Operation IDs must be unique (OpenAPI requirement)."""
+    operation_ids = [e.operation_id for e in ROUTE_REGISTRY]
+    duplicates = [op for op in set(operation_ids) if operation_ids.count(op) > 1]
+    assert not duplicates, f"Duplicate operation IDs: {duplicates}"
+
+def test_all_handlers_are_callable():
+    """Every handler must be a callable function."""
+    for entry in ROUTE_REGISTRY:
+        assert callable(entry.handler), f"{entry.path} has non-callable handler"
+
+def test_all_routes_have_tags():
+    """Every route must have tags for OpenAPI grouping."""
+    for entry in ROUTE_REGISTRY:
+        assert entry.tags, f"{entry.path} has no tags"
+
+def test_all_routes_have_operation_id():
+    """Every route must have operation_id for client generation."""
+    for entry in ROUTE_REGISTRY:
+        assert entry.operation_id, f"{entry.path} has no operation_id"
+
+def test_all_routes_have_resource_name():
+    """Every route must have resource name for grouping."""
+    for entry in ROUTE_REGISTRY:
+        assert entry.resource, f"{entry.path} has no resource name"
+```
+
+### 2. Auth Policy Enforcement (3 tests)
+
+```python
+def test_public_routes_have_no_auth_dependencies():
+    """PUBLIC routes should not inject auth dependencies."""
+    for entry in ROUTE_REGISTRY:
+        if entry.auth_policy.level == AuthLevel.PUBLIC:
+            sig = inspect.signature(entry.handler)
+            for param in sig.parameters.values():
+                assert "CurrentUser" not in str(param.annotation)
+
+def test_authenticated_routes_have_auth_or_manual():
+    """AUTHENTICATED routes must have CurrentUser OR MANUAL_AUTH."""
+    for entry in ROUTE_REGISTRY:
+        if entry.auth_policy.level == AuthLevel.AUTHENTICATED:
+            sig = inspect.signature(entry.handler)
+            has_auth = any("CurrentUser" in str(p.annotation) for p in sig.parameters.values())
+            is_manual = entry.auth_policy.level == AuthLevel.MANUAL_AUTH
+            assert has_auth or is_manual
+
+def test_manual_auth_routes_have_rationale():
+    """MANUAL_AUTH routes must document why."""
+    for entry in ROUTE_REGISTRY:
+        if entry.auth_policy.level == AuthLevel.MANUAL_AUTH:
+            assert entry.auth_policy.rationale
+            assert len(entry.auth_policy.rationale) > 10
+```
+
+### 3. Rate Limit Coverage (4 tests)
+
+```python
+def test_all_registry_entries_have_rate_limit_policy():
+    """Every endpoint must have rate limit policy."""
+    for entry in ROUTE_REGISTRY:
+        assert entry.rate_limit_policy is not None
+
+def test_rate_limit_rules_cover_all_registry_entries():
+    """Generated rules must cover all endpoints."""
+    generated_rules = build_rate_limit_rules(ROUTE_REGISTRY)
+    for entry in ROUTE_REGISTRY:
+        endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+        assert endpoint_key in generated_rules
+
+def test_no_orphaned_rate_limit_rules():
+    """Rules should only exist for registered routes."""
+    registry_endpoints = {f"{e.method.value} /api/v1{e.path}" for e in ROUTE_REGISTRY}
+    for rule_endpoint in RATE_LIMIT_RULES.keys():
+        assert rule_endpoint in registry_endpoints
+
+def test_rate_limit_rules_have_positive_values():
+    """Rules must have valid positive values."""
+    for endpoint, rule in RATE_LIMIT_RULES.items():
+        assert rule.max_tokens > 0
+        assert rule.refill_rate > 0
+        assert rule.cost > 0
+```
+
+### 4. Metadata Consistency (4 tests)
+
+```python
+def test_registry_matches_fastapi_routes():
+    """Registry metadata must match generated FastAPI routes."""
+    for entry in ROUTE_REGISTRY:
+        endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+        fastapi_route = get_route_from_router(v1_router, endpoint_key)
+        
+        assert fastapi_route.summary == entry.summary
+        assert fastapi_route.status_code == entry.status_code
+
+def test_response_models_are_defined():
+    """All non-204 routes must have response_model."""
+    for entry in ROUTE_REGISTRY:
+        if entry.status_code == 204:
+            assert entry.response_model is None
+        else:
+            assert entry.response_model is not None
+
+def test_error_specs_are_valid():
+    """Error specs must have valid HTTP status codes."""
+    valid_statuses = {400, 401, 403, 404, 409, 415, 422, 429, 500, 502, 503}
+    for entry in ROUTE_REGISTRY:
+        for error_spec in entry.errors:
+            assert error_spec.status in valid_statuses
+            assert error_spec.description
+
+def test_path_parameters_match_handler_signature():
+    """Path params must exist in handler signature."""
+    for entry in ROUTE_REGISTRY:
+        path_params = re.findall(r"\{(\w+)\}", entry.path)
+        if path_params:
+            sig = inspect.signature(entry.handler)
+            handler_params = set(sig.parameters.keys())
+            missing = set(path_params) - handler_params
+            assert not missing, f"{entry.path} missing params: {missing}"
+```
+
+### 5. Statistics Reporting (1 test)
+
+```python
+def test_registry_statistics():
+    """Report comprehensive registry statistics (always passes)."""
+    stats = {
+        "Total Endpoints": len(ROUTE_REGISTRY),
+        "HTTP Methods": count_by(lambda e: e.method.value),
+        "Auth Policies": count_by(lambda e: e.auth_policy.level.value),
+        "Rate Limit Policies": count_by(lambda e: e.rate_limit_policy.value),
+        "Idempotency Levels": count_by(lambda e: e.idempotency.value),
+    }
+    print_statistics(stats)  # Visible with pytest -v -s
+    assert True  # Always passes (informational)
+```
+
+**Benefits**:
+
+- ✅ **Zero drift**: Tests fail if registry incomplete
+- ✅ **Self-updating**: Tests adapt to registry changes automatically
+- ✅ **Comprehensive**: 18 tests cover all aspects
+- ✅ **Fast**: All tests run in <1 second
+
+---
+
+## Integration with Existing Systems
+
+### RFC 7807 Error Handling
+
+Route registry includes error specs for OpenAPI docs:
+
+```python
+RouteMetadata(
+    path="/users",
+    errors=[
+        ErrorSpec(status=400, description="Validation failed"),
+        ErrorSpec(status=409, description="User already exists"),
+    ],
+    ...
+)
+```
+
+Handlers return RFC 7807 Problem Details:
+
+```python
+async def create_user(...) -> UserCreateResponse:
+    result = await handler.handle(...)
+    
+    if isinstance(result, Failure):
+        # RFC 7807 error response
+        return ErrorResponseBuilder.from_application_error(
+            error=result.error,
+            request_path="/api/v1/users"
+        )
+    
+    return UserCreateResponse(id=result.value, ...)
+```
+
+**Reference**: `docs/guides/error-handling-guide.md`
+
+### Dependency Injection
+
+Handlers use FastAPI `Depends()` for dependencies:
+
+```python
+async def create_user(
+    data: UserCreate,
+    handler: RegisterUserHandler = Depends(get_register_handler),
+) -> UserCreateResponse:
+    ...
+```
+
+Container functions return protocol types:
+
+```python
+def get_register_handler() -> RegisterUserHandler:
+    from src.core.container import get_user_repository
+    return RegisterUserHandler(user_repo=get_user_repository())
+```
+
+**Reference**: `docs/architecture/dependency-injection-architecture.md`
+
+### CQRS Pattern
+
+Handlers dispatch to CQRS command/query handlers:
+
+```python
+async def create_user(...) -> UserCreateResponse:
+    # Create command
+    command = RegisterUser(email=data.email, password=data.password)
+    
+    # Dispatch to command handler
+    result = await handler.handle(command)
+    
+    # Return response or error
+    ...
+```
+
+**Reference**: `docs/architecture/cqrs-pattern.md`
+
+---
+
+## Evolution and Maintenance
+
+### Adding a New Endpoint
+
+**Process** (enforced by tests):
+
+1. **Write handler function** (pure function, no decorator)
+2. **Add entry to ROUTE_REGISTRY**
+3. **Run tests** → they tell you what's missing
+4. **Add missing pieces** (auth deps, rate limits, etc.)
+5. **Tests pass** ✅
+
+**Example**:
+
+```python
+# Step 1: Write handler
+async def get_account_balance(
+    account_id: UUID,
+    current_user: CurrentUser = Depends(get_current_user),
+) -> BalanceResponse:
+    ...
+
+# Step 2: Add to registry
+RouteMetadata(
+    method=HTTPMethod.GET,
+    path="/accounts/{account_id}/balance",
+    handler=get_account_balance,
+    resource="accounts",
+    tags=["Accounts"],
+    summary="Get account balance",
+    operation_id="get_account_balance",
+    response_model=BalanceResponse,
+    status_code=200,
+    errors=[
+        ErrorSpec(status=404, description="Account not found"),
+    ],
+    idempotency=IdempotencyLevel.SAFE,
+    auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+    rate_limit_policy=RateLimitPolicy.API_READ,
+)
+
+# Step 3-5: Run tests, fix issues, tests pass
+```
+
+### Changing Rate Limits
+
+**Modify policy definition** (affects all endpoints with that policy):
+
+```python
+# src/presentation/routers/api/v1/routes/derivations.py
+RateLimitPolicy.API_READ: RateLimitRule(
+    max_tokens=200,  # ← Changed from 100
+    refill_rate=200.0,
+    ...
+)
+```
+
+All endpoints with `rate_limit_policy=RateLimitPolicy.API_READ` now use new limit.
+
+### Deprecating an Endpoint
+
+**Mark in registry** (future feature):
+
+```python
+RouteMetadata(
+    path="/legacy-endpoint",
+    deprecated=True,
+    deprecation_message="Use /v2/new-endpoint instead",
+    ...
+)
+```
+
+Generator can add deprecation warnings to OpenAPI docs.
+
+---
+
+## Comparison with Other Registries
+
+| Registry | Purpose | Scope | Components |
+|----------|---------|-------|------------|
+| **Route Registry** | API endpoints | 36 routes | Metadata, Generator, Rate Limits, Tests |
+| **Provider Registry** | OAuth providers | 1 provider (Schwab) | Metadata, Adapters, Validators, Tests |
+| **Domain Events Registry** | Domain events | 50+ events | Metadata, Handlers, Auto-Wiring, Tests |
+| **Validation Registry** | Validators | 20+ validators | Metadata, Rules, Decorators, Tests |
+
+**Common Pattern**: Single source of truth + Auto-generation + Self-enforcing tests.
+
+---
+
+## Benefits
+
+### Before Registry (Manual)
+
+- **12 router files** with scattered decorators
+- **Manual rate limit rules** in separate file
+- **Inconsistent auth** (some endpoints missing)
+- **OpenAPI gaps** (missing summaries, tags)
+- **Hard to audit** (can't see all endpoints)
+- **Drift-prone** (easy to forget rate limits)
+
+### After Registry (Automated)
+
+- **1 registry file** with all 36 endpoints
+- **Auto-generated rate limits** (zero drift)
+- **Consistent auth** (enforced by tests)
+- **Complete OpenAPI** (metadata from registry)
+- **Easy audit** (single file shows all routes)
+- **Zero drift** (tests catch incomplete metadata)
+
+---
+
+## References
+
+- **Implementation**: `src/presentation/routers/api/v1/routes/`
+- **Tests**: `tests/api/test_route_metadata_registry_compliance.py`
+- **General Pattern**: [Registry Pattern Architecture](registry-pattern-architecture.md)
+- **Error Handling**: [Error Handling Guide](../guides/error-handling-guide.md)
+- **User Documentation**: `WARP.md` Section 9a (Route Metadata Registry Pattern)
+
+---
+
+**Created**: 2025-12-31 | **Last Updated**: 2025-12-31

--- a/docs/guides/error-handling-guide.md
+++ b/docs/guides/error-handling-guide.md
@@ -1,0 +1,758 @@
+# Error Handling Guide
+
+**Purpose**: Comprehensive guide to RFC 7807 Problem Details error handling in Dashtam API.
+
+**Audience**: Backend developers, API consumers, frontend developers.
+
+## Overview
+
+Dashtam uses **RFC 7807 Problem Details** as the standard error format across all API endpoints. This provides consistent, machine-readable error responses with structured metadata for debugging and user-facing error messages.
+
+**Key Benefits**:
+
+- **Consistent format**: All errors follow the same structure
+- **Machine-readable**: Clients can parse errors programmatically
+- **Debuggable**: Includes trace IDs for correlation with logs
+- **User-friendly**: Structured field-level errors for form validation
+- **Standards-compliant**: Follows IETF RFC 7807 specification
+
+## RFC 7807 Problem Details Standard
+
+RFC 7807 defines a standard JSON format for HTTP API errors. Every error response is a JSON object with these fields:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/validation_failed",
+  "title": "Validation Failed",
+  "status": 400,
+  "detail": "Request validation failed. Check 'errors' for details.",
+  "instance": "/api/v1/users",
+  "errors": [
+    {
+      "field": "email",
+      "message": "Invalid email format",
+      "code": "invalid_format"
+    }
+  ],
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Field Definitions
+
+#### `type` (string, required)
+
+**URL identifying the error type**. Provides machine-readable error classification.
+
+**Format**: `https://api.dashtam.com/errors/{error_code}`
+
+**Examples**:
+
+- `https://api.dashtam.com/errors/not_found`
+- `https://api.dashtam.com/errors/unauthorized`
+- `https://api.dashtam.com/errors/validation_failed`
+
+**Usage**: Clients should match on `type` URL for error handling logic (NOT on status codes).
+
+#### `title` (string, required)
+
+**Human-readable summary** of the error type. Same for all occurrences of this error type.
+
+**Examples**:
+
+- `"Resource Not Found"`
+- `"Authentication Required"`
+- `"Validation Failed"`
+
+**Usage**: Display to users or use in logs. Consistent per error type.
+
+#### `status` (integer, required)
+
+**HTTP status code** for this error. Duplicates the HTTP response status for convenience.
+
+**Examples**: `400`, `401`, `403`, `404`, `409`, `422`, `429`, `500`
+
+#### `detail` (string, optional)
+
+**Human-readable explanation** specific to this error occurrence. May include variable data.
+
+**Examples**:
+
+- `"User with email 'user@example.com' not found"`
+- `"Access token expired at 2025-12-31T10:00:00Z"`
+- `"Request validation failed. Check 'errors' for details."`
+
+**Usage**: Display to users or include in error logs. Context-specific.
+
+#### `instance` (string, optional)
+
+**URI reference** identifying the specific occurrence. Usually the request path.
+
+**Examples**:
+
+- `"/api/v1/users/123"`
+- `"/api/v1/sessions"`
+- `"/api/v1/providers/schwab/callback"`
+
+**Usage**: Correlate errors with specific API calls in logs.
+
+#### `errors` (array, optional)
+
+**Field-level validation errors**. Used for form validation failures.
+
+Each error object contains:
+
+- `field` (string): Field name that failed validation
+- `message` (string): Human-readable error message
+- `code` (string, optional): Machine-readable error code
+
+**Example**:
+
+```json
+"errors": [
+  {
+    "field": "email",
+    "message": "Invalid email format",
+    "code": "invalid_format"
+  },
+  {
+    "field": "password",
+    "message": "Password must be at least 12 characters",
+    "code": "min_length"
+  }
+]
+```
+
+**Usage**: Display field-specific errors next to form inputs.
+
+#### `trace_id` (string, required)
+
+**Unique identifier** for this error occurrence. Links error response to backend logs.
+
+**Format**: UUID v4 (e.g., `550e8400-e29b-41d4-a716-446655440000`)
+
+**Usage**: Include in support tickets. Search logs by trace_id to debug.
+
+## ProblemDetails Schema
+
+Dashtam defines the error schema in `src/schemas/error_schemas.py`:
+
+```python
+class FieldError(BaseModel):
+    """Field-level validation error."""
+    field: str
+    message: str
+    code: str | None = None
+
+class ProblemDetails(BaseModel):
+    """RFC 7807 Problem Details error response."""
+    type: str
+    title: str
+    status: int
+    detail: str | None = None
+    instance: str | None = None
+    errors: list[FieldError] | None = None
+    trace_id: str
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "type": "https://api.dashtam.com/errors/validation_failed",
+                "title": "Validation Failed",
+                "status": 400,
+                "detail": "Request validation failed",
+                "instance": "/api/v1/users",
+                "errors": [
+                    {"field": "email", "message": "Invalid format", "code": "invalid_format"}
+                ],
+                "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+            }
+        }
+    )
+```
+
+## ErrorResponseBuilder Usage
+
+`ErrorResponseBuilder` is the primary interface for creating RFC 7807 error responses.
+
+### Basic Usage
+
+```python
+from src.core.errors import ApplicationError, ApplicationErrorCode
+from src.presentation.api.error_response_builder import ErrorResponseBuilder
+
+# Create error from ApplicationError
+error = ApplicationError(
+    code=ApplicationErrorCode.NOT_FOUND,
+    message="User not found",
+    details={"user_id": "123"}
+)
+
+response = ErrorResponseBuilder.from_application_error(
+    error=error,
+    request_path="/api/v1/users/123"
+)
+
+# Returns JSONResponse with ProblemDetails body
+return response
+```
+
+### With Field-Level Errors
+
+```python
+from src.schemas.error_schemas import FieldError
+
+# Validation failure with field-level errors
+error = ApplicationError(
+    code=ApplicationErrorCode.COMMAND_VALIDATION_FAILED,
+    message="Request validation failed"
+)
+
+response = ErrorResponseBuilder.from_application_error(
+    error=error,
+    request_path="/api/v1/users",
+    field_errors=[
+        FieldError(field="email", message="Invalid email format", code="invalid_format"),
+        FieldError(field="password", message="Too short", code="min_length")
+    ]
+)
+
+return response
+```
+
+### With Custom Detail
+
+```python
+# Not found with specific detail
+error = ApplicationError(
+    code=ApplicationErrorCode.NOT_FOUND,
+    message=f"User with email '{email}' not found"
+)
+
+response = ErrorResponseBuilder.from_application_error(
+    error=error,
+    request_path="/api/v1/users"
+)
+
+return response
+```
+
+## ApplicationErrorCode Reference
+
+`ApplicationErrorCode` enum maps error types to HTTP status codes and RFC 7807 metadata.
+
+Defined in `src/core/errors/application_error.py`:
+
+```python
+class ApplicationErrorCode(str, Enum):
+    """Application-level error codes."""
+    
+    # 400 Bad Request
+    COMMAND_VALIDATION_FAILED = "command_validation_failed"
+    QUERY_VALIDATION_FAILED = "query_validation_failed"
+    INVALID_REQUEST = "invalid_request"
+    
+    # 401 Unauthorized
+    UNAUTHORIZED = "unauthorized"
+    INVALID_CREDENTIALS = "invalid_credentials"
+    TOKEN_EXPIRED = "token_expired"
+    
+    # 403 Forbidden
+    FORBIDDEN = "forbidden"
+    INSUFFICIENT_PERMISSIONS = "insufficient_permissions"
+    
+    # 404 Not Found
+    NOT_FOUND = "not_found"
+    
+    # 409 Conflict
+    CONFLICT = "conflict"
+    DUPLICATE_RESOURCE = "duplicate_resource"
+    
+    # 422 Unprocessable Entity
+    BUSINESS_RULE_VIOLATION = "business_rule_violation"
+    
+    # 429 Too Many Requests
+    RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
+    
+    # 500 Internal Server Error
+    INTERNAL_ERROR = "internal_error"
+    EXTERNAL_SERVICE_ERROR = "external_service_error"
+```
+
+### HTTP Status Mapping
+
+| ApplicationErrorCode | HTTP Status | Title |
+|---------------------|-------------|-------|
+| `COMMAND_VALIDATION_FAILED` | 400 | Validation Failed |
+| `QUERY_VALIDATION_FAILED` | 400 | Validation Failed |
+| `INVALID_REQUEST` | 400 | Bad Request |
+| `UNAUTHORIZED` | 401 | Authentication Required |
+| `INVALID_CREDENTIALS` | 401 | Authentication Required |
+| `TOKEN_EXPIRED` | 401 | Authentication Required |
+| `FORBIDDEN` | 403 | Access Denied |
+| `INSUFFICIENT_PERMISSIONS` | 403 | Access Denied |
+| `NOT_FOUND` | 404 | Resource Not Found |
+| `CONFLICT` | 409 | Resource Conflict |
+| `DUPLICATE_RESOURCE` | 409 | Resource Conflict |
+| `BUSINESS_RULE_VIOLATION` | 422 | Business Rule Violation |
+| `RATE_LIMIT_EXCEEDED` | 429 | Too Many Requests |
+| `INTERNAL_ERROR` | 500 | Internal Server Error |
+| `EXTERNAL_SERVICE_ERROR` | 500 | Internal Server Error |
+
+## When to Use Field-Level Errors
+
+Use the `errors` array for **form validation failures** where multiple fields may have errors.
+
+### ✅ Use Field-Level Errors For
+
+- User registration form validation
+- Profile update validation
+- Multi-field search filters
+- Bulk operation validation
+
+**Example**:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/validation_failed",
+  "title": "Validation Failed",
+  "status": 400,
+  "detail": "User registration failed validation",
+  "instance": "/api/v1/users",
+  "errors": [
+    {"field": "email", "message": "Invalid email format", "code": "invalid_format"},
+    {"field": "password", "message": "Password too short", "code": "min_length"},
+    {"field": "terms", "message": "Must accept terms", "code": "required"}
+  ],
+  "trace_id": "..."
+}
+```
+
+### ❌ Don't Use Field-Level Errors For
+
+- Single resource not found (use `detail` instead)
+- Authentication failures (no fields to report)
+- Permission denials (not field-related)
+- Rate limit exceeded (not field-related)
+
+**Example** (correct - no field errors):
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/not_found",
+  "title": "Resource Not Found",
+  "status": 404,
+  "detail": "User with ID '123' not found",
+  "instance": "/api/v1/users/123",
+  "trace_id": "..."
+}
+```
+
+## Common Error Scenarios
+
+### 1. Validation Error (400)
+
+**Scenario**: User submits invalid form data.
+
+**Request**:
+
+```http
+POST /api/v1/users
+Content-Type: application/json
+
+{
+  "email": "invalid-email",
+  "password": "short"
+}
+```
+
+**Response**:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.dashtam.com/errors/command_validation_failed",
+  "title": "Validation Failed",
+  "status": 400,
+  "detail": "User registration validation failed",
+  "instance": "/api/v1/users",
+  "errors": [
+    {"field": "email", "message": "Invalid email format", "code": "invalid_format"},
+    {"field": "password", "message": "Must be at least 12 characters", "code": "min_length"}
+  ],
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### 2. Authentication Required (401)
+
+**Scenario**: User attempts to access protected resource without valid token.
+
+**Request**:
+
+```http
+GET /api/v1/accounts
+Authorization: Bearer invalid-token
+```
+
+**Response**:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.dashtam.com/errors/unauthorized",
+  "title": "Authentication Required",
+  "status": 401,
+  "detail": "Invalid or expired access token",
+  "instance": "/api/v1/accounts",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### 3. Access Denied (403)
+
+**Scenario**: User authenticated but lacks permission.
+
+**Request**:
+
+```http
+DELETE /api/v1/users/456
+Authorization: Bearer valid-token-for-user-123
+```
+
+**Response**:
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.dashtam.com/errors/forbidden",
+  "title": "Access Denied",
+  "status": 403,
+  "detail": "You do not have permission to delete this user",
+  "instance": "/api/v1/users/456",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### 4. Resource Not Found (404)
+
+**Scenario**: Requested resource does not exist.
+
+**Request**:
+
+```http
+GET /api/v1/accounts/99999
+Authorization: Bearer valid-token
+```
+
+**Response**:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.dashtam.com/errors/not_found",
+  "title": "Resource Not Found",
+  "status": 404,
+  "detail": "Account with ID '99999' not found",
+  "instance": "/api/v1/accounts/99999",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### 5. Resource Conflict (409)
+
+**Scenario**: User attempts to create resource that already exists.
+
+**Request**:
+
+```http
+POST /api/v1/users
+Content-Type: application/json
+
+{
+  "email": "existing@example.com",
+  "password": "ValidPassword123!"
+}
+```
+
+**Response**:
+
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.dashtam.com/errors/conflict",
+  "title": "Resource Conflict",
+  "status": 409,
+  "detail": "User with email 'existing@example.com' already exists",
+  "instance": "/api/v1/users",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### 6. Rate Limit Exceeded (429)
+
+**Scenario**: User exceeds rate limit for endpoint.
+
+**Request**:
+
+```http
+POST /api/v1/sessions
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "password"
+}
+```
+
+**Response**:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/problem+json
+Retry-After: 60
+X-RateLimit-Limit: 5
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1735689600
+
+{
+  "type": "https://api.dashtam.com/errors/rate_limit_exceeded",
+  "title": "Too Many Requests",
+  "status": 429,
+  "detail": "Rate limit exceeded. Try again in 60 seconds.",
+  "instance": "/api/v1/sessions",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Client Error Handling Examples
+
+### TypeScript/JavaScript
+
+```typescript
+interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  errors?: Array<{
+    field: string;
+    message: string;
+    code?: string;
+  }>;
+  trace_id: string;
+}
+
+async function createUser(email: string, password: string) {
+  try {
+    const response = await fetch('/api/v1/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+
+    if (!response.ok) {
+      const error: ProblemDetails = await response.json();
+      
+      // Handle by error type (NOT status code)
+      if (error.type.endsWith('/validation_failed')) {
+        // Display field-level errors
+        error.errors?.forEach(err => {
+          showFieldError(err.field, err.message);
+        });
+      } else if (error.type.endsWith('/conflict')) {
+        showMessage('User already exists');
+      } else {
+        // Generic error with trace ID
+        showMessage(`Error: ${error.detail} (Trace: ${error.trace_id})`);
+      }
+      
+      throw error;
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Request failed:', error);
+    throw error;
+  }
+}
+```
+
+### Python Client
+
+```python
+import requests
+from typing import Optional
+from dataclasses import dataclass
+
+@dataclass
+class FieldError:
+    field: str
+    message: str
+    code: Optional[str] = None
+
+@dataclass
+class ProblemDetails:
+    type: str
+    title: str
+    status: int
+    detail: Optional[str] = None
+    instance: Optional[str] = None
+    errors: Optional[list[FieldError]] = None
+    trace_id: str
+
+def create_user(email: str, password: str):
+    response = requests.post(
+        'https://api.dashtam.com/api/v1/users',
+        json={'email': email, 'password': password}
+    )
+    
+    if not response.ok:
+        error_data = response.json()
+        
+        # Parse into ProblemDetails
+        problem = ProblemDetails(
+            type=error_data['type'],
+            title=error_data['title'],
+            status=error_data['status'],
+            detail=error_data.get('detail'),
+            instance=error_data.get('instance'),
+            errors=[
+                FieldError(**e) for e in error_data.get('errors', [])
+            ],
+            trace_id=error_data['trace_id']
+        )
+        
+        # Handle by error type
+        if problem.type.endswith('/validation_failed'):
+            for err in problem.errors or []:
+                print(f"Field '{err.field}': {err.message}")
+        elif problem.type.endswith('/conflict'):
+            print("User already exists")
+        else:
+            print(f"Error: {problem.detail} (Trace: {problem.trace_id})")
+        
+        raise Exception(problem)
+    
+    return response.json()
+```
+
+## Debugging with trace_id
+
+Every error response includes a `trace_id` that uniquely identifies the error occurrence. This links the error response to backend logs.
+
+### User Reports Error
+
+**User sees**:
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/internal_error",
+  "title": "Internal Server Error",
+  "status": 500,
+  "detail": "An unexpected error occurred",
+  "instance": "/api/v1/accounts/sync",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Developer Searches Logs
+
+Search application logs for `trace_id`:
+
+```bash
+# CloudWatch Logs query
+fields @timestamp, @message
+| filter trace_id = "550e8400-e29b-41d4-a716-446655440000"
+| sort @timestamp desc
+```
+
+**Logs reveal**:
+
+```json
+{
+  "timestamp": "2025-12-31T21:30:00Z",
+  "level": "ERROR",
+  "message": "Account sync failed",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000",
+  "error": "ConnectionTimeout: schwab.api.com timeout after 30s",
+  "user_id": "123",
+  "provider": "schwab"
+}
+```
+
+**Result**: Developer identifies root cause (Schwab API timeout) and can investigate further or apply fix.
+
+## Migration from AuthErrorResponse
+
+**Breaking Change in v1.6.3**: `AuthErrorResponse` removed, replaced with RFC 7807 `ProblemDetails`.
+
+### Old Format (Deprecated)
+
+```json
+{
+  "error": "unauthorized",
+  "message": "Invalid access token"
+}
+```
+
+### New Format (RFC 7807)
+
+```json
+{
+  "type": "https://api.dashtam.com/errors/unauthorized",
+  "title": "Authentication Required",
+  "status": 401,
+  "detail": "Invalid access token",
+  "instance": "/api/v1/accounts",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Migration Checklist
+
+1. ✅ Update client error parsing to expect `ProblemDetails` format
+2. ✅ Match on `type` URL instead of `error` string
+3. ✅ Extract field errors from `errors` array (not root level)
+4. ✅ Store/display `trace_id` for support tickets
+5. ✅ Update error handling tests to assert `ProblemDetails` schema
+
+## Best Practices
+
+### For Backend Developers
+
+1. **Always use ErrorResponseBuilder** - Don't construct JSONResponse manually
+2. **Choose appropriate ApplicationErrorCode** - Maps to correct HTTP status + RFC 7807 metadata
+3. **Include contextual detail** - Help users understand what went wrong
+4. **Add field errors for validation** - Use `errors` array for multi-field validation
+5. **Never expose internal errors** - Map exceptions to generic INTERNAL_ERROR with trace_id
+
+### For API Consumers
+
+1. **Match on `type` URL** - NOT on status codes (multiple error types can share status)
+2. **Display field errors inline** - Show validation errors next to form fields
+3. **Include trace_id in bug reports** - Essential for backend debugging
+4. **Handle rate limits gracefully** - Respect `Retry-After` header
+5. **Show user-friendly messages** - Use `detail` for user-facing error messages
+
+## References
+
+- **RFC 7807 Specification**: <https://tools.ietf.org/html/rfc7807>
+- **Source Code**: `src/schemas/error_schemas.py`, `src/presentation/api/error_response_builder.py`
+- **Route Metadata Registry**: `src/presentation/routers/api/v1/routes/registry.py` (error specs per endpoint)
+- **Application Errors**: `src/core/errors/application_error.py`
+
+---
+
+**Created**: 2025-12-31 | **Last Updated**: 2025-12-31

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,162 +1,69 @@
 # Dashtam Documentation
 
-Welcome to the Dashtam documentation. Dashtam is a secure, modern
-financial data aggregation platform built with clean architecture
-principles from the ground up.
+Dashtam is a **secure, modern financial data aggregation platform** built from the ground up with clean architecture principles. It demonstrates production-grade hexagonal architecture, protocol-based design, and pragmatic domain-driven design in Python.
 
-## Architecture Documentation
+## Core Architecture
 
-### Core Architecture
+Dashtam is built on six foundational architectural pillars:
 
-- **[Hexagonal Architecture](architecture/hexagonal-architecture.md)** -
-  Ports & adapters pattern, dependency rule, layer boundaries,
-  domain at core with zero framework dependencies
-- **[Protocol-Based Architecture](architecture/protocol-based-architecture.md)** -
-  Structural typing with Python Protocol, why Protocol over ABC,
-  repository protocols, testing with protocols
-- **[Domain-Driven Design](architecture/domain-driven-design-architecture.md)** -
-  Pragmatic DDD approach, entities vs value objects, domain events,
-  ubiquitous language, patterns used and skipped
-- **[CQRS Pattern](architecture/cqrs-pattern.md)** -
-  Command Query Responsibility Segregation with separate handlers
-- **[Event Registry Pattern](architecture/registry-pattern-architecture.md)** -
-  Metadata-driven auto-wiring pattern for eliminating manual drift,
-  zero-maintenance component registration (4 implementations: Domain Events,
-  Provider Integration, Rate Limit Rules, Validation Rules)
-- **[Directory Structure](architecture/directory-structure.md)** -
-  Hexagonal architecture organization, layer responsibilities,
-  file naming conventions
-- **[Dependency Injection](architecture/dependency-injection-architecture.md)** -
-  Centralized container pattern for managing application and
-  request-scoped dependencies
-- **[Error Handling](architecture/error-handling-architecture.md)** -
-  Railway-oriented programming with Result types, RFC 7807 compliance
-- **[Testing Architecture](architecture/testing-architecture.md)** -
-  Test pyramid, fixtures, mocking strategies for centralized DI
+**[Hexagonal Architecture](architecture/hexagonal-architecture.md)**
+: Domain at center with zero framework dependencies. Infrastructure adapts to domain through protocols (ports & adapters).
 
-### Infrastructure Components
+**[Protocol-Based Design](architecture/protocol-based-architecture.md)**
+: Structural typing with Python `Protocol`. No inheritance required. Framework-independent interfaces.
 
-- **[Audit Trail](architecture/audit-trail-architecture.md)** -
-  Immutable audit logging with ATTEMPT → OUTCOME semantics,
-  PCI-DSS/SOC 2/GDPR compliance
-- **[Database Architecture](architecture/database-architecture.md)** -
-  PostgreSQL with async SQLAlchemy, session management, Alembic migrations
-- **[Cache Architecture](architecture/cache-architecture.md)** -
-  Redis implementation with connection pooling, TTL strategies,
-  fail-open patterns
-- **[Domain Events](architecture/domain-events-architecture.md)** -
-  Event-driven architecture with in-memory event bus, fail-open behavior,
-  pragmatic DDD approach (events for critical workflows only)
-- **[Secrets Management](architecture/secrets-management-architecture.md)** -
-  Multi-tier secrets (local .env → AWS Secrets Manager), read-only protocol
-- **[Structured Logging](architecture/structured-logging-architecture.md)** -
-  JSON structured logs with contextual information for observability
+**[CQRS Pattern](architecture/cqrs-pattern.md)**
+: Separate command handlers (write) from query handlers (read). Clear separation of concerns.
 
-### Domain Models
+**[Domain-Driven Design](architecture/domain-driven-design-architecture.md)**
+: Pragmatic DDD with entities, value objects, and domain events for critical workflows only.
 
-- **[Account Domain](architecture/account-domain-model.md)** -
-  Account entity with balance tracking, provider connections
-- **[Holding Domain](architecture/holding-domain-model.md)** -
-  Investment holdings with cost basis, market value, unrealized gains
-- **[Balance Tracking](architecture/balance-tracking-architecture.md)** -
-  Point-in-time balance snapshots for portfolio history and analytics
-- **[Transaction Domain](architecture/transaction-domain-model.md)** -
-  Financial transactions with two-level categorization
-- **[Provider Domain](architecture/provider-domain-model.md)** -
-  Provider connections with OAuth token management
-- **[Provider Integration](architecture/provider-integration-architecture.md)** -
-  Multi-provider architecture (OAuth, API Key, File Import)
-- **[Provider Registry](architecture/provider-registry-architecture.md)** -
-  Registry Pattern for zero-drift provider metadata management
-- **[Validation Registry](architecture/validation-registry-architecture.md)** -
-  Single source of truth for validation rules with self-enforcing compliance tests
+**[Registry Pattern](architecture/registry-pattern-architecture.md)**
+: Metadata-driven auto-wiring eliminates manual drift. Single source of truth with self-enforcing tests. **5 implementations**: Domain Events, Provider Integration, Rate Limits, Validation Rules, Route Metadata.
 
-## Project Overview
+**[Dependency Injection](architecture/dependency-injection-architecture.md)**
+: Centralized container with app-scoped singletons and request-scoped dependencies. Protocol-first design.
 
-### Core Architectural Principles
+## Documentation Structure
 
-**Hexagonal Architecture**:
+**Architecture** (31 docs)
+: Deep dives into architectural patterns, design decisions, and system components. Covers infrastructure (database, cache, audit), security (auth, authorization, rate limiting), and domain models (accounts, transactions, holdings).
 
-- **Domain at center**: Pure business logic with zero infrastructure
-  dependencies
-- **Infrastructure at edges**: Adapters implement domain protocols
-- **Dependency inversion**: All dependencies point inward toward domain
+**API Reference** (7 docs)
+: REST API documentation for authentication, account operations, provider connections, transactions, holdings, balance snapshots, and admin endpoints.
 
-**CQRS Pattern**:
+**Guides** (16 docs)
+: Practical how-to guides for common tasks. Includes release management, adding providers, error handling, domain events, and component usage patterns.
 
-- **Commands**: Write operations that change state
-- **Queries**: Read operations that fetch data (can cache)
-- **Handlers**: Separate command and query handlers from the start
+**Code Reference**
+: Auto-generated API documentation from Python docstrings (Google style).
 
-**Domain-Driven Design**:
+## Key Features
 
-- **Entities**: Mutable objects with identity (User, Account, Transaction)
-- **Value Objects**: Immutable values (Email, Money, DateRange)
-- **Domain Events**: Critical workflows emit events
-  (UserRegistered, TokenRefreshFailed)
-- **Protocols**: Domain defines what it needs (Ports),
-  infrastructure implements (Adapters)
+**Clean Architecture**
+: 100% hexagonal with protocol-based ports & adapters. Domain layer has zero framework dependencies.
 
-**Protocol-Based Design**:
+**Production-Ready Security**
+: JWT + opaque refresh tokens, Casbin RBAC, token bucket rate limiting, audit trail (PCI-DSS compliant).
 
-- Use Python `Protocol` for all interfaces (structural typing)
-- No inheritance required for implementations
-- Easy to test (mock protocols, not implementations)
-- Framework-independent domain layer
+**Multi-Provider Integration**
+: OAuth (Schwab), API Key (Alpaca), File Import (Chase). Extensible provider registry pattern.
 
-### Technology Stack
+**Modern Python**
+: Python 3.13+, FastAPI, Pydantic v2, async/await, Result types, Protocol-based design.
 
-**Backend**:
+**Comprehensive Testing**
+: **2,253 tests** with **88% coverage**. Unit tests for domain/application, integration tests for infrastructure, API tests for endpoints.
 
-- **Language**: Python 3.13+ (modern type hints, match/case, slots)
-- **Framework**: FastAPI (async, high performance)
-- **Validation**: Pydantic v2 (strict mode)
-- **Package Manager**: UV 0.8.22+ (fast, modern, NOT pip)
+## Technology Stack
 
-**Infrastructure**:
+**Backend**: Python 3.13 | FastAPI | Pydantic v2 | UV package manager
 
-- **Database**: PostgreSQL 17.6 (async with asyncpg driver)
-- **ORM**: SQLAlchemy 2.0+ (async, declarative)
-- **Migrations**: Alembic (async mode)
-- **Cache**: Redis 8.2.1 (async with redis-py)
-- **Secrets**: Multi-tier (local .env → AWS Secrets Manager)
+**Data**: PostgreSQL 17.6 (async) | SQLAlchemy 2.0 | Alembic | Redis 8.2.1
 
-**Development Environment**:
+**Development**: Docker Compose | Traefik (HTTPS) | pytest | ruff | mypy
 
-- **Containers**: Docker Compose v2 (multi-environment)
-- **Reverse Proxy**: Traefik 3.0+ (automatic SSL with mkcert)
-- **Domains**: `https://dashtam.local` (dev),
-  `https://test.dashtam.local` (test)
-
-**Quality Assurance**:
-
-- **Testing**: pytest + pytest-asyncio (85%+ coverage target)
-- **Linting**: ruff (fast, all-in-one linter/formatter)
-- **Type Checking**: mypy (strict mode)
-- **CI/CD**: GitHub Actions with Codecov
-
-### Design Patterns
-
-**Dependency Injection**:
-
-- Centralized container in `src/core/container.py`
-- App-scoped singletons (cache, secrets, database)
-- Request-scoped dependencies (sessions, handlers)
-- Easy to mock for testing
-
-**Error Handling**:
-
-- Result types (Success/Failure) - no exceptions in domain
-- Railway-oriented programming
-- RFC 7807 Problem Details for HTTP APIs
-- ErrorCode enums for machine-readable errors
-
-**Testing Strategy**:
-
-- Unit tests: Mock container dependencies (60%)
-- Integration tests: Real infrastructure (30%)
-- API tests: Complete request/response flows (10%)
-- No unit tests for infrastructure adapters
+**CI/CD**: GitHub Actions | Codecov | Self-hosted runners
 
 ## Getting Started
 
@@ -192,54 +99,25 @@ make test
 8. **Commit with conventional commits** - `feat:`, `fix:`, `docs:`
 9. **Create pull request** to `development` branch
 
-## Development Guides
+## Essential Reading
 
-### Process & Workflow
+New to Dashtam? Start with these key documents:
 
-- **[Release Management](guides/release-management.md)** -
-  Comprehensive guide to versioning, branching, tagging, GitHub releases,
-  and CHANGELOG management. Includes semantic versioning decision tree,
-  complete release checklist, sync strategy, and troubleshooting.
+1. **[Hexagonal Architecture](architecture/hexagonal-architecture.md)** - Understand the core architectural pattern
+2. **[Protocol-Based Architecture](architecture/protocol-based-architecture.md)** - Learn why we use Protocol over ABC
+3. **[Error Handling Guide](guides/error-handling-guide.md)** - RFC 7807 API errors and Result types
+4. **[Registry Pattern](architecture/registry-pattern-architecture.md)** - How we eliminate manual drift
+5. **[Release Management](guides/release-management.md)** - Complete development workflow
 
-### Feature Development
+## Development Workflow
 
-- **[Adding New Providers](guides/adding-new-providers.md)** -
-  Complete 10-phase guide for integrating new financial data providers
-  including OAuth, API Key, and File Import providers
-- **[Chase File Import](guides/chase-file-import.md)** -
-  User guide for importing Chase bank transactions from QFX/CSV files
-- **[Audit Usage Patterns](guides/audit-usage-patterns.md)** -
-  Complete guide with copy-pasteable examples for registration,
-  login, provider connection, data access audit patterns
-- **[Domain Events Usage](guides/domain-events-usage.md)** -
-  Complete guide for using domain events - when to use, event naming,
-  defining events, creating handlers, testing, anti-patterns
+1. Create feature branch from `development`
+2. Research & plan (identify layers, create TODO list)
+3. Implement with tests (85%+ coverage target)
+4. Verify quality: `make verify` (tests, lint, format, type-check)
+5. Create PR to `development` branch
 
-### Architecture Documentation Status
-
-✅ **Complete** - All core architecture components:
-
-- **Foundation**: Directory structure, dependency injection, error handling
-- **Security**: Authentication (JWT + refresh tokens), authorization (Casbin RBAC), rate limiting
-- **Data Layer**: Database (async PostgreSQL), cache (Redis), repositories
-- **Domain**: Entities (User, Account, Transaction, Holding, BalanceSnapshot), value objects, domain events
-- **Application**: CQRS handlers (commands + queries), event handlers
-- **Infrastructure**: Audit trail (PCI-DSS compliant), structured logging, secrets management
-- **Providers**: Schwab (OAuth), Alpaca (API Key), Chase (File Import) - three provider types
-- **Testing**: 2,100+ tests (87% coverage), integration tests, API tests
-
-## Contributing
-
-See `~/starter/development-checklist.md` for the complete feature development workflow.
-
-**Key principles**:
-
-- Always follow hexagonal architecture
-- Use centralized dependency injection
-- Return Result types (not exceptions)
-- Test at the right level (unit vs integration)
-- Document architecture decisions
-- 100% REST compliance for API endpoints
+**Core principles**: Hexagonal architecture | Protocol-based design | Result types (no exceptions) | 100% REST compliance
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
     - Rate Limiting: architecture/rate-limit-architecture.md
     - Registry Pattern: architecture/registry-pattern-architecture.md
     - Repository Pattern: architecture/repository-pattern.md
+    - Route Registry: architecture/route-registry-architecture.md
     - Secrets Management: architecture/secrets-management-architecture.md
     - Session Management: architecture/session-management-architecture.md
     - Structured Logging: architecture/structured-logging-architecture.md
@@ -181,6 +182,7 @@ nav:
     - Dependency Injection Usage: guides/dependency-injection-usage.md
     - Domain Events Usage: guides/domain-events-usage.md
     - Enum Security: guides/enum-security-guidelines.md
+    - Error Handling Guide: guides/error-handling-guide.md
     - Error Handling Usage: guides/error-handling-usage.md
     - Import Guidelines: guides/import-guidelines.md
     - Key Management: guides/key-management.md

--- a/src/infrastructure/rate_limit/config.py
+++ b/src/infrastructure/rate_limit/config.py
@@ -1,323 +1,68 @@
-"""Rate limit rules configuration (Single Source of Truth).
+"""Rate limit rules configuration (Generated from Registry).
 
-This module defines rate limit rules for all endpoints. Rules are centralized
-here to ensure consistency and easy maintenance.
+IMPORTANT: This module is now a thin proxy to registry-generated rules.
+Rate limit rules are automatically generated from the Route Metadata Registry.
 
-Rule Design Principles:
-- Auth endpoints: Restrictive (5/min IP-scoped) - Prevent credential stuffing
-- API endpoints: Generous (100/min user-scoped) - Normal API usage
-- Expensive operations: Moderate (10/min user-scoped) - Prevent abuse
-- Global limits: Very restrictive - Emergency brake
+Two-Tier Configuration Pattern:
+    Rate limits use a two-tier configuration similar to CSS classes:
+
+    Tier 1 - Policy Assignment (registry.py):
+        Assigns a rate limit policy to each endpoint.
+        Example: "Login endpoint should use AUTH_LOGIN policy"
+
+        To change: Update rate_limit_policy in RouteMetadata
+        Effect: Changes policy for ONE specific endpoint
+
+    Tier 2 - Policy Implementation (derivations.py):
+        Defines the actual limits for each policy category.
+        Example: "AUTH_LOGIN policy = 5 attempts per minute"
+
+        To change: Update RateLimitRule in _create_rate_limit_rule()
+        Effect: Changes limits for ALL endpoints using that policy
+
+Examples:
+    # Make login endpoint more generous (Tier 1 - one endpoint)
+    RouteMetadata(
+        path="/sessions",
+        rate_limit_policy=RateLimitPolicy.API_READ,  # Change policy
+    )
+
+    # Increase AUTH_LOGIN limits globally (Tier 2 - all AUTH_LOGIN endpoints)
+    RateLimitPolicy.AUTH_LOGIN: RateLimitRule(
+        max_tokens=10,  # Change from 5 to 10
+    )
+
+DO NOT add hand-written rules here - they will be ignored.
 
 Usage:
     from src.infrastructure.rate_limit.config import RATE_LIMIT_RULES
 
     # Lookup rule for endpoint
     rule = RATE_LIMIT_RULES.get("POST /api/v1/sessions")
+
+Reference:
+    - src/infrastructure/rate_limit/from_registry.py (actual implementation)
+    - src/presentation/routers/api/v1/routes/registry.py (Tier 1: policy assignment)
+    - src/presentation/routers/api/v1/routes/derivations.py (Tier 2: policy implementation)
 """
 
-from src.domain.enums import RateLimitScope
-from src.domain.value_objects.rate_limit_rule import RateLimitRule
-
-
 # =============================================================================
-# Authentication Endpoints (Restrictive - IP-scoped)
+# DEPRECATED: Hand-written rules (replaced by registry-generated rules)
 # =============================================================================
-# These endpoints are high-value targets for credential stuffing attacks.
-# IP-scoped limits prevent brute force from single sources.
+# All rate limit rules are now automatically generated from the Route Metadata
+# Registry. The hand-written rules below have been removed.
+#
+# To modify rate limits:
+#     1. Update RateLimitPolicy in ROUTE_REGISTRY
+#     2. Or update policy mapping in derivations.py
+#
+# DO NOT add rules here - use the registry instead.
 
-AUTH_LOGIN_RULE = RateLimitRule(
-    max_tokens=5,
-    refill_rate=5.0,  # 1 token every 12 seconds
-    scope=RateLimitScope.IP,
-    cost=1,
-    enabled=True,
+# Import registry-generated rules
+from src.infrastructure.rate_limit.from_registry import (
+    RATE_LIMIT_RULES,
+    get_rule_for_endpoint,
 )
-"""Login endpoint: 5 attempts per minute per IP.
 
-Rationale:
-- Legitimate users rarely need >5 login attempts per minute
-- Prevents credential stuffing (one IP, many accounts)
-- 12-second refill allows retry after typos
-"""
-
-AUTH_REGISTER_RULE = RateLimitRule(
-    max_tokens=3,
-    refill_rate=3.0,  # 1 token every 20 seconds
-    scope=RateLimitScope.IP,
-    cost=1,
-    enabled=True,
-)
-"""Registration endpoint: 3 attempts per minute per IP.
-
-Rationale:
-- Legitimate users register once
-- More restrictive than login (fewer legitimate retries)
-- Prevents mass account creation attacks
-"""
-
-AUTH_PASSWORD_RESET_RULE = RateLimitRule(
-    max_tokens=3,
-    refill_rate=1.0,  # 1 token per minute
-    scope=RateLimitScope.IP,
-    cost=1,
-    enabled=True,
-)
-"""Password reset endpoint: 3 attempts, 1 refill per minute per IP.
-
-Rationale:
-- Highly sensitive operation
-- Abuse can lead to email flooding
-- Low legitimate need (user forgets password once)
-"""
-
-AUTH_TOKEN_REFRESH_RULE = RateLimitRule(
-    max_tokens=10,
-    refill_rate=10.0,  # 1 token every 6 seconds
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""Token refresh: 10 per minute per user.
-
-Rationale:
-- Legitimate apps refresh tokens periodically
-- User-scoped (requires valid token)
-- More generous than login (automated, not manual)
-"""
-
-
-# =============================================================================
-# Provider Endpoints (Moderate - User-scoped)
-# =============================================================================
-# Provider operations are resource-intensive (external API calls, OAuth flows).
-
-PROVIDER_CONNECT_RULE = RateLimitRule(
-    max_tokens=5,
-    refill_rate=5.0,
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""Provider connect: 5 per minute per user.
-
-Rationale:
-- OAuth flow is resource-intensive
-- User shouldn't need many connect attempts
-- Prevents abuse of OAuth flow
-"""
-
-PROVIDER_SYNC_RULE = RateLimitRule(
-    max_tokens=10,
-    refill_rate=5.0,
-    scope=RateLimitScope.USER_PROVIDER,
-    cost=1,
-    enabled=True,
-)
-"""Provider sync: 10 per minute per user-provider.
-
-Rationale:
-- Sync triggers external API calls
-- Per user-provider to allow multiple providers
-- Burst of 10 allows initial data load
-"""
-
-
-# =============================================================================
-# API Endpoints (Generous - User-scoped)
-# =============================================================================
-# Standard API endpoints with reasonable limits for legitimate usage.
-
-API_READ_RULE = RateLimitRule(
-    max_tokens=100,
-    refill_rate=100.0,  # ~1.67 tokens per second
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""API read operations: 100 per minute per user.
-
-Rationale:
-- Read operations are cheap
-- Allows responsive UIs with many requests
-- Prevents runaway scripts
-"""
-
-API_WRITE_RULE = RateLimitRule(
-    max_tokens=50,
-    refill_rate=50.0,
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""API write operations: 50 per minute per user.
-
-Rationale:
-- Write operations are more expensive
-- Still generous for legitimate use
-- Prevents bulk data manipulation
-"""
-
-
-# =============================================================================
-# Expensive Operations (Restrictive - User-scoped)
-# =============================================================================
-# Operations that consume significant resources (CPU, memory, external APIs).
-
-EXPORT_RULE = RateLimitRule(
-    max_tokens=5,
-    refill_rate=1.0,  # 1 token per minute
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""Data export: 5 burst, 1 per minute per user.
-
-Rationale:
-- Exports are expensive (large data queries)
-- Allow small burst for retry, but slow refill
-- Prevents abuse of expensive operations
-"""
-
-REPORT_RULE = RateLimitRule(
-    max_tokens=10,
-    refill_rate=2.0,  # 1 token every 30 seconds
-    scope=RateLimitScope.USER,
-    cost=1,
-    enabled=True,
-)
-"""Report generation: 10 burst, 2 per minute per user.
-
-Rationale:
-- Reports require computation
-- Moderate limits for legitimate analytics use
-- Prevents denial of service via report generation
-"""
-
-
-# =============================================================================
-# Global Limits (Emergency Brake - Global scope)
-# =============================================================================
-# These limits apply to ALL users. Use for emergency protection.
-
-GLOBAL_API_RULE = RateLimitRule(
-    max_tokens=10000,
-    refill_rate=10000.0,
-    scope=RateLimitScope.GLOBAL,
-    cost=1,
-    enabled=False,  # Disabled by default - enable in emergencies
-)
-"""Global API limit: 10k per minute (emergency brake).
-
-Rationale:
-- Emergency protection against DDoS
-- Disabled by default (enable if under attack)
-- Global scope means ALL users share this limit
-"""
-
-
-# =============================================================================
-# RATE_LIMIT_RULES - Single Source of Truth
-# =============================================================================
-# Mapping of endpoint patterns to rules.
-# Endpoint format: "{METHOD} {PATH}" (e.g., "POST /api/v1/sessions")
-
-RATE_LIMIT_RULES: dict[str, RateLimitRule] = {
-    # Authentication endpoints
-    "POST /api/v1/sessions": AUTH_LOGIN_RULE,
-    "DELETE /api/v1/sessions": AUTH_TOKEN_REFRESH_RULE,  # Logout
-    "POST /api/v1/users": AUTH_REGISTER_RULE,
-    "POST /api/v1/auth/password-reset": AUTH_PASSWORD_RESET_RULE,
-    "POST /api/v1/auth/password-reset/confirm": AUTH_PASSWORD_RESET_RULE,
-    "POST /api/v1/auth/refresh": AUTH_TOKEN_REFRESH_RULE,
-    # Provider endpoints
-    "POST /api/v1/providers": PROVIDER_CONNECT_RULE,
-    "DELETE /api/v1/providers/{provider_id}": PROVIDER_CONNECT_RULE,
-    "POST /api/v1/providers/{provider_id}/sync": PROVIDER_SYNC_RULE,
-    # Account endpoints (read-heavy)
-    "GET /api/v1/accounts": API_READ_RULE,
-    "GET /api/v1/accounts/{account_id}": API_READ_RULE,
-    "GET /api/v1/accounts/{account_id}/transactions": API_READ_RULE,
-    "GET /api/v1/accounts/{account_id}/balance": API_READ_RULE,
-    # Transaction endpoints
-    "GET /api/v1/transactions": API_READ_RULE,
-    "GET /api/v1/transactions/{transaction_id}": API_READ_RULE,
-    # Export endpoints (expensive)
-    "POST /api/v1/exports/transactions": EXPORT_RULE,
-    "POST /api/v1/exports/accounts": EXPORT_RULE,
-    # Report endpoints
-    "POST /api/v1/reports/spending": REPORT_RULE,
-    "POST /api/v1/reports/income": REPORT_RULE,
-    # User profile endpoints
-    "GET /api/v1/users/me": API_READ_RULE,
-    "PATCH /api/v1/users/me": API_WRITE_RULE,
-    "PUT /api/v1/users/me/password": AUTH_PASSWORD_RESET_RULE,  # Sensitive
-}
-"""Endpoint to rate limit rule mapping.
-
-Add new endpoints here as they're created. The endpoint format must match
-exactly what the middleware/dependency receives (typically from FastAPI's
-request.scope["path"] and request.method).
-
-Note:
-    Path parameters like {account_id} are kept in the key for documentation.
-    The actual matching may use prefix matching or regex depending on
-    middleware implementation.
-"""
-
-
-def get_rule_for_endpoint(endpoint: str) -> RateLimitRule | None:
-    """Get rate limit rule for endpoint.
-
-    Supports exact match and path parameter patterns.
-
-    Args:
-        endpoint: Endpoint string (e.g., "GET /api/v1/accounts/123").
-
-    Returns:
-        RateLimitRule if found, None otherwise.
-    """
-    # Try exact match first
-    if endpoint in RATE_LIMIT_RULES:
-        return RATE_LIMIT_RULES[endpoint]
-
-    # Try pattern matching for path parameters
-    method, _, path = endpoint.partition(" ")
-    if not path:
-        return None
-
-    for pattern, rule in RATE_LIMIT_RULES.items():
-        pattern_method, _, pattern_path = pattern.partition(" ")
-        if method != pattern_method:
-            continue
-
-        # Check if paths match (handling {param} placeholders)
-        if _paths_match(path, pattern_path):
-            return rule
-
-    return None
-
-
-def _paths_match(actual: str, pattern: str) -> bool:
-    """Check if actual path matches pattern with placeholders.
-
-    Args:
-        actual: Actual request path (e.g., "/api/v1/accounts/123").
-        pattern: Pattern path (e.g., "/api/v1/accounts/{account_id}").
-
-    Returns:
-        True if paths match, False otherwise.
-    """
-    actual_parts = actual.strip("/").split("/")
-    pattern_parts = pattern.strip("/").split("/")
-
-    if len(actual_parts) != len(pattern_parts):
-        return False
-
-    for actual_part, pattern_part in zip(actual_parts, pattern_parts, strict=True):
-        if pattern_part.startswith("{") and pattern_part.endswith("}"):
-            continue  # Placeholder matches anything
-        if actual_part != pattern_part:
-            return False
-
-    return True
+# Re-export for backward compatibility
+__all__ = ["RATE_LIMIT_RULES", "get_rule_for_endpoint"]

--- a/src/infrastructure/rate_limit/from_registry.py
+++ b/src/infrastructure/rate_limit/from_registry.py
@@ -1,0 +1,136 @@
+"""Generated rate limit rules from Route Metadata Registry.
+
+This module generates RATE_LIMIT_RULES from the declarative ROUTE_REGISTRY,
+replacing hand-written rate limit configuration. Rules are automatically derived
+from RateLimitPolicy enums in the registry.
+
+Two-Tier Configuration Pattern:
+    Rate limits use a two-tier system (similar to CSS classes):
+
+    Tier 1 - Policy Assignment (registry.py):
+        Each endpoint is assigned a policy category.
+        Example: POST /api/v1/sessions → AUTH_LOGIN policy
+
+    Tier 2 - Policy Implementation (derivations.py):
+        Each policy category has concrete limits.
+        Example: AUTH_LOGIN → 5 attempts/min per IP
+
+    This file: Combines both tiers to generate the final rules dict.
+
+To Modify Rate Limits:
+    ONE endpoint: Update rate_limit_policy in registry.py
+    ALL endpoints in a policy: Update RateLimitRule in derivations.py
+
+Exports:
+    RATE_LIMIT_RULES: Dict mapping endpoints to rate limit rules (auto-generated)
+    get_rule_for_endpoint: Lookup function with path parameter matching
+
+Usage:
+    from src.infrastructure.rate_limit.from_registry import RATE_LIMIT_RULES
+
+    # Lookup rule for endpoint
+    rule = RATE_LIMIT_RULES.get("POST /api/v1/sessions")
+
+Reference:
+    - src/presentation/routers/api/v1/routes/registry.py (Tier 1: policy assignment)
+    - src/presentation/routers/api/v1/routes/derivations.py (Tier 2: policy implementation)
+"""
+
+from src.domain.value_objects.rate_limit_rule import RateLimitRule
+from src.presentation.routers.api.v1.routes.derivations import (
+    build_rate_limit_rules,
+)
+from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+
+
+# =============================================================================
+# Generated Rate Limit Rules (Single Source of Truth)
+# =============================================================================
+# These rules are automatically generated from ROUTE_REGISTRY.
+# DO NOT modify this dict manually - update the registry instead.
+
+RATE_LIMIT_RULES: dict[str, RateLimitRule] = build_rate_limit_rules(ROUTE_REGISTRY)
+"""Endpoint to rate limit rule mapping (generated from registry).
+
+Generated at module import time from ROUTE_REGISTRY. Endpoint format is
+"{METHOD} {PATH}" (e.g., "POST /api/v1/sessions").
+
+To modify rate limits:
+    1. Update the RateLimitPolicy in ROUTE_REGISTRY
+    2. Or update the policy mapping in derivations.py
+
+DO NOT modify this dict directly - it will be regenerated on next import.
+"""
+
+
+# =============================================================================
+# Lookup Functions
+# =============================================================================
+
+
+def get_rule_for_endpoint(endpoint: str) -> RateLimitRule | None:
+    """Get rate limit rule for endpoint.
+
+    Supports exact match and path parameter patterns (e.g., /accounts/{id}).
+
+    Args:
+        endpoint: Endpoint string (e.g., "GET /api/v1/accounts/123").
+
+    Returns:
+        RateLimitRule if found, None otherwise.
+
+    Example:
+        >>> rule = get_rule_for_endpoint("GET /api/v1/accounts/abc-123")
+        >>> rule.max_tokens
+        100
+    """
+    # Try exact match first
+    if endpoint in RATE_LIMIT_RULES:
+        return RATE_LIMIT_RULES[endpoint]
+
+    # Try pattern matching for path parameters
+    method, _, path = endpoint.partition(" ")
+    if not path:
+        return None
+
+    for pattern, rule in RATE_LIMIT_RULES.items():
+        pattern_method, _, pattern_path = pattern.partition(" ")
+        if method != pattern_method:
+            continue
+
+        # Check if paths match (handling {param} placeholders)
+        if _paths_match(path, pattern_path):
+            return rule
+
+    return None
+
+
+def _paths_match(actual: str, pattern: str) -> bool:
+    """Check if actual path matches pattern with placeholders.
+
+    Args:
+        actual: Actual request path (e.g., "/api/v1/accounts/123").
+        pattern: Pattern path (e.g., "/api/v1/accounts/{account_id}").
+
+    Returns:
+        True if paths match, False otherwise.
+
+    Example:
+        >>> _paths_match("/api/v1/accounts/123", "/api/v1/accounts/{id}")
+        True
+        >>> _paths_match("/api/v1/accounts", "/api/v1/accounts/{id}")
+        False
+    """
+    actual_parts = actual.strip("/").split("/")
+    pattern_parts = pattern.strip("/").split("/")
+
+    if len(actual_parts) != len(pattern_parts):
+        return False
+
+    for actual_part, pattern_part in zip(actual_parts, pattern_parts, strict=True):
+        if pattern_part.startswith("{") and pattern_part.endswith("}"):
+            continue  # Placeholder matches anything
+        if actual_part != pattern_part:
+            return False
+
+    return True

--- a/src/presentation/routers/api/v1/__init__.py
+++ b/src/presentation/routers/api/v1/__init__.py
@@ -3,6 +3,10 @@
 RESTful resource-based endpoints following strict REST compliance.
 All endpoints use resource nouns, not action verbs.
 
+NOTE: All routes are now generated from the Route Metadata Registry at startup.
+The registry (ROUTE_REGISTRY) is the single source of truth for all endpoints.
+See src/presentation/routers/api/v1/routes/registry.py for the complete route catalog.
+
 Resources:
     /api/v1/users                  - User management
     /api/v1/sessions               - Session management (login/logout)
@@ -21,98 +25,23 @@ Admin Resources:
     /api/v1/admin/security/rotations     - Global token rotation
     /api/v1/admin/security/config        - Security configuration
     /api/v1/admin/users/{id}/rotations   - Per-user token rotation
+
+Reference:
+    - docs/architecture/registry-pattern-architecture.md
 """
 
 from fastapi import APIRouter
 
-from src.presentation.routers.api.v1.accounts import (
-    provider_accounts_router,
-    router as accounts_router,
+from src.presentation.routers.api.v1.routes.generator import (
+    register_routes_from_registry,
 )
-from src.presentation.routers.api.v1.admin import admin_router
-from src.presentation.routers.api.v1.email_verifications import (
-    router as email_verifications_router,
-)
-from src.presentation.routers.api.v1.password_resets import (
-    password_reset_tokens_router,
-    password_resets_router,
-)
-from src.presentation.routers.api.v1.providers import router as providers_router
-from src.presentation.routers.api.v1.sessions import router as sessions_router
-from src.presentation.routers.api.v1.tokens import router as tokens_router
-from src.presentation.routers.api.v1.transactions import (
-    account_transactions_router,
-    router as transactions_router,
-)
-from src.presentation.routers.api.v1.holdings import (
-    account_holdings_router,
-    router as holdings_router,
-)
-from src.presentation.routers.api.v1.balance_snapshots import (
-    account_balance_router,
-    router as balance_snapshots_router,
-)
-from src.presentation.routers.api.v1.imports import router as imports_router
-from src.presentation.routers.api.v1.users import router as users_router
+from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
 
-# Create combined v1 router
+# Create v1 router and generate all routes from registry
 v1_router = APIRouter(prefix="/api/v1")
+register_routes_from_registry(v1_router, ROUTE_REGISTRY)
 
-# Include all resource routers
-v1_router.include_router(users_router)
-v1_router.include_router(sessions_router)
-v1_router.include_router(tokens_router)
-v1_router.include_router(email_verifications_router)
-v1_router.include_router(password_reset_tokens_router)
-v1_router.include_router(password_resets_router)
-
-# Include Phase 5 routers (providers, accounts, transactions)
-v1_router.include_router(providers_router)
-v1_router.include_router(accounts_router)
-v1_router.include_router(transactions_router)
-
-# Include Phase 7 routers (holdings)
-v1_router.include_router(holdings_router)
-
-# Include Phase 8 routers (balance snapshots)
-v1_router.include_router(balance_snapshots_router)
-
-# Include Phase 7.2 routers (file imports)
-v1_router.include_router(imports_router)
-
-# Include nested resource routers
-# GET /api/v1/providers/{id}/accounts - List accounts for a provider connection
-v1_router.include_router(provider_accounts_router)
-# GET /api/v1/accounts/{id}/transactions - List transactions for an account
-v1_router.include_router(account_transactions_router)
-# GET /api/v1/accounts/{id}/holdings - List holdings for an account
-# POST /api/v1/accounts/{id}/holdings/syncs - Sync holdings for an account
-v1_router.include_router(account_holdings_router)
-# GET /api/v1/accounts/{id}/balance-history - Get balance history for account
-# GET /api/v1/accounts/{id}/balance-snapshots - List balance snapshots for account
-v1_router.include_router(account_balance_router)
-
-# Include admin routers
-v1_router.include_router(admin_router)
-
-# Export individual routers for testing
+# Export v1_router
 __all__ = [
     "v1_router",
-    "users_router",
-    "sessions_router",
-    "tokens_router",
-    "email_verifications_router",
-    "password_reset_tokens_router",
-    "password_resets_router",
-    "providers_router",
-    "accounts_router",
-    "transactions_router",
-    "holdings_router",
-    "balance_snapshots_router",
-    "imports_router",
-    "provider_accounts_router",
-    "account_transactions_router",
-    "account_holdings_router",
-    "account_balance_router",
-    "admin_router",
 ]

--- a/src/presentation/routers/api/v1/admin/__init__.py
+++ b/src/presentation/routers/api/v1/admin/__init__.py
@@ -1,28 +1,24 @@
-"""Admin API routers.
+"""Admin API handlers.
 
-Admin-only endpoints for security and system management.
-All endpoints require admin authentication (TODO: implement admin auth).
+Handler functions for admin security and system management endpoints.
+Routes are registered via ROUTE_REGISTRY in routes/registry.py.
+All handlers require admin authentication (Casbin RBAC).
 
-Resources:
-    /api/v1/admin/security/rotations     - Global token rotation
-    /api/v1/admin/security/config        - Security configuration
-    /api/v1/admin/users/{id}/rotations   - Per-user token rotation
+Handlers:
+    create_global_rotation - Global token rotation
+    create_user_rotation   - Per-user token rotation
+    get_security_config    - Security configuration
 """
 
-from fastapi import APIRouter
-
 from src.presentation.routers.api.v1.admin.token_rotation import (
-    router as token_rotation_router,
+    create_global_rotation,
+    create_user_rotation,
+    get_security_config,
 )
 
-# Create combined admin router
-admin_router = APIRouter(prefix="/admin", tags=["Admin"])
-
-# Include all admin routers
-admin_router.include_router(token_rotation_router)
-
-# Export routers
+# Export handlers
 __all__ = [
-    "admin_router",
-    "token_rotation_router",
+    "create_global_rotation",
+    "create_user_rotation",
+    "get_security_config",
 ]

--- a/src/presentation/routers/api/v1/imports.py
+++ b/src/presentation/routers/api/v1/imports.py
@@ -1,10 +1,11 @@
-"""Imports resource router.
+"""Imports resource handlers.
 
-RESTful endpoints for file-based data imports.
+Handler functions for file-based data imports.
+Routes are registered via ROUTE_REGISTRY in routes/registry.py.
 
-Endpoints:
-    POST   /api/v1/imports                 - Import data from uploaded file
-    GET    /api/v1/imports/formats         - List supported file formats
+Handlers:
+    import_from_file      - Import data from uploaded file
+    list_supported_formats - List supported file formats
 
 Reference:
     - docs/architecture/api-design-patterns.md
@@ -13,7 +14,7 @@ Reference:
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Request, UploadFile, status
+from fastapi import Depends, File, Request, UploadFile, status
 from fastapi.responses import JSONResponse
 
 from src.application.commands.handlers.import_from_file_handler import (
@@ -31,9 +32,6 @@ from src.schemas.import_schemas import (
     ImportResponse,
     SupportedFormatsResponse,
 )
-
-
-router = APIRouter(prefix="/imports", tags=["Imports"])
 
 
 # =============================================================================
@@ -101,22 +99,10 @@ def _map_import_error(error: str) -> ApplicationError:
 
 
 # =============================================================================
-# Endpoints
+# Handlers
 # =============================================================================
 
 
-@router.post(
-    "",
-    response_model=ImportResponse,
-    status_code=status.HTTP_201_CREATED,
-    summary="Import from file",
-    description="Import financial data from an uploaded file (QFX, OFX).",
-    responses={
-        201: {"description": "Import successful"},
-        400: {"description": "Invalid file or format"},
-        415: {"description": "Unsupported file format"},
-    },
-)
 async def import_from_file(
     request: Request,
     current_user: AuthenticatedUser,
@@ -202,12 +188,6 @@ async def import_from_file(
     return ImportResponse.from_result(result.value)
 
 
-@router.get(
-    "/formats",
-    response_model=SupportedFormatsResponse,
-    summary="List supported formats",
-    description="List file formats supported for import.",
-)
 async def list_supported_formats() -> SupportedFormatsResponse:
     """List supported file formats for import.
 

--- a/src/presentation/routers/api/v1/routes/__init__.py
+++ b/src/presentation/routers/api/v1/routes/__init__.py
@@ -1,0 +1,31 @@
+"""API Route Registry package.
+
+This package implements the Route Metadata Registry pattern for API routes.
+The registry is the single source of truth for all routes, generating FastAPI
+routes, rate limit rules, auth dependencies, and OpenAPI metadata.
+
+Modules:
+    metadata: Core types (RouteMetadata, AuthPolicy, RateLimitPolicy, etc.)
+    registry: ROUTE_REGISTRY - List of all route specifications
+    generator: register_routes_from_registry() - Generate FastAPI routes
+    derivations: Helpers to derive artifacts from registry
+
+Usage:
+    from src.presentation.routers.api.v1.routes import ROUTE_REGISTRY
+    from src.presentation.routers.api.v1.routes.generator import register_routes_from_registry
+
+    router = APIRouter(prefix="/api/v1")
+    register_routes_from_registry(router, ROUTE_REGISTRY)
+"""
+
+__all__ = [
+    # Metadata types
+    "RouteMetadata",
+    "HTTPMethod",
+    "AuthPolicy",
+    "AuthLevel",
+    "RateLimitPolicy",
+    "ErrorSpec",
+    "IdempotencyLevel",
+    "CachePolicy",
+]

--- a/src/presentation/routers/api/v1/routes/derivations.py
+++ b/src/presentation/routers/api/v1/routes/derivations.py
@@ -1,0 +1,188 @@
+"""Derive runtime configurations from route metadata registry.
+
+This module generates runtime configurations (auth dependencies, rate limit rules)
+from the declarative Route Metadata Registry. This ensures consistency between
+the registry and actual application behavior.
+
+Two-Tier Rate Limit Configuration:
+    This module implements Tier 2 - Policy Implementation.
+
+    Tier 1 (registry.py): Assigns policies to endpoints
+        Example: "Login endpoint uses AUTH_LOGIN policy"
+
+    Tier 2 (this file): Defines what each policy means
+        Example: "AUTH_LOGIN = 5 attempts/min per IP"
+
+To Modify Rate Limits:
+    Scenario 1: Change rate limit for ONE specific endpoint
+        Where: registry.py
+        What: Change the rate_limit_policy field
+        Example: Make login more generous
+            rate_limit_policy=RateLimitPolicy.API_READ
+
+    Scenario 2: Change rate limit for ALL endpoints using a policy
+        Where: This file (derivations.py)
+        What: Update RateLimitRule in _create_rate_limit_rule()
+        Example: Increase all AUTH_LOGIN endpoints from 5 to 10
+            RateLimitPolicy.AUTH_LOGIN: RateLimitRule(max_tokens=10, ...)
+
+Functions:
+    build_rate_limit_rules: Generate rate limit rules dict from registry
+    _create_rate_limit_rule: Map RateLimitPolicy enum to RateLimitRule (Tier 2)
+
+Reference:
+    - src/presentation/routers/api/v1/routes/registry.py (Tier 1: policy assignment)
+    - src/infrastructure/rate_limit/config.py (public API for rules)
+"""
+
+from src.domain.enums import RateLimitScope
+from src.domain.value_objects.rate_limit_rule import RateLimitRule
+from src.presentation.routers.api.v1.routes.metadata import (
+    RateLimitPolicy,
+    RouteMetadata,
+)
+
+
+def build_rate_limit_rules(
+    registry: list[RouteMetadata],
+) -> dict[str, RateLimitRule]:
+    """Build rate limit rules dict from route registry.
+
+    Generates the RATE_LIMIT_RULES dict by iterating registry and mapping
+    RateLimitPolicy enums to RateLimitRule objects. Endpoint keys use
+    the format "{METHOD} {PATH}" (e.g., "POST /api/v1/sessions").
+
+    Args:
+        registry: List of route metadata entries from ROUTE_REGISTRY.
+
+    Returns:
+        Dict mapping endpoint strings to RateLimitRule objects.
+
+    Example:
+        >>> from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+        >>> rules = build_rate_limit_rules(ROUTE_REGISTRY)
+        >>> login_rule = rules["POST /api/v1/sessions"]
+        >>> login_rule.max_tokens
+        5
+    """
+    rules: dict[str, RateLimitRule] = {}
+
+    for entry in registry:
+        # Build endpoint key: "{METHOD} /api/v1{PATH}"
+        # Note: Router adds /api/v1 prefix, so we must include it here
+        endpoint = f"{entry.method.value} /api/v1{entry.path}"
+
+        # Map RateLimitPolicy to RateLimitRule
+        rule = _create_rate_limit_rule(entry.rate_limit_policy)
+        rules[endpoint] = rule
+
+    return rules
+
+
+def _create_rate_limit_rule(policy: RateLimitPolicy) -> RateLimitRule:
+    """Create RateLimitRule from RateLimitPolicy enum.
+
+    Maps policy enums to concrete rate limit rules with specific
+    max_tokens, refill_rate, and scope values.
+
+    Args:
+        policy: RateLimitPolicy enum value.
+
+    Returns:
+        RateLimitRule instance with policy-specific configuration.
+
+    Example:
+        >>> rule = _create_rate_limit_rule(RateLimitPolicy.AUTH_LOGIN)
+        >>> rule.max_tokens
+        5
+        >>> rule.scope
+        <RateLimitScope.IP: 'ip'>
+    """
+    # Map policy to rule configuration
+    # Keep these in sync with src/infrastructure/rate_limit/config.py patterns
+    mapping: dict[RateLimitPolicy, RateLimitRule] = {
+        # Auth endpoints (IP-scoped, restrictive)
+        RateLimitPolicy.AUTH_LOGIN: RateLimitRule(
+            max_tokens=5,
+            refill_rate=5.0,  # 1 token every 12 seconds
+            scope=RateLimitScope.IP,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.AUTH_REGISTER: RateLimitRule(
+            max_tokens=3,
+            refill_rate=3.0,  # 1 token every 20 seconds
+            scope=RateLimitScope.IP,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.AUTH_PASSWORD_RESET: RateLimitRule(
+            max_tokens=3,
+            refill_rate=1.0,  # 1 token per minute
+            scope=RateLimitScope.IP,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.AUTH_TOKEN_REFRESH: RateLimitRule(
+            max_tokens=10,
+            refill_rate=10.0,  # 1 token every 6 seconds
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        # Provider endpoints (moderate, user-scoped)
+        RateLimitPolicy.PROVIDER_CONNECT: RateLimitRule(
+            max_tokens=5,
+            refill_rate=5.0,
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.PROVIDER_SYNC: RateLimitRule(
+            max_tokens=10,
+            refill_rate=5.0,
+            scope=RateLimitScope.USER_PROVIDER,
+            cost=1,
+            enabled=True,
+        ),
+        # Standard API endpoints (generous, user-scoped)
+        RateLimitPolicy.API_READ: RateLimitRule(
+            max_tokens=100,
+            refill_rate=100.0,  # ~1.67 tokens per second
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.API_WRITE: RateLimitRule(
+            max_tokens=50,
+            refill_rate=50.0,
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        # Expensive operations (restrictive, user-scoped)
+        RateLimitPolicy.EXPENSIVE_EXPORT: RateLimitRule(
+            max_tokens=5,
+            refill_rate=1.0,  # 1 token per minute
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        RateLimitPolicy.REPORT: RateLimitRule(
+            max_tokens=10,
+            refill_rate=2.0,  # 1 token every 30 seconds
+            scope=RateLimitScope.USER,
+            cost=1,
+            enabled=True,
+        ),
+        # Global limits (emergency brake, disabled by default)
+        RateLimitPolicy.GLOBAL: RateLimitRule(
+            max_tokens=10000,
+            refill_rate=10000.0,
+            scope=RateLimitScope.GLOBAL,
+            cost=1,
+            enabled=False,  # Enable only in emergencies
+        ),
+    }
+
+    return mapping[policy]

--- a/src/presentation/routers/api/v1/routes/generator.py
+++ b/src/presentation/routers/api/v1/routes/generator.py
@@ -1,0 +1,181 @@
+"""Route generator for the API Route Registry.
+
+This module provides register_routes_from_registry(), which generates FastAPI routes
+from RouteMetadata entries at application startup. It's the core of the Registry Pattern,
+converting declarative metadata into runtime routes.
+
+Functions:
+    register_routes_from_registry: Generate all routes from registry
+    _build_dependencies: Build FastAPI dependencies from auth policy
+    _build_responses: Build OpenAPI responses dict from error specs
+
+Usage:
+    from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+    from src.presentation.routers.api.v1.routes.generator import register_routes_from_registry
+
+    v1_router = APIRouter(prefix="/api/v1")
+    register_routes_from_registry(v1_router, ROUTE_REGISTRY)
+
+Reference:
+    - docs/architecture/registry-pattern-architecture.md
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.presentation.routers.api.middleware.auth_dependencies import (
+    get_current_user,
+)
+from src.presentation.routers.api.middleware.authorization_dependencies import (
+    require_casbin_role,
+)
+from src.presentation.routers.api.v1.routes.metadata import (
+    AuthLevel,
+    AuthPolicy,
+    RouteMetadata,
+)
+
+
+def register_routes_from_registry(
+    router: APIRouter,
+    registry: list[RouteMetadata],
+) -> None:
+    """Generate FastAPI routes from registry metadata.
+
+    This function converts declarative RouteMetadata entries into runtime FastAPI
+    routes using router.add_api_route(). It handles:
+    - HTTP method and path
+    - Handler function reference
+    - Request/response models
+    - Status codes
+    - OpenAPI documentation (summary, description, operation_id)
+    - Error responses
+    - Auth dependencies (based on auth_policy)
+
+    Args:
+        router: FastAPI APIRouter to register routes on
+        registry: List of RouteMetadata entries to convert into routes
+
+    Example:
+        >>> from fastapi import APIRouter
+        >>> from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+        >>>
+        >>> v1_router = APIRouter(prefix="/api/v1")
+        >>> register_routes_from_registry(v1_router, ROUTE_REGISTRY)
+        >>> # Now v1_router has 36 routes registered
+
+    Reference:
+        - docs/architecture/registry-pattern-architecture.md
+    """
+    for metadata in registry:
+        # Build dependencies based on auth policy
+        dependencies = _build_dependencies(metadata.auth_policy)
+
+        # Build OpenAPI responses from error specs
+        responses = _build_responses(metadata.errors) if metadata.errors else None
+
+        # Register route with FastAPI
+        router.add_api_route(
+            path=metadata.path,
+            endpoint=metadata.handler,
+            methods=[metadata.method.value],
+            response_model=metadata.response_model,
+            status_code=metadata.status_code,
+            tags=list(metadata.tags),  # Convert Sequence to list for FastAPI
+            summary=metadata.summary,
+            description=metadata.description,
+            operation_id=metadata.operation_id,
+            responses=responses,
+            dependencies=dependencies,
+            deprecated=metadata.deprecated,
+        )
+
+
+def _build_dependencies(auth_policy: AuthPolicy) -> list[Any]:
+    """Build FastAPI dependencies from auth policy.
+
+    Converts declarative AuthPolicy into FastAPI Depends() dependencies that
+    will be injected into the route handler.
+
+    Auth policy mapping:
+        PUBLIC: No dependencies (anyone can access)
+        AUTHENTICATED: Depends(get_current_user) - requires valid JWT
+        ADMIN: Depends(get_current_user) + Depends(require_casbin_role("admin"))
+        MANUAL_AUTH: No dependencies (route handles auth manually)
+
+    Args:
+        auth_policy: Authentication policy from RouteMetadata
+
+    Returns:
+        List of FastAPI dependencies to inject
+
+    Examples:
+        >>> # Public route - no auth
+        >>> _build_dependencies(AuthPolicy(level=AuthLevel.PUBLIC))
+        []
+        >>>
+        >>> # Authenticated route - requires JWT
+        >>> _build_dependencies(AuthPolicy(level=AuthLevel.AUTHENTICATED))
+        [Depends(get_current_user)]
+        >>>
+        >>> # Admin route - requires JWT + admin role
+        >>> _build_dependencies(AuthPolicy(level=AuthLevel.ADMIN, role="admin"))
+        [Depends(get_current_user), Depends(require_casbin_role("admin"))]
+        >>>
+        >>> # Manual auth - route handles it
+        >>> _build_dependencies(AuthPolicy(level=AuthLevel.MANUAL_AUTH, rationale="..."))
+        []
+    """
+    match auth_policy.level:
+        case AuthLevel.PUBLIC:
+            # No authentication required
+            return []
+
+        case AuthLevel.AUTHENTICATED:
+            # Requires valid JWT (CurrentUser injected)
+            return [Depends(get_current_user)]
+
+        case AuthLevel.ADMIN:
+            # Requires JWT + admin role check (Casbin RBAC)
+            role = auth_policy.role or "admin"
+            return [
+                Depends(get_current_user),
+                Depends(require_casbin_role(role)),
+            ]
+
+        case AuthLevel.MANUAL_AUTH:
+            # Route handles authentication manually (e.g., sessions with custom error mapping)
+            # No dependencies - handler contains auth logic
+            return []
+
+        case _:
+            # Unknown auth level - fail closed (no access)
+            msg = f"Unknown auth level: {auth_policy.level}"
+            raise ValueError(msg)
+
+
+def _build_responses(errors: list[Any]) -> dict[int | str, dict[str, Any]]:
+    """Build OpenAPI responses dict from error specifications.
+
+    Converts list of ErrorSpec into FastAPI responses dict for OpenAPI schema.
+
+    Args:
+        errors: List of ErrorSpec from RouteMetadata
+
+    Returns:
+        Dict mapping status codes to response descriptions for OpenAPI
+
+    Example:
+        >>> from src.presentation.routers.api.v1.routes.metadata import ErrorSpec
+        >>> errors = [
+        ...     ErrorSpec(status=400, description="Validation error"),
+        ...     ErrorSpec(status=404, description="User not found"),
+        ... ]
+        >>> _build_responses(errors)
+        {
+            400: {"description": "Validation error"},
+            404: {"description": "User not found"}
+        }
+    """
+    return {error.status: {"description": error.description} for error in errors}

--- a/src/presentation/routers/api/v1/routes/metadata.py
+++ b/src/presentation/routers/api/v1/routes/metadata.py
@@ -1,0 +1,360 @@
+"""Route metadata types for the API Route Registry.
+
+This module defines the core types for the Route Metadata Registry pattern.
+The registry is the single source of truth for all API routes, generating
+FastAPI routes, rate limit rules, auth dependencies, and OpenAPI metadata.
+
+Core types:
+    RouteMetadata: Complete route specification (method, path, handler, auth, rate limits, etc.)
+    HTTPMethod: HTTP method enum (GET, POST, PATCH, PUT, DELETE)
+    AuthPolicy: Authentication policy (PUBLIC, AUTHENTICATED, ADMIN, MANUAL_AUTH)
+    RateLimitPolicy: Rate limit policy enum (AUTH_LOGIN, API_READ, etc.)
+    ErrorSpec: Error response specification for OpenAPI
+    IdempotencyLevel: HTTP idempotency classification
+
+Usage:
+    from src.presentation.routers.api.v1.routes.metadata import RouteMetadata, HTTPMethod
+
+    metadata = RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/api/v1/users",
+        handler=create_user_handler,
+        response_model=UserCreateResponse,
+        status_code=201,
+        auth_policy=AuthPolicy.PUBLIC,
+        rate_limit_policy=RateLimitPolicy.AUTH_REGISTER,
+    )
+
+Reference:
+    - docs/architecture/registry-pattern-architecture.md
+"""
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+# =============================================================================
+# HTTP Method Enum
+# =============================================================================
+
+
+class HTTPMethod(str, Enum):
+    """HTTP methods for API routes.
+
+    Attributes:
+        GET: Safe, idempotent read operations
+        POST: Non-idempotent create operations
+        PUT: Idempotent complete replacement
+        PATCH: Non-idempotent partial update
+        DELETE: Idempotent delete operations
+    """
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
+
+# =============================================================================
+# Authentication Policy
+# =============================================================================
+
+
+@dataclass(frozen=True, kw_only=True)
+class AuthPolicy:
+    """Authentication policy for a route.
+
+    Defines who can access the route and what dependencies to inject.
+
+    Attributes:
+        level: Authentication level (public, authenticated, admin, manual_auth)
+        role: Optional Casbin role requirement (e.g., "admin")
+        permission: Optional Casbin permission requirement
+        rationale: Optional explanation for MANUAL_AUTH routes
+
+    Examples:
+        >>> # Public route (no auth)
+        >>> AuthPolicy(level=AuthLevel.PUBLIC)
+        >>>
+        >>> # Authenticated route (any logged-in user)
+        >>> AuthPolicy(level=AuthLevel.AUTHENTICATED)
+        >>>
+        >>> # Admin-only route
+        >>> AuthPolicy(level=AuthLevel.ADMIN, role="admin")
+        >>>
+        >>> # Manual auth (custom token parsing)
+        >>> AuthPolicy(
+        ...     level=AuthLevel.MANUAL_AUTH,
+        ...     rationale="Custom 401/403 mapping for session endpoints"
+        ... )
+    """
+
+    level: "AuthLevel"
+    role: str | None = None
+    permission: str | None = None
+    rationale: str | None = None
+
+
+class AuthLevel(str, Enum):
+    """Authentication levels for routes.
+
+    Attributes:
+        PUBLIC: No authentication required (e.g., registration, login)
+        AUTHENTICATED: Requires valid JWT (AuthenticatedUser dependency)
+        ADMIN: Requires admin role (CurrentUser + Casbin check)
+        MANUAL_AUTH: Route handles auth manually (e.g., sessions with custom error mapping)
+    """
+
+    PUBLIC = "public"
+    AUTHENTICATED = "authenticated"
+    ADMIN = "admin"
+    MANUAL_AUTH = "manual_auth"
+
+
+# =============================================================================
+# Rate Limit Policy
+# =============================================================================
+
+
+class RateLimitPolicy(str, Enum):
+    """Rate limit policy for routes.
+
+    Each policy maps to a RateLimitRule with specific limits and scope.
+    Policies are organized by endpoint category and sensitivity.
+
+    Auth endpoints (IP-scoped, restrictive):
+        AUTH_LOGIN: 5/min per IP (credential stuffing prevention)
+        AUTH_REGISTER: 3/min per IP (mass account creation prevention)
+        AUTH_PASSWORD_RESET: 3/min per IP, slow refill (email flooding prevention)
+        AUTH_TOKEN_REFRESH: 10/min per user (automated token refresh)
+
+    Provider endpoints (user-scoped, moderate):
+        PROVIDER_CONNECT: 5/min per user (OAuth flow rate limiting)
+        PROVIDER_SYNC: 10/min per user-provider (external API protection)
+
+    API endpoints (user-scoped, generous):
+        API_READ: 100/min per user (read operations)
+        API_WRITE: 50/min per user (write operations)
+
+    Expensive operations (user-scoped, restrictive):
+        EXPENSIVE_EXPORT: 5 burst, 1/min per user (large data queries)
+        REPORT: 10 burst, 2/min per user (computation-heavy)
+
+    Global limits (emergency brake):
+        GLOBAL: 10k/min across all users (DDoS protection, disabled by default)
+
+    Reference:
+        - docs/architecture/rate-limit-architecture.md
+    """
+
+    # Auth endpoints (IP-scoped)
+    AUTH_LOGIN = "auth_login"
+    AUTH_REGISTER = "auth_register"
+    AUTH_PASSWORD_RESET = "auth_password_reset"
+    AUTH_TOKEN_REFRESH = "auth_token_refresh"
+
+    # Provider endpoints (user-scoped or user-provider-scoped)
+    PROVIDER_CONNECT = "provider_connect"
+    PROVIDER_SYNC = "provider_sync"
+
+    # Standard API endpoints (user-scoped)
+    API_READ = "api_read"
+    API_WRITE = "api_write"
+
+    # Expensive operations (user-scoped, restrictive)
+    EXPENSIVE_EXPORT = "expensive_export"
+    REPORT = "report"
+
+    # Global limits (emergency brake)
+    GLOBAL = "global"
+
+
+# =============================================================================
+# Idempotency Level
+# =============================================================================
+
+
+class IdempotencyLevel(str, Enum):
+    """HTTP idempotency classification.
+
+    Attributes:
+        SAFE: No side effects (GET, HEAD, OPTIONS) - cacheable
+        IDEMPOTENT: Side effects, but repeatable (PUT, DELETE) - safe to retry
+        NON_IDEMPOTENT: Side effects, not repeatable (POST, PATCH) - do not retry
+
+    Reference:
+        - RFC 7231 Section 4.2 (HTTP Semantics)
+    """
+
+    SAFE = "safe"
+    IDEMPOTENT = "idempotent"
+    NON_IDEMPOTENT = "non_idempotent"
+
+
+# =============================================================================
+# Error Specification
+# =============================================================================
+
+
+@dataclass(frozen=True, kw_only=True)
+class ErrorSpec:
+    """Error response specification for OpenAPI documentation.
+
+    Attributes:
+        status: HTTP status code (e.g., 400, 404, 500)
+        description: Human-readable error description
+        model: Optional Pydantic model for response (defaults to ProblemDetails)
+
+    Examples:
+        >>> ErrorSpec(status=400, description="Validation error")
+        >>> ErrorSpec(status=404, description="User not found")
+        >>> ErrorSpec(status=409, description="Email already registered")
+    """
+
+    status: int
+    description: str
+    model: type[BaseModel] | None = None
+
+
+# =============================================================================
+# Cache Policy
+# =============================================================================
+
+
+class CachePolicy(str, Enum):
+    """HTTP caching policy for GET endpoints.
+
+    Attributes:
+        NONE: No caching headers (default for most endpoints)
+        PRIVATE: Cache-Control: private (user-specific data)
+        NO_STORE: Cache-Control: no-store (sensitive data, never cache)
+
+    Reference:
+        - RFC 7234 (HTTP Caching)
+    """
+
+    NONE = "none"
+    PRIVATE = "private"
+    NO_STORE = "no_store"
+
+
+# =============================================================================
+# Route Metadata (SSOT)
+# =============================================================================
+
+
+@dataclass(frozen=True, kw_only=True)
+class RouteMetadata:
+    """Complete specification for an API route (Single Source of Truth).
+
+    This dataclass contains all metadata needed to generate a FastAPI route,
+    including method, path, handler, auth policy, rate limits, and OpenAPI docs.
+
+    Identity fields:
+        method: HTTP method (GET, POST, etc.)
+        path: URL path with placeholders (e.g., "/api/v1/accounts/{account_id}")
+        handler: Async function that implements the endpoint
+
+    Grouping fields:
+        resource: Resource category (e.g., "accounts", "users")
+        tags: OpenAPI tags (e.g., ["Accounts"])
+        version: API version (e.g., "v1")
+
+    OpenAPI documentation:
+        summary: Short endpoint description (appears in OpenAPI UI)
+        description: Detailed endpoint description (markdown supported)
+        operation_id: Stable operation ID for client generation
+
+    Request/Response:
+        request_model: Optional Pydantic model for request body
+        response_model: Pydantic model for success response
+        status_code: Expected success status (e.g., 200, 201, 204)
+        errors: List of possible error responses for OpenAPI
+
+    Behavior:
+        idempotency: HTTP idempotency level (safe, idempotent, non_idempotent)
+        auth_policy: Authentication policy (public, authenticated, admin, manual_auth)
+        rate_limit_policy: Rate limit policy (auth_login, api_read, etc.)
+        cache_policy: HTTP caching policy for GETs (none, private, no_store)
+
+    Deprecation:
+        deprecated: Whether endpoint is deprecated
+        replacement: Optional replacement endpoint path
+
+    Examples:
+        >>> # Simple GET endpoint
+        >>> RouteMetadata(
+        ...     method=HTTPMethod.GET,
+        ...     path="/api/v1/users/me",
+        ...     handler=get_current_user_handler,
+        ...     resource="users",
+        ...     tags=["Users"],
+        ...     summary="Get current user",
+        ...     response_model=UserResponse,
+        ...     status_code=200,
+        ...     idempotency=IdempotencyLevel.SAFE,
+        ...     auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        ...     rate_limit_policy=RateLimitPolicy.API_READ,
+        ... )
+        >>>
+        >>> # POST endpoint with request body
+        >>> RouteMetadata(
+        ...     method=HTTPMethod.POST,
+        ...     path="/api/v1/users",
+        ...     handler=create_user_handler,
+        ...     resource="users",
+        ...     tags=["Users"],
+        ...     summary="Create user",
+        ...     description="Register a new user account. Sends verification email.",
+        ...     operation_id="create_user",
+        ...     request_model=UserCreateRequest,
+        ...     response_model=UserCreateResponse,
+        ...     status_code=201,
+        ...     errors=[
+        ...         ErrorSpec(status=400, description="Validation error"),
+        ...         ErrorSpec(status=409, description="Email already registered"),
+        ...     ],
+        ...     idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        ...     auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        ...     rate_limit_policy=RateLimitPolicy.AUTH_REGISTER,
+        ... )
+
+    Reference:
+        - docs/architecture/registry-pattern-architecture.md
+    """
+
+    # Identity
+    method: HTTPMethod
+    path: str
+    handler: Callable[..., Awaitable[Any]]
+
+    # Grouping
+    resource: str
+    tags: Sequence[str]
+    version: str = "v1"
+
+    # OpenAPI documentation
+    summary: str
+    description: str | None = None
+    operation_id: str | None = None
+
+    # Request/Response
+    request_model: type[BaseModel] | None = None
+    response_model: type[BaseModel] | None = None
+    status_code: int = 200
+    errors: list[ErrorSpec] | None = None
+
+    # Behavior
+    idempotency: IdempotencyLevel
+    auth_policy: AuthPolicy
+    rate_limit_policy: RateLimitPolicy
+    cache_policy: CachePolicy = CachePolicy.NONE
+
+    # Deprecation
+    deprecated: bool = False
+    replacement: str | None = None

--- a/src/presentation/routers/api/v1/routes/registry.py
+++ b/src/presentation/routers/api/v1/routes/registry.py
@@ -1,0 +1,884 @@
+"""API Route Registry - Single Source of Truth for all routes.
+
+This module contains ROUTE_REGISTRY, the authoritative list of all API endpoints.
+The registry is used to generate FastAPI routes, rate limit rules, auth dependencies,
+and OpenAPI metadata at application startup.
+
+Registry structure:
+    - 36 total endpoints across 12 resource categories
+    - Each entry is a RouteMetadata instance with complete specification
+    - Handlers reference actual functions from router modules
+    - Auth policies explicitly declared (PUBLIC, AUTHENTICATED, ADMIN, MANUAL_AUTH)
+    - Rate limit policies assigned based on endpoint sensitivity
+
+Usage:
+    from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+    from src.presentation.routers.api.v1.routes.generator import register_routes_from_registry
+
+    router = APIRouter(prefix="/api/v1")
+    register_routes_from_registry(router, ROUTE_REGISTRY)
+
+Reference:
+    - docs/architecture/registry-pattern-architecture.md
+"""
+
+from src.presentation.routers.api.v1.routes.metadata import (
+    AuthLevel,
+    AuthPolicy,
+    ErrorSpec,
+    HTTPMethod,
+    IdempotencyLevel,
+    RateLimitPolicy,
+    RouteMetadata,
+)
+
+# Import handlers from router modules
+from src.presentation.routers.api.v1.accounts import (
+    get_account,
+    list_accounts,
+    list_accounts_by_connection,
+    sync_accounts,
+)
+from src.presentation.routers.api.v1.admin.token_rotation import (
+    create_global_rotation,
+    create_user_rotation,
+    get_security_config,
+)
+from src.presentation.routers.api.v1.balance_snapshots import (
+    get_balance_history,
+    get_latest_snapshots,
+    list_balance_snapshots,
+)
+from src.presentation.routers.api.v1.email_verifications import (
+    create_email_verification,
+)
+from src.presentation.routers.api.v1.holdings import (
+    list_holdings,
+    list_holdings_by_account,
+    sync_holdings,
+)
+from src.presentation.routers.api.v1.imports import (
+    import_from_file,
+    list_supported_formats,
+)
+from src.presentation.routers.api.v1.password_resets import (
+    create_password_reset,
+    create_password_reset_token,
+)
+from src.presentation.routers.api.v1.providers import (
+    disconnect_provider,
+    get_provider_connection,
+    initiate_connection,
+    list_providers,
+    oauth_callback,
+    refresh_provider_tokens,
+    update_provider,
+)
+from src.presentation.routers.api.v1.sessions import (
+    create_session,
+    delete_current_session,
+    get_session,
+    list_sessions,
+    revoke_all_sessions,
+    revoke_session,
+)
+from src.presentation.routers.api.v1.tokens import create_tokens
+from src.presentation.routers.api.v1.transactions import (
+    get_transaction,
+    list_transactions_by_account,
+    sync_transactions,
+)
+from src.presentation.routers.api.v1.users import create_user
+from src.schemas.account_schemas import (
+    AccountListResponse,
+    AccountResponse,
+    SyncAccountsResponse,
+)
+from src.schemas.auth_schemas import (
+    EmailVerificationCreateResponse,
+    PasswordResetCreateResponse,
+    PasswordResetTokenCreateResponse,
+    SessionCreateResponse,
+    TokenCreateResponse,
+    UserCreateResponse,
+)
+from src.schemas.balance_snapshot_schemas import (
+    BalanceHistoryResponse,
+    LatestSnapshotsResponse,
+)
+from src.schemas.holding_schemas import HoldingListResponse, SyncHoldingsResponse
+from src.schemas.import_schemas import ImportResponse, SupportedFormatsResponse
+from src.schemas.provider_schemas import (
+    AuthorizationUrlResponse,
+    ProviderConnectionListResponse,
+    ProviderConnectionResponse,
+    TokenRefreshResponse,
+)
+from src.schemas.rotation_schemas import (
+    GlobalRotationResponse,
+    SecurityConfigResponse,
+    UserRotationResponse,
+)
+from src.schemas.session_schemas import (
+    SessionListResponse,
+    SessionResponse,
+    SessionRevokeAllResponse,
+)
+from src.schemas.transaction_schemas import (
+    SyncTransactionsResponse,
+    TransactionListResponse,
+    TransactionResponse,
+)
+
+# =============================================================================
+# ROUTE_REGISTRY - Single Source of Truth
+# =============================================================================
+
+ROUTE_REGISTRY: list[RouteMetadata] = [
+    # =========================================================================
+    # Users Resource (1 endpoint)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/users",
+        handler=create_user,
+        resource="users",
+        tags=["Users"],
+        summary="Create user",
+        description="Register a new user account. Sends verification email.",
+        operation_id="create_user",
+        response_model=UserCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Validation error"),
+            ErrorSpec(status=409, description="Email already registered"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_REGISTER,
+    ),
+    # =========================================================================
+    # Sessions Resource (6 endpoints)
+    # =========================================================================
+    # MANUAL_AUTH: Sessions endpoints handle authentication manually with custom
+    # 401/403 error mapping and token/session validation logic. They use
+    # _extract_user_id_from_token helper instead of AuthenticatedUser dependency.
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/sessions",
+        handler=create_session,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="Create session",
+        description="Authenticate user and create a new session with tokens.",
+        operation_id="create_session",
+        response_model=SessionCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid credentials"),
+            ErrorSpec(status=401, description="Authentication failed"),
+            ErrorSpec(status=403, description="Account locked or not verified"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Custom 401/403 mapping for credential validation and account status",
+        ),
+        rate_limit_policy=RateLimitPolicy.AUTH_LOGIN,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.DELETE,
+        path="/sessions/current",
+        handler=delete_current_session,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="Delete current session",
+        description="Logout by revoking the refresh token for current session.",
+        operation_id="delete_current_session",
+        response_model=None,
+        status_code=204,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+        ],
+        idempotency=IdempotencyLevel.IDEMPOTENT,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Requires token extraction for session revocation",
+        ),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/sessions",
+        handler=list_sessions,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="List sessions",
+        description="Get all sessions for the current user.",
+        operation_id="list_sessions",
+        response_model=SessionListResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Requires user_id and session_id extraction for filtering",
+        ),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/sessions/{session_id}",
+        handler=get_session,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="Get session",
+        description="Get details of a specific session.",
+        operation_id="get_session",
+        response_model=SessionResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=404, description="Session not found"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Requires ownership verification via token parsing",
+        ),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.DELETE,
+        path="/sessions/{session_id}",
+        handler=revoke_session,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="Revoke session",
+        description="Revoke a specific session (logout that device).",
+        operation_id="revoke_session",
+        response_model=None,
+        status_code=204,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=404, description="Session not found"),
+        ],
+        idempotency=IdempotencyLevel.IDEMPOTENT,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Requires ownership verification for security",
+        ),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.DELETE,
+        path="/sessions",
+        handler=revoke_all_sessions,
+        resource="sessions",
+        tags=["Sessions"],
+        summary="Revoke all sessions",
+        description="Revoke all sessions except the current one (logout everywhere else).",
+        operation_id="revoke_all_sessions",
+        response_model=SessionRevokeAllResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+        ],
+        idempotency=IdempotencyLevel.IDEMPOTENT,
+        auth_policy=AuthPolicy(
+            level=AuthLevel.MANUAL_AUTH,
+            rationale="Requires current session_id to exclude from revocation",
+        ),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    # =========================================================================
+    # Tokens Resource (1 endpoint)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/tokens",
+        handler=create_tokens,
+        resource="tokens",
+        tags=["Tokens"],
+        summary="Create tokens",
+        description="Refresh access token using refresh token. Implements token rotation.",
+        operation_id="create_tokens",
+        response_model=TokenCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid token"),
+            ErrorSpec(status=401, description="Token expired or revoked"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_TOKEN_REFRESH,
+    ),
+    # =========================================================================
+    # Email Verifications Resource (1 endpoint)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/email-verifications",
+        handler=create_email_verification,
+        resource="email_verifications",
+        tags=["Email Verifications"],
+        summary="Create email verification",
+        description="Verify user's email address using verification token from email.",
+        operation_id="create_email_verification",
+        response_model=EmailVerificationCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid or expired token"),
+            ErrorSpec(status=404, description="Token not found"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_PASSWORD_RESET,
+    ),
+    # =========================================================================
+    # Password Reset Tokens Resource (1 endpoint)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/password-reset-tokens",
+        handler=create_password_reset_token,
+        resource="password_reset_tokens",
+        tags=["Password Reset Tokens"],
+        summary="Create password reset token",
+        description="Request a password reset. Always returns success to prevent user enumeration.",
+        operation_id="create_password_reset_token",
+        response_model=PasswordResetTokenCreateResponse,
+        status_code=201,
+        errors=[],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_PASSWORD_RESET,
+    ),
+    # =========================================================================
+    # Password Resets Resource (1 endpoint)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/password-resets",
+        handler=create_password_reset,
+        resource="password_resets",
+        tags=["Password Resets"],
+        summary="Create password reset",
+        description="Reset password using token from email. Revokes all sessions.",
+        operation_id="create_password_reset",
+        response_model=PasswordResetCreateResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid or expired token"),
+            ErrorSpec(status=404, description="Token not found"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.AUTH_PASSWORD_RESET,
+    ),
+    # =========================================================================
+    # Providers Resource (6 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/providers",
+        handler=list_providers,
+        resource="providers",
+        tags=["Providers"],
+        summary="List provider connections",
+        description="List all provider connections for the authenticated user.",
+        operation_id="list_providers",
+        response_model=ProviderConnectionListResponse,
+        status_code=200,
+        errors=[],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/providers/{connection_id}",
+        handler=get_provider_connection,
+        resource="providers",
+        tags=["Providers"],
+        summary="Get provider connection",
+        description="Get details of a specific provider connection.",
+        operation_id="get_provider_connection",
+        response_model=ProviderConnectionResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(
+                status=403, description="Not authorized to access this connection"
+            ),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/providers",
+        handler=initiate_connection,
+        resource="providers",
+        tags=["Providers"],
+        summary="Initiate provider connection",
+        description="Start OAuth flow to connect a financial provider.",
+        operation_id="initiate_provider_connection",
+        response_model=AuthorizationUrlResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=404, description="Provider not supported"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_CONNECT,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/providers/callback",
+        handler=oauth_callback,
+        resource="providers",
+        tags=["Providers"],
+        summary="Complete OAuth callback",
+        description="Complete OAuth flow after user consent. Called by frontend after redirect.",
+        operation_id="oauth_callback",
+        response_model=ProviderConnectionResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid or expired state"),
+            ErrorSpec(status=502, description="Provider authentication failed"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_CONNECT,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.PATCH,
+        path="/providers/{connection_id}",
+        handler=update_provider,
+        resource="providers",
+        tags=["Providers"],
+        summary="Update provider connection",
+        description="Update connection properties (currently only alias).",
+        operation_id="update_provider_connection",
+        response_model=ProviderConnectionResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(
+                status=403, description="Not authorized to update this connection"
+            ),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.DELETE,
+        path="/providers/{connection_id}",
+        handler=disconnect_provider,
+        resource="providers",
+        tags=["Providers"],
+        summary="Disconnect provider",
+        description="Disconnect and remove a provider connection.",
+        operation_id="disconnect_provider",
+        response_model=None,
+        status_code=204,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(
+                status=403, description="Not authorized to disconnect this connection"
+            ),
+        ],
+        idempotency=IdempotencyLevel.IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/providers/{connection_id}/token-refreshes",
+        handler=refresh_provider_tokens,
+        resource="providers",
+        tags=["Providers"],
+        summary="Refresh provider tokens",
+        description="Refresh OAuth tokens for a provider connection.",
+        operation_id="refresh_provider_tokens",
+        response_model=TokenRefreshResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(
+                status=403, description="Not authorized or connection not active"
+            ),
+            ErrorSpec(status=502, description="Provider token refresh failed"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_SYNC,
+    ),
+    # =========================================================================
+    # Accounts Resource (3 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts",
+        handler=list_accounts,
+        resource="accounts",
+        tags=["Accounts"],
+        summary="List accounts",
+        description="List all accounts for the authenticated user across all connections.",
+        operation_id="list_accounts",
+        response_model=AccountListResponse,
+        status_code=200,
+        errors=[],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts/{account_id}",
+        handler=get_account,
+        resource="accounts",
+        tags=["Accounts"],
+        summary="Get account",
+        description="Get details of a specific account.",
+        operation_id="get_account",
+        response_model=AccountResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to access this account"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/accounts/syncs",
+        handler=sync_accounts,
+        resource="accounts",
+        tags=["Accounts"],
+        summary="Sync accounts",
+        description="Sync accounts from a provider connection.",
+        operation_id="sync_accounts",
+        response_model=SyncAccountsResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(status=403, description="Not authorized to sync this connection"),
+            ErrorSpec(status=429, description="Sync rate limit exceeded"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_SYNC,
+    ),
+    # =========================================================================
+    # Transactions Resource (2 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/transactions/{transaction_id}",
+        handler=get_transaction,
+        resource="transactions",
+        tags=["Transactions"],
+        summary="Get transaction",
+        description="Get details of a specific transaction.",
+        operation_id="get_transaction",
+        response_model=TransactionResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Transaction not found"),
+            ErrorSpec(
+                status=403, description="Not authorized to access this transaction"
+            ),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/transactions/syncs",
+        handler=sync_transactions,
+        resource="transactions",
+        tags=["Transactions"],
+        summary="Sync transactions",
+        description="Sync transactions from a provider connection.",
+        operation_id="sync_transactions",
+        response_model=SyncTransactionsResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=404, description="Connection or account not found"),
+            ErrorSpec(status=403, description="Not authorized to sync"),
+            ErrorSpec(status=429, description="Sync rate limit exceeded"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_SYNC,
+    ),
+    # =========================================================================
+    # Holdings Resource (2 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/holdings",
+        handler=list_holdings,
+        resource="holdings",
+        tags=["Holdings"],
+        summary="List holdings",
+        description="List all holdings for the authenticated user across all accounts.",
+        operation_id="list_holdings",
+        response_model=HoldingListResponse,
+        status_code=200,
+        errors=[],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/accounts/{account_id}/holdings/syncs",
+        handler=sync_holdings,
+        resource="holdings",
+        tags=["Accounts"],
+        summary="Sync holdings",
+        description="Sync holdings from provider for a specific account.",
+        operation_id="sync_holdings",
+        response_model=SyncHoldingsResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to sync this account"),
+            ErrorSpec(status=429, description="Sync rate limit exceeded"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.PROVIDER_SYNC,
+    ),
+    # =========================================================================
+    # Balance Snapshots Resource (3 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/balance-snapshots",
+        handler=get_latest_snapshots,
+        resource="balance_snapshots",
+        tags=["Balance Snapshots"],
+        summary="Get latest balance snapshots",
+        description="Get the most recent balance snapshot for each of user's accounts.",
+        operation_id="get_latest_balance_snapshots",
+        response_model=LatestSnapshotsResponse,
+        status_code=200,
+        errors=[],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts/{account_id}/balance-history",
+        handler=get_balance_history,
+        resource="balance_snapshots",
+        tags=["Accounts"],
+        summary="Get balance history",
+        description="Get balance history for an account within a date range.",
+        operation_id="get_balance_history",
+        response_model=BalanceHistoryResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to access this account"),
+            ErrorSpec(status=400, description="Invalid date range"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts/{account_id}/balance-snapshots",
+        handler=list_balance_snapshots,
+        resource="balance_snapshots",
+        tags=["Accounts"],
+        summary="List balance snapshots",
+        description="List recent balance snapshots for an account.",
+        operation_id="list_balance_snapshots",
+        response_model=BalanceHistoryResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to access this account"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    # =========================================================================
+    # Imports Resource (2 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/imports",
+        handler=import_from_file,
+        resource="imports",
+        tags=["Imports"],
+        summary="Import from file",
+        description="Import financial data from an uploaded file (QFX, OFX).",
+        operation_id="import_from_file",
+        response_model=ImportResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=400, description="Invalid file or format"),
+            ErrorSpec(status=415, description="Unsupported file format"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/imports/formats",
+        handler=list_supported_formats,
+        resource="imports",
+        tags=["Imports"],
+        summary="List supported formats",
+        description="List file formats supported for import.",
+        operation_id="list_supported_formats",
+        response_model=SupportedFormatsResponse,
+        status_code=200,
+        errors=[],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.PUBLIC),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    # =========================================================================
+    # Admin Resource (3 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/admin/security/rotations",
+        handler=create_global_rotation,
+        resource="admin",
+        tags=["Token Rotation"],
+        summary="Trigger global token rotation",
+        description="Admin-only. Increments global minimum token version, invalidating all existing refresh tokens.",
+        operation_id="create_global_rotation",
+        response_model=GlobalRotationResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=403, description="Not authorized (admin only)"),
+            ErrorSpec(status=500, description="Rotation failed"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.ADMIN, role="admin"),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.POST,
+        path="/admin/users/{user_id}/rotations",
+        handler=create_user_rotation,
+        resource="admin",
+        tags=["Token Rotation"],
+        summary="Trigger per-user token rotation",
+        description="Admin-only. Increments user's minimum token version, invalidating only that user's tokens.",
+        operation_id="create_user_rotation",
+        response_model=UserRotationResponse,
+        status_code=201,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=403, description="Not authorized (admin only)"),
+            ErrorSpec(status=404, description="User not found"),
+            ErrorSpec(status=500, description="Rotation failed"),
+        ],
+        idempotency=IdempotencyLevel.NON_IDEMPOTENT,
+        auth_policy=AuthPolicy(level=AuthLevel.ADMIN, role="admin"),
+        rate_limit_policy=RateLimitPolicy.API_WRITE,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/admin/security/config",
+        handler=get_security_config,
+        resource="admin",
+        tags=["Token Rotation"],
+        summary="Get security configuration",
+        description="Admin-only. Retrieve current security configuration including token version.",
+        operation_id="get_security_config",
+        response_model=SecurityConfigResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=403, description="Not authorized (admin only)"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.ADMIN, role="admin"),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    # =========================================================================
+    # Nested Resource Routes (4 endpoints)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/providers/{connection_id}/accounts",
+        handler=list_accounts_by_connection,
+        resource="accounts",
+        tags=["Providers"],
+        summary="List accounts for connection",
+        description="List all accounts for a specific provider connection.",
+        operation_id="list_accounts_by_connection",
+        response_model=AccountListResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Connection not found"),
+            ErrorSpec(
+                status=403, description="Not authorized to access this connection"
+            ),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts/{account_id}/transactions",
+        handler=list_transactions_by_account,
+        resource="transactions",
+        tags=["Accounts"],
+        summary="List transactions for account",
+        description="List transactions for a specific account with pagination and filters.",
+        operation_id="list_transactions_by_account",
+        response_model=TransactionListResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to access this account"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/accounts/{account_id}/holdings",
+        handler=list_holdings_by_account,
+        resource="holdings",
+        tags=["Accounts"],
+        summary="List holdings for account",
+        description="List all holdings for a specific account.",
+        operation_id="list_holdings_by_account",
+        response_model=HoldingListResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=404, description="Account not found"),
+            ErrorSpec(status=403, description="Not authorized to access this account"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+]

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -26,8 +26,6 @@ from src.schemas.auth_schemas import (
     PasswordResetTokenCreateResponse,
     PasswordResetCreateRequest,
     PasswordResetCreateResponse,
-    # Error response
-    AuthErrorResponse,
 )
 from src.schemas.session_schemas import (
     SessionListResponse,
@@ -62,6 +60,4 @@ __all__ = [
     "PasswordResetTokenCreateResponse",
     "PasswordResetCreateRequest",
     "PasswordResetCreateResponse",
-    # Error
-    "AuthErrorResponse",
 ]

--- a/src/schemas/auth_schemas.py
+++ b/src/schemas/auth_schemas.py
@@ -270,27 +270,3 @@ class PasswordResetCreateResponse(BaseModel):
         default="Password has been reset successfully. Please create a new session.",
         description="Success message",
     )
-
-
-# =============================================================================
-# Common Error Response
-# =============================================================================
-
-
-class AuthErrorResponse(BaseModel):
-    """Standard error response for auth endpoints.
-
-    Follows RFC 7807 Problem Details structure.
-    """
-
-    type: str = Field(
-        default="about:blank",
-        description="URI reference for error type",
-    )
-    title: str = Field(..., description="Short human-readable summary")
-    status: int = Field(..., description="HTTP status code")
-    detail: str = Field(..., description="Human-readable explanation")
-    instance: str | None = Field(
-        default=None,
-        description="URI reference for specific occurrence",
-    )

--- a/tests/api/test_admin_rotation_api.py
+++ b/tests/api/test_admin_rotation_api.py
@@ -356,7 +356,7 @@ class TestUserRotationEndpoint:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         data = response.json()
-        assert data["title"] == "User Not Found"
+        assert data["title"] == "Resource Not Found"
 
     def test_user_rotation_requires_reason(self, client):
         """Test rotation requires reason field."""

--- a/tests/api/test_email_verifications_api.py
+++ b/tests/api/test_email_verifications_api.py
@@ -127,8 +127,8 @@ class TestCreateEmailVerification:
         # Verify: RFC 7807 error response
         assert response.status_code == 404
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_not_found"
-        assert data["title"] == "Token Not Found"
+        assert data["type"].endswith("/errors/not_found")
+        assert data["title"] == "Resource Not Found"
         assert data["status"] == 404
         assert data["instance"] == "/api/v1/email-verifications"
 
@@ -150,8 +150,8 @@ class TestCreateEmailVerification:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_expired"
-        assert data["title"] == "Token Expired"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert "expired" in data["detail"].lower()
 
@@ -173,8 +173,8 @@ class TestCreateEmailVerification:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_already_used"
-        assert data["title"] == "Token Already Used"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert "already" in data["detail"].lower()
 
@@ -196,8 +196,8 @@ class TestCreateEmailVerification:
         # Verify: RFC 7807 error response
         assert response.status_code == 404
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/user_not_found"
-        assert data["title"] == "User Not Found"
+        assert data["type"].endswith("/errors/not_found")
+        assert data["title"] == "Resource Not Found"
         assert data["status"] == 404
 
     def test_create_email_verification_missing_token(self, client):

--- a/tests/api/test_password_resets_api.py
+++ b/tests/api/test_password_resets_api.py
@@ -224,8 +224,8 @@ class TestCreatePasswordReset:
         # Verify: RFC 7807 error response
         assert response.status_code == 404
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_not_found"
-        assert data["title"] == "Token Not Found"
+        assert data["type"].endswith("/errors/not_found")
+        assert data["title"] == "Resource Not Found"
         assert data["status"] == 404
         assert data["instance"] == "/api/v1/password-resets"
 
@@ -252,8 +252,8 @@ class TestCreatePasswordReset:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_expired"
-        assert data["title"] == "Token Expired"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert "expired" in data["detail"].lower()
 
@@ -280,8 +280,8 @@ class TestCreatePasswordReset:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_already_used"
-        assert data["title"] == "Token Already Used"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert "already" in data["detail"].lower()
 
@@ -308,8 +308,8 @@ class TestCreatePasswordReset:
         # Verify: RFC 7807 error response
         assert response.status_code == 404
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/user_not_found"
-        assert data["title"] == "User Not Found"
+        assert data["type"].endswith("/errors/not_found")
+        assert data["title"] == "Resource Not Found"
         assert data["status"] == 404
 
     def test_create_password_reset_missing_token(self, client):

--- a/tests/api/test_route_metadata_registry_compliance.py
+++ b/tests/api/test_route_metadata_registry_compliance.py
@@ -1,0 +1,464 @@
+"""Registry compliance tests - prevent drift and ensure completeness.
+
+These tests ensure the Route Metadata Registry remains the single source of truth
+by validating that:
+1. All FastAPI routes are registered in the registry (no orphans)
+2. All registry entries generate actual routes (no dead entries)
+3. Auth policies are enforced correctly
+4. Rate limit rules cover all endpoints
+5. Metadata is consistent across layers
+
+If these tests fail, it means the registry has drifted from actual implementation.
+"""
+
+from src.infrastructure.rate_limit.config import RATE_LIMIT_RULES
+from src.presentation.routers.api.v1 import v1_router
+from src.presentation.routers.api.v1.routes.derivations import build_rate_limit_rules
+from src.presentation.routers.api.v1.routes.metadata import AuthLevel
+from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+
+
+# =============================================================================
+# Test Class 1: Route Completeness
+# =============================================================================
+
+
+class TestRegistryCompleteness:
+    """Verify registry and FastAPI routes are in sync."""
+
+    def test_all_routes_are_registered(self):
+        """Every FastAPI route must have a registry entry.
+
+        Fails if: Someone adds a route without registering it in ROUTE_REGISTRY.
+        """
+        # Extract actual routes from FastAPI router
+        actual_routes = set()
+        for route in v1_router.routes:
+            # Skip non-endpoint routes (docs, openapi, etc.)
+            if hasattr(route, "methods") and hasattr(route, "path"):
+                for method in route.methods:
+                    # Normalize path (FastAPI includes /api/v1 prefix)
+                    path = route.path
+                    endpoint_key = f"{method} {path}"
+                    actual_routes.add(endpoint_key)
+
+        # Extract expected routes from registry
+        expected_routes = set()
+        for entry in ROUTE_REGISTRY:
+            endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+            expected_routes.add(endpoint_key)
+
+        # Find missing and extra routes
+        missing_in_registry = actual_routes - expected_routes
+        missing_in_fastapi = expected_routes - actual_routes
+
+        # Filter out FastAPI-added routes (HEAD for GET, OPTIONS)
+        ignored_methods = {"HEAD", "OPTIONS"}
+        missing_in_registry = {
+            r
+            for r in missing_in_registry
+            if not any(r.startswith(m) for m in ignored_methods)
+        }
+
+        # Assert 1:1 mapping
+        assert not missing_in_registry, (
+            f"Routes exist in FastAPI but not in ROUTE_REGISTRY: {missing_in_registry}. "
+            "Add these routes to registry.py or remove from router."
+        )
+
+        assert not missing_in_fastapi, (
+            f"Routes exist in ROUTE_REGISTRY but not in FastAPI: {missing_in_fastapi}. "
+            "Check route generation in generator.py."
+        )
+
+    def test_operation_ids_are_unique(self):
+        """Every operation_id must be unique across all routes.
+
+        Fails if: Duplicate operation_id in registry (breaks OpenAPI spec).
+        """
+        operation_ids = [entry.operation_id for entry in ROUTE_REGISTRY]
+        duplicates = [
+            op_id for op_id in set(operation_ids) if operation_ids.count(op_id) > 1
+        ]
+
+        assert not duplicates, (
+            f"Duplicate operation_ids found: {duplicates}. "
+            "Each route must have a unique operation_id."
+        )
+
+    def test_all_handlers_are_callable(self):
+        """Every handler in registry must be a callable function.
+
+        Fails if: Someone registers a non-function as handler.
+        """
+        for entry in ROUTE_REGISTRY:
+            assert callable(entry.handler), (
+                f"Route '{entry.method.value} {entry.path}' has non-callable handler: "
+                f"{entry.handler}. Handler must be a function."
+            )
+
+    def test_all_routes_have_tags(self):
+        """Every route must have at least one tag for OpenAPI grouping.
+
+        Fails if: Route has empty tags list.
+        """
+        for entry in ROUTE_REGISTRY:
+            assert entry.tags and len(entry.tags) > 0, (
+                f"Route '{entry.method.value} {entry.path}' has no tags. "
+                "Add at least one tag for OpenAPI documentation grouping."
+            )
+
+    def test_all_routes_have_operation_id(self):
+        """Every route must have an operation_id.
+
+        Fails if: Route has None or empty operation_id.
+        """
+        for entry in ROUTE_REGISTRY:
+            assert entry.operation_id, (
+                f"Route '{entry.method.value} {entry.path}' has no operation_id. "
+                "Add unique operation_id for OpenAPI client generation."
+            )
+
+    def test_all_routes_have_resource_name(self):
+        """Every route must have a resource name.
+
+        Fails if: Route has None or empty resource field.
+        """
+        for entry in ROUTE_REGISTRY:
+            assert entry.resource, (
+                f"Route '{entry.method.value} {entry.path}' has no resource name. "
+                "Add resource field for grouping and documentation."
+            )
+
+
+# =============================================================================
+# Test Class 2: Auth Policy Enforcement
+# =============================================================================
+
+
+class TestAuthPolicyEnforcement:
+    """Verify auth policies are correctly enforced."""
+
+    def test_public_routes_have_no_auth_dependencies(self):
+        """PUBLIC routes should not inject auth dependencies.
+
+        Fails if: PUBLIC route has AuthenticatedUser/CurrentUser dependency.
+        """
+        for entry in ROUTE_REGISTRY:
+            if entry.auth_policy.level == AuthLevel.PUBLIC:
+                # Check handler signature for auth dependencies
+                import inspect
+
+                sig = inspect.signature(entry.handler)
+
+                for param_name, param in sig.parameters.items():
+                    param_annotation = str(param.annotation)
+                    assert "CurrentUser" not in param_annotation, (
+                        f"PUBLIC route '{entry.method.value} {entry.path}' "
+                        f"has CurrentUser dependency in parameter '{param_name}'. "
+                        "PUBLIC routes should not require authentication."
+                    )
+
+    def test_authenticated_routes_have_auth_or_manual(self):
+        """AUTHENTICATED routes must have auth dependency OR be MANUAL_AUTH.
+
+        Fails if: AUTHENTICATED route has no auth mechanism.
+        """
+        for entry in ROUTE_REGISTRY:
+            if entry.auth_policy.level == AuthLevel.AUTHENTICATED:
+                import inspect
+
+                sig = inspect.signature(entry.handler)
+
+                # Check if handler has CurrentUser or is MANUAL_AUTH
+                has_auth_dependency = any(
+                    "CurrentUser" in str(param.annotation)
+                    for param in sig.parameters.values()
+                )
+
+                # MANUAL_AUTH routes handle auth themselves
+                is_manual_auth = entry.auth_policy.level == AuthLevel.MANUAL_AUTH
+
+                # Either has dependency OR is manual (but not both in this case)
+                assert has_auth_dependency or is_manual_auth, (
+                    f"AUTHENTICATED route '{entry.method.value} {entry.path}' "
+                    f"has no CurrentUser dependency. Add CurrentUser parameter "
+                    f"or change auth_policy to MANUAL_AUTH."
+                )
+
+    def test_manual_auth_routes_have_rationale(self):
+        """MANUAL_AUTH routes must document why they're manual.
+
+        Fails if: MANUAL_AUTH route has no rationale comment.
+        """
+        manual_auth_routes = [
+            entry
+            for entry in ROUTE_REGISTRY
+            if entry.auth_policy.level == AuthLevel.MANUAL_AUTH
+        ]
+
+        for entry in manual_auth_routes:
+            assert entry.auth_policy.rationale, (
+                f"MANUAL_AUTH route '{entry.method.value} {entry.path}' "
+                f"has no rationale. Add rationale to AuthPolicy explaining "
+                f"why this route handles auth manually."
+            )
+
+            # Rationale should be meaningful (not just a placeholder)
+            assert len(entry.auth_policy.rationale) > 10, (
+                f"MANUAL_AUTH route '{entry.method.value} {entry.path}' "
+                f"has insufficient rationale: '{entry.auth_policy.rationale}'. "
+                f"Provide detailed explanation."
+            )
+
+
+# =============================================================================
+# Test Class 3: Rate Limit Coverage
+# =============================================================================
+
+
+class TestRateLimitCoverage:
+    """Verify rate limits are complete and consistent."""
+
+    def test_all_registry_entries_have_rate_limit_policy(self):
+        """Every registry entry must have a rate_limit_policy.
+
+        Fails if: Someone forgets to set rate_limit_policy.
+        """
+        for entry in ROUTE_REGISTRY:
+            assert entry.rate_limit_policy is not None, (
+                f"Route '{entry.method.value} {entry.path}' "
+                f"has no rate_limit_policy. Add a rate limit policy."
+            )
+
+    def test_rate_limit_rules_have_positive_values(self):
+        """Generated rate limit rules must have valid positive values.
+
+        Fails if: Rule has zero or negative max_tokens, refill_rate, or cost.
+        """
+        for endpoint, rule in RATE_LIMIT_RULES.items():
+            assert rule.max_tokens > 0, (
+                f"Rate limit rule for '{endpoint}' has invalid max_tokens: {rule.max_tokens}. "
+                "Must be positive integer."
+            )
+            assert rule.refill_rate > 0, (
+                f"Rate limit rule for '{endpoint}' has invalid refill_rate: {rule.refill_rate}. "
+                "Must be positive number."
+            )
+            assert rule.cost > 0, (
+                f"Rate limit rule for '{endpoint}' has invalid cost: {rule.cost}. "
+                "Must be positive integer."
+            )
+
+    def test_rate_limit_rules_cover_all_registry_entries(self):
+        """Generated rate limit rules must cover all registry entries.
+
+        Fails if: build_rate_limit_rules() doesn't generate rule for an entry.
+        """
+        generated_rules = build_rate_limit_rules(ROUTE_REGISTRY)
+
+        for entry in ROUTE_REGISTRY:
+            endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+            assert endpoint_key in generated_rules, (
+                f"No rate limit rule generated for '{endpoint_key}'. "
+                f"Check build_rate_limit_rules() in derivations.py."
+            )
+
+    def test_no_orphaned_rate_limit_rules(self):
+        """Rate limit rules should only exist for registered routes.
+
+        Fails if: Rate limit rule exists for non-existent endpoint.
+        """
+        registry_endpoints = {
+            f"{entry.method.value} /api/v1{entry.path}" for entry in ROUTE_REGISTRY
+        }
+
+        for rule_endpoint in RATE_LIMIT_RULES.keys():
+            assert rule_endpoint in registry_endpoints, (
+                f"Rate limit rule exists for unregistered endpoint: '{rule_endpoint}'. "
+                f"Remove orphaned rule or add route to registry."
+            )
+
+
+# =============================================================================
+# Test Class 4: Metadata Consistency
+# =============================================================================
+
+
+class TestMetadataConsistency:
+    """Verify metadata is consistent across layers."""
+
+    def test_registry_matches_fastapi_routes(self):
+        """Registry metadata should match generated FastAPI routes.
+
+        Fails if: Generator doesn't properly translate registry to FastAPI.
+        """
+        # Build map of FastAPI routes
+        fastapi_routes = {}
+        for route in v1_router.routes:
+            if hasattr(route, "methods") and hasattr(route, "path"):
+                for method in route.methods:
+                    if method not in {"HEAD", "OPTIONS"}:
+                        key = f"{method} {route.path}"
+                        fastapi_routes[key] = route
+
+        # Verify each registry entry
+        for entry in ROUTE_REGISTRY:
+            endpoint_key = f"{entry.method.value} /api/v1{entry.path}"
+
+            assert endpoint_key in fastapi_routes, (
+                f"Registry entry '{endpoint_key}' not found in FastAPI routes"
+            )
+
+            fastapi_route = fastapi_routes[endpoint_key]
+
+            # Verify metadata matches
+            if hasattr(fastapi_route, "summary"):
+                assert fastapi_route.summary == entry.summary, (
+                    f"Summary mismatch for '{endpoint_key}': "
+                    f"Registry='{entry.summary}', FastAPI='{fastapi_route.summary}'"
+                )
+
+            if hasattr(fastapi_route, "status_code"):
+                assert fastapi_route.status_code == entry.status_code, (
+                    f"Status code mismatch for '{endpoint_key}': "
+                    f"Registry={entry.status_code}, FastAPI={fastapi_route.status_code}"
+                )
+
+    def test_response_models_are_defined(self):
+        """All non-204 routes should have response_model defined.
+
+        Fails if: Route returns data but has no response schema.
+        """
+        for entry in ROUTE_REGISTRY:
+            # 204 No Content doesn't need response model
+            if entry.status_code == 204:
+                assert entry.response_model is None, (
+                    f"Route '{entry.method.value} {entry.path}' "
+                    f"has 204 status but defines response_model. "
+                    f"204 No Content should have response_model=None."
+                )
+            else:
+                # Other status codes should have response model
+                assert entry.response_model is not None, (
+                    f"Route '{entry.method.value} {entry.path}' "
+                    f"returns {entry.status_code} but has no response_model. "
+                    f"Define a response schema in src/schemas/."
+                )
+
+    def test_error_specs_are_valid(self):
+        """All error specs must have valid status codes.
+
+        Fails if: ErrorSpec has invalid or non-error HTTP status code.
+        """
+        valid_error_statuses = {400, 401, 403, 404, 409, 415, 422, 429, 500, 502, 503}
+
+        for entry in ROUTE_REGISTRY:
+            for error_spec in entry.errors:
+                assert error_spec.status in valid_error_statuses, (
+                    f"Route '{entry.method.value} {entry.path}' "
+                    f"has invalid error status: {error_spec.status}. "
+                    f"Must be one of: {valid_error_statuses}"
+                )
+                assert error_spec.description, (
+                    f"Route '{entry.method.value} {entry.path}' "
+                    f"has ErrorSpec with status {error_spec.status} but no description. "
+                    f"Add description for OpenAPI documentation."
+                )
+
+    def test_path_parameters_match_handler_signature(self):
+        """Path parameters in route must exist in handler signature.
+
+        Fails if: Path has {param} but handler doesn't accept param.
+        """
+        import re
+        import inspect
+
+        for entry in ROUTE_REGISTRY:
+            # Extract path parameters (e.g., {user_id} from /users/{user_id})
+            path_params = re.findall(r"\{(\w+)\}", entry.path)
+
+            if path_params:
+                sig = inspect.signature(entry.handler)
+                handler_params = set(sig.parameters.keys())
+
+                missing_params = set(path_params) - handler_params
+                assert not missing_params, (
+                    f"Route '{entry.method.value} {entry.path}' "
+                    f"has path parameters {missing_params} not in handler signature. "
+                    f"Handler parameters: {handler_params}"
+                )
+
+
+# =============================================================================
+# Test Class 5: Registry Statistics
+# =============================================================================
+
+
+class TestRegistryStatistics:
+    """Report registry statistics for visibility."""
+
+    def test_registry_statistics(self):
+        """Report comprehensive registry statistics.
+
+        This test always passes - it's informational only.
+        """
+        # Count by method
+        method_counts = {}
+        for entry in ROUTE_REGISTRY:
+            method = entry.method.value
+            method_counts[method] = method_counts.get(method, 0) + 1
+
+        # Count by auth policy
+        auth_counts = {}
+        for entry in ROUTE_REGISTRY:
+            level = entry.auth_policy.level.value
+            auth_counts[level] = auth_counts.get(level, 0) + 1
+
+        # Count by rate limit policy
+        rate_limit_counts = {}
+        for entry in ROUTE_REGISTRY:
+            policy = entry.rate_limit_policy.value
+            rate_limit_counts[policy] = rate_limit_counts.get(policy, 0) + 1
+
+        # Count by idempotency
+        idempotency_counts = {}
+        for entry in ROUTE_REGISTRY:
+            level = entry.idempotency.value
+            idempotency_counts[level] = idempotency_counts.get(level, 0) + 1
+
+        # Build report
+        report = [
+            "\n" + "=" * 60,
+            "ROUTE METADATA REGISTRY STATISTICS",
+            "=" * 60,
+            f"Total Endpoints: {len(ROUTE_REGISTRY)}",
+            "",
+            "HTTP Methods:",
+            *[
+                f"  {method}: {count}"
+                for method, count in sorted(method_counts.items())
+            ],
+            "",
+            "Auth Policies:",
+            *[f"  {policy}: {count}" for policy, count in sorted(auth_counts.items())],
+            "",
+            "Rate Limit Policies:",
+            *[
+                f"  {policy}: {count}"
+                for policy, count in sorted(rate_limit_counts.items())
+            ],
+            "",
+            "Idempotency Levels:",
+            *[
+                f"  {level}: {count}"
+                for level, count in sorted(idempotency_counts.items())
+            ],
+            "=" * 60,
+        ]
+
+        # Print report (visible in pytest output with -v)
+        print("\n".join(report))
+
+        # Test always passes (informational only)
+        assert True, "Registry statistics reported"

--- a/tests/api/test_sessions_api.py
+++ b/tests/api/test_sessions_api.py
@@ -429,7 +429,7 @@ class TestCreateSession:
 
         assert response.status_code == 401
         data = response.json()
-        assert data["title"] == "Invalid Credentials"
+        assert data["title"] == "Authentication Required"
         assert data["status"] == 401
 
     def test_create_session_account_locked(self, client):
@@ -441,7 +441,7 @@ class TestCreateSession:
 
         assert response.status_code == 403
         data = response.json()
-        assert data["title"] == "Account Locked"
+        assert data["title"] == "Access Denied"
 
     def test_create_session_email_not_verified(self, client):
         """Test unverified email returns 403."""
@@ -452,7 +452,7 @@ class TestCreateSession:
 
         assert response.status_code == 403
         data = response.json()
-        assert data["title"] == "Email Not Verified"
+        assert data["title"] == "Access Denied"
 
     def test_create_session_missing_email(self, client):
         """Test missing email returns 422 validation error."""
@@ -488,7 +488,7 @@ class TestListSessions:
 
         assert response.status_code == 401
         data = response.json()
-        assert data["title"] == "Unauthorized"
+        assert data["title"] == "Authentication Required"
 
     def test_list_sessions_success(self, client):
         """Test successful session listing returns 200."""
@@ -546,7 +546,7 @@ class TestGetSession:
 
         assert response.status_code == 404
         data = response.json()
-        assert data["title"] == "Not Found"
+        assert data["title"] == "Resource Not Found"
 
 
 # =============================================================================

--- a/tests/api/test_tokens_api.py
+++ b/tests/api/test_tokens_api.py
@@ -148,8 +148,8 @@ class TestCreateTokens:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_invalid"
-        assert data["title"] == "Invalid Token"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert "invalid" in data["detail"].lower()
         assert data["instance"] == "/api/v1/tokens"
@@ -172,8 +172,8 @@ class TestCreateTokens:
         # Verify: RFC 7807 error response
         assert response.status_code == 401
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_expired"
-        assert data["title"] == "Token Expired"
+        assert data["type"].endswith("/errors/unauthorized")
+        assert data["title"] == "Authentication Required"
         assert data["status"] == 401
         assert "expired" in data["detail"].lower()
         assert data["instance"] == "/api/v1/tokens"
@@ -196,8 +196,8 @@ class TestCreateTokens:
         # Verify: RFC 7807 error response
         assert response.status_code == 401
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/token_revoked"
-        assert data["title"] == "Token Revoked"
+        assert data["type"].endswith("/errors/unauthorized")
+        assert data["title"] == "Authentication Required"
         assert data["status"] == 401
         assert "revoked" in data["detail"].lower()
         assert data["instance"] == "/api/v1/tokens"
@@ -220,8 +220,8 @@ class TestCreateTokens:
         # Verify: RFC 7807 error response
         assert response.status_code == 401
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/user_not_found"
-        assert data["title"] == "User Not Found"
+        assert data["type"].endswith("/errors/unauthorized")
+        assert data["title"] == "Authentication Required"
         assert data["status"] == 401
 
     def test_create_tokens_user_inactive(self, client):
@@ -242,8 +242,8 @@ class TestCreateTokens:
         # Verify: RFC 7807 error response
         assert response.status_code == 401
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/user_inactive"
-        assert data["title"] == "User Inactive"
+        assert data["type"].endswith("/errors/unauthorized")
+        assert data["title"] == "Authentication Required"
         assert data["status"] == 401
 
     def test_create_tokens_missing_refresh_token(self, client):

--- a/tests/api/test_users_api.py
+++ b/tests/api/test_users_api.py
@@ -132,8 +132,8 @@ class TestCreateUser:
         # Verify: RFC 7807 error response
         assert response.status_code == 409
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/email-already-registered"
-        assert data["title"] == "Email Already Registered"
+        assert data["type"].endswith("/errors/conflict")
+        assert data["title"] == "Resource Conflict"
         assert data["status"] == 409
         assert "already registered" in data["detail"].lower()
         assert data["instance"] == "/api/v1/users"
@@ -159,8 +159,8 @@ class TestCreateUser:
         # Verify: RFC 7807 error response
         assert response.status_code == 400
         data = response.json()
-        assert data["type"] == "https://api.dashtam.com/errors/validation-error"
-        assert data["title"] == "Validation Error"
+        assert data["type"].endswith("/errors/command_validation_failed")
+        assert data["title"] == "Validation Failed"
         assert data["status"] == 400
         assert (
             "password" in data["detail"].lower()

--- a/tests/unit/test_domain_rate_limit_scope.py
+++ b/tests/unit/test_domain_rate_limit_scope.py
@@ -110,7 +110,8 @@ class TestGetRuleForEndpoint:
 
     def test_provider_sync_endpoint(self) -> None:
         """Should match provider sync endpoint with USER_PROVIDER scope."""
-        rule = get_rule_for_endpoint("POST /api/v1/providers/123/sync")
+        # Use actual sync endpoint path from registry
+        rule = get_rule_for_endpoint("POST /api/v1/accounts/syncs")
         assert rule is not None
         assert rule.scope == RateLimitScope.USER_PROVIDER
 

--- a/tests/unit/test_rate_limit_registry_compliance.py
+++ b/tests/unit/test_rate_limit_registry_compliance.py
@@ -137,10 +137,12 @@ class TestRateLimitRuleConsistency:
 
     def test_api_endpoints_use_user_scope(self):
         """Standard API endpoints should use USER scope."""
+        # Exclude sync endpoints which use USER_PROVIDER scope
         api_endpoints = [
             ep
             for ep in RATE_LIMIT_RULES
-            if "/accounts" in ep or "/transactions" in ep or "/holdings" in ep
+            if ("/accounts" in ep or "/transactions" in ep or "/holdings" in ep)
+            and "/syncs" not in ep  # Sync endpoints use USER_PROVIDER
         ]
 
         for endpoint in api_endpoints:
@@ -291,8 +293,8 @@ class TestRateLimitRegistryStatistics:
         critical_endpoints = [
             "POST /api/v1/sessions",  # Login
             "POST /api/v1/users",  # Registration
-            "POST /api/v1/auth/refresh",  # Token refresh
-            "POST /api/v1/providers",  # Provider connect
+            "POST /api/v1/tokens",  # Token refresh (new RESTful path)
+            "POST /api/v1/providers",  # Provider connect (initiate)
         ]
 
         missing = [ep for ep in critical_endpoints if ep not in RATE_LIMIT_RULES]


### PR DESCRIPTION
## F8.2: Route Metadata Registry with Generated Routes

### Summary
Implements declarative route metadata registry with auto-generated FastAPI routes, replacing decorator-based routing with single source of truth pattern. Achieves RFC 7807 full compliance and auto-generated rate limit rules.

### Changes
**Core Infrastructure** (9 new files):
- Route metadata registry (36 endpoints) with types, registry, generator, derivations
- Auto-generated rate limit rules (from_registry.py)
- Self-enforcing test suite (18 tests)
- Comprehensive documentation (error-handling-guide.md, route-registry-architecture.md)

**Router Refactoring** (12 files):
- Converted all routers to pure handler functions (no decorators)
- Handlers: sessions (6), tokens (1), users (1), email_verifications (1), password_resets (2), providers (6), accounts (4), transactions (3), holdings (3), balance_snapshots (3), imports (2), admin (3)

**RFC 7807 Full Compliance**:
- Removed AuthErrorResponse from schemas (BREAKING CHANGE)
- All errors use ErrorResponseBuilder with ApplicationErrorCode
- Updated 21 API tests for new error format

**Rate Limit Generation**:
- Two-tier pattern: policy assignment (registry) + policy rules (derivations)
- Auto-generated rules replace hand-written config.py mappings
- config.py becomes thin proxy importing from from_registry.py

### Testing
- All 2,271 tests pass (88% coverage)
- 18 self-enforcing tests prevent registry drift
- Full verification passed (make verify)

### Documentation
- Error Handling Guide (726 lines) - RFC 7807 with client examples
- Route Registry Architecture (772 lines) - Complete pattern documentation
- Updated WARP.md, registry-pattern-architecture.md, docs/index.md
- Updated mkdocs.yml navigation

### Breaking Changes
- `AuthErrorResponse` removed from `src/schemas/auth_schemas.py`
- All API errors now use RFC 7807 `ProblemDetails` format
- Clients must update error handling to parse `type` field (ApplicationErrorCode URLs)

### Migration Guide
**Before** (AuthErrorResponse):
```json
{
  "error": "invalid_credentials",
  "message": "Invalid email or password"
}
```

**After** (RFC 7807):
```json
{
  "type": "https://api.dashtam.com/errors/unauthorized",
  "title": "Authentication Required",
  "status": 401,
  "detail": "Invalid email or password",
  "instance": "/api/v1/sessions",
  "trace_id": "550e8400-..."
}
```

**Client Updates**:
- Match on `error.type` (NOT `status` code)
- Parse `detail` for human-readable message
- Use `trace_id` for debugging/support

See `docs/guides/error-handling-guide.md` for complete examples.

### Closes
Part of Phase 8 (Administrative Features) - F8.2 Route Metadata Registry