### PR TITLE
docs: migrate RFC 7807 references to RFC 9457

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **RFC 9457 Migration**: Updated all RFC 7807 references to RFC 9457 (current standard)
+  - RFC 9457 (July 2023) obsoletes RFC 7807 with backward-compatible enhancements
+  - No code changes required - JSON schema and behavior identical
+  - Updated 222 references across source, docs, and tests
+  - Key files: `problem_details.py`, `error_response_builder.py`, `exception_handlers.py`
+  - Removed hardcoded test count from README.md
+  - Audit report: `~/references/audit/dashtam-rfc-7807-to-9457-migration-audit-2026-01-17.md`
+
 ## [1.8.1] - 2026-01-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Protocol-Based Design** — Structural typing with Python `Protocol`; no inheritance, easy testing
 - **Registry Patterns** — Single source of truth for events, routes, rate limits with self-enforcing tests
 - **Production Security** — JWT + opaque refresh tokens, Casbin RBAC, token bucket rate limiting, PCI-DSS audit trails
-- **100% REST Compliance** — Resource-oriented URLs, RFC 7807 error responses, no controller-style endpoints
+- **100% REST Compliance** — Resource-oriented URLs, RFC 9457 error responses, no controller-style endpoints
 
 ## Architecture
 
@@ -124,7 +124,7 @@ curl -k https://dashtam.local/health
 
 ### Guides
 
-- [Error Handling](https://faiyaz7283.github.io/Dashtam/guides/error-handling/) — RFC 7807, Result types
+- [Error Handling](https://faiyaz7283.github.io/Dashtam/guides/error-handling/) — RFC 9457, Result types
 - [Adding Providers](https://faiyaz7283.github.io/Dashtam/guides/adding-providers/) — OAuth, API key, file import
 - [Release Management](https://faiyaz7283.github.io/Dashtam/guides/releases/) — Git flow, versioning
 
@@ -137,7 +137,7 @@ curl -k https://dashtam.local/health
 | Database | PostgreSQL 17.7 (async SQLAlchemy) |
 | Cache | Redis 8.4 |
 | Infrastructure | Docker Compose, Traefik, Alembic |
-| Testing | pytest (2,273 tests, 87% coverage) |
+| Testing | pytest (88%+ coverage) |
 
 ## Development
 

--- a/WARP.md
+++ b/WARP.md
@@ -704,9 +704,9 @@ async def create_user(data: dict):  # No!
     ...
 ```
 
-#### Error Handling (RFC 7807 Problem Details)
+#### Error Handling (RFC 9457 Problem Details)
 
-**CRITICAL**: All API errors use RFC 7807 Problem Details format. **AuthErrorResponse removed in v1.6.3**.
+**CRITICAL**: All API errors use RFC 9457 Problem Details format. **AuthErrorResponse removed in v1.6.3**.
 
 **Error Response Format**:
 
@@ -730,7 +730,7 @@ async def create_user(data: dict):  # No!
 from src.core.errors import ApplicationError, ApplicationErrorCode
 from src.presentation.api.error_response_builder import ErrorResponseBuilder
 
-# Return RFC 7807 error
+# Return RFC 9457 error
 error = ApplicationError(
     code=ApplicationErrorCode.NOT_FOUND,
     message="User not found"

--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -318,9 +318,9 @@ sequenceDiagram
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -438,9 +438,9 @@ sequenceDiagram
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/api/balance-snapshots.md
+++ b/docs/api/balance-snapshots.md
@@ -220,9 +220,9 @@ Same structure as Balance History response.
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/api/holdings.md
+++ b/docs/api/holdings.md
@@ -223,9 +223,9 @@ curl -k -X POST "{BASE_URL}/accounts/123e4567-e89b-12d3-a456-426614174000/holdin
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,7 +6,7 @@ All endpoints follow REST best practices:
 
 - **Resource-oriented URLs** — Nouns, not verbs
 - **Standard HTTP methods** — GET, POST, PATCH, DELETE
-- **RFC 7807 error responses** — Problem Details format
+- **RFC 9457 error responses** — Problem Details format
 - **JWT authentication** — Bearer token in Authorization header
 
 Browse the sidebar for endpoint documentation.

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -369,9 +369,9 @@ sequenceDiagram
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/api/transactions.md
+++ b/docs/api/transactions.md
@@ -332,9 +332,9 @@ curl -k -X GET "{BASE_URL}/accounts/123e4567-e89b-12d3-a456-426614174000/transac
 
 ---
 
-## Error Response Format (RFC 7807)
+## Error Response Format (RFC 9457)
 
-All errors follow RFC 7807 Problem Details format:
+All errors follow RFC 9457 Problem Details format:
 
 ```json
 {

--- a/docs/architecture/api-patterns.md
+++ b/docs/architecture/api-patterns.md
@@ -210,7 +210,7 @@ async def list_accounts(
 
     Returns:
         AccountListResponse with list of accounts.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = ListAccountsByUser(
         user_id=current_user.user_id,
@@ -261,7 +261,7 @@ async def get_account(
 
     Returns:
         AccountResponse with account details.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = GetAccount(
         account_id=account_id,
@@ -270,7 +270,7 @@ async def get_account(
     result = await handler.handle(query)
 
     if isinstance(result, Failure):
-        # Use error mapper for consistent RFC 7807 responses
+        # Use error mapper for consistent RFC 9457 responses
         app_error = _map_account_error(result.error)
         return ErrorResponseBuilder.from_application_error(
             error=app_error,
@@ -358,7 +358,7 @@ async def disconnect_provider(
 
     Returns:
         Response with 204 No Content on success.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     command = DisconnectProvider(
         connection_id=connection_id,
@@ -530,9 +530,9 @@ class PaginatedResponse(BaseModel):
 
 ## 5. Error Handling
 
-### 5.1 RFC 7807 Problem Details
+### 5.1 RFC 9457 Problem Details
 
-All error responses follow RFC 7807 format:
+All error responses follow RFC 9457 format:
 
 ```json
 {
@@ -547,7 +547,7 @@ All error responses follow RFC 7807 format:
 
 ### 5.2 String-to-ApplicationError Mapping Pattern
 
-**Current State**: Handlers return `Result[T, str]`. Each router file includes a mapper function to convert string errors to typed `ApplicationError` for RFC 7807 compliance.
+**Current State**: Handlers return `Result[T, str]`. Each router file includes a mapper function to convert string errors to typed `ApplicationError` for RFC 9457 compliance.
 
 **TODO (Phase 6)**: Refactor handlers to return `Result[T, ApplicationError]` directly.
 
@@ -813,7 +813,7 @@ def test_list_accounts_returns_empty_list(client):
 - Tests real router registration and middleware
 - Validates DI wiring via `Depends()`
 - Catches routing bugs before runtime
-- Full RFC 7807 error response testing
+- Full RFC 9457 error response testing
 
 ### 8.3 Authentication Override Pattern (CRITICAL)
 
@@ -919,7 +919,7 @@ Each endpoint should have tests for:
 1. **Happy Path**: Successful operation with valid inputs
 2. **Empty Results**: List endpoints return empty lists (not errors)
 3. **Not Found**: 404 when resource doesn't exist
-4. **RFC 7807 Errors**: Verify error response format
+4. **RFC 9457 Errors**: Verify error response format
 
 **Note**: Authentication tests (401) require NOT setting the auth override, which can be complex with `autouse=True`. Consider dedicated auth test files.
 

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -241,7 +241,7 @@ class UserRepository:
 
 - Infrastructure: Database exceptions → Domain errors
 - Application: Domain errors → Application errors
-- Presentation: Application errors → RFC 7807 Problem Details
+- Presentation: Application errors → RFC 9457 Problem Details
 
 ### Structured Logging Integration
 
@@ -959,7 +959,7 @@ The database architecture is fully integrated with Dashtam's architecture ecosys
 
 - Database operations return Result types (Success/Failure)
 - No exceptions thrown to domain layer
-- Errors mapped: SQLAlchemy exceptions → Domain errors → RFC 7807
+- Errors mapped: SQLAlchemy exceptions → Domain errors → RFC 9457
 
 **Structured Logging** (see `docs/architecture/logging.md`):
 

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -15,7 +15,7 @@ while maintaining proper error propagation and user-friendly HTTP responses.
 
 1. **No Exceptions in Domain Business Logic**: Domain services and entities use Result types, not exceptions
 2. **Railway-Oriented Programming**: Errors flow through pipeline as data
-3. **RFC 7807 Compliance**: HTTP API errors follow industry standard
+3. **RFC 9457 Compliance**: HTTP API errors follow industry standard
 4. **Machine-Readable Codes**: All errors have enums for client handling
 5. **User-Friendly Messages**: Human-readable descriptions for end users
 6. **Detailed Logging**: Structured logs with trace IDs for debugging
@@ -244,9 +244,9 @@ class UserService:
 
 ## Industry Standards
 
-### RFC 7807: Problem Details for HTTP APIs
+### RFC 9457: Problem Details for HTTP APIs
 
-**Official Standard**: [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)
+**Official Standard**: [RFC 9457](https://datatracker.ietf.org/doc/html/rfc7807)
 
 **Required Fields**:
 
@@ -314,7 +314,7 @@ class UserService:
 graph TB
     subgraph "Presentation Layer"
         API[FastAPI Endpoints]
-        RFC[RFC 7807 Problem Details]
+        RFC[RFC 9457 Problem Details]
         HTTP[HTTP Status Codes]
     end
     
@@ -357,7 +357,7 @@ graph TB
 1. **Infrastructure**: Catches exceptions → Maps to DomainError
 2. **Domain**: Business logic returns Result[T, DomainError]
 3. **Application**: Maps DomainError → ApplicationError
-4. **Presentation**: Maps ApplicationError → RFC 7807 ProblemDetails
+4. **Presentation**: Maps ApplicationError → RFC 9457 ProblemDetails
 
 ---
 
@@ -786,7 +786,7 @@ class RedisAdapter:
 
 ---
 
-## Presentation Layer (RFC 7807)
+## Presentation Layer (RFC 9457)
 
 ### Location: `src/presentation/routers/api/v1/errors/`
 
@@ -803,7 +803,7 @@ class ErrorDetail(BaseModel):
 
 
 class ProblemDetails(BaseModel):
-    """RFC 7807 Problem Details for HTTP APIs."""
+    """RFC 9457 Problem Details for HTTP APIs."""
     
     type: str = Field(
         ...,
@@ -848,7 +848,7 @@ from fastapi.responses import JSONResponse
 from src.application.errors import ApplicationError, ApplicationErrorCode
 
 class ErrorResponseBuilder:
-    """Build RFC 7807 Problem Details responses."""
+    """Build RFC 9457 Problem Details responses."""
     
     # Uses settings.api_base_url for error type URLs
     
@@ -858,7 +858,7 @@ class ErrorResponseBuilder:
         request: Request,
         trace_id: str,
     ) -> JSONResponse:
-        """Convert ApplicationError to RFC 7807 response."""
+        """Convert ApplicationError to RFC 9457 response."""
         
         # Map to HTTP status
         status_code = ErrorResponseBuilder._get_status_code(error.code)
@@ -1087,7 +1087,7 @@ async def test_create_user_command_handler():
 
 ```python
 def test_register_user_validation_error(client):
-    """Test API returns RFC 7807 response."""
+    """Test API returns RFC 9457 response."""
     response = client.post("/api/v1/auth/register", json={
         "email": "invalid",
         "password": "weak",
@@ -1129,7 +1129,7 @@ Dashtam's error handling architecture provides:
 
 - **Type-Safe Errors**: ErrorCode enums with frozen dataclasses
 - **Railway-Oriented Programming**: Result types throughout
-- **RFC 7807 Compliance**: Industry-standard HTTP API errors
+- **RFC 9457 Compliance**: Industry-standard HTTP API errors
 - **Clear Separation**: Domain → Application → Infrastructure → Presentation
 - **User-Friendly**: Human-readable messages with machine-readable codes
 - **Developer-Friendly**: Detailed logs with trace IDs for debugging

--- a/docs/architecture/route-registry.md
+++ b/docs/architecture/route-registry.md
@@ -199,7 +199,7 @@ class RouteMetadata:
     response_model: type[BaseModel] | None = None
     status_code: int = 200
     
-    # Error handling (RFC 7807)
+    # Error handling (RFC 9457)
     errors: list[ErrorSpec] = field(default_factory=list)
     
     # Policies
@@ -581,7 +581,7 @@ def test_registry_statistics():
 
 ## Integration with Existing Systems
 
-### RFC 7807 Error Handling
+### RFC 9457 Error Handling
 
 Route registry includes error specs for OpenAPI docs:
 
@@ -596,14 +596,14 @@ RouteMetadata(
 )
 ```
 
-Handlers return RFC 7807 Problem Details:
+Handlers return RFC 9457 Problem Details:
 
 ```python
 async def create_user(...) -> UserCreateResponse:
     result = await handler.handle(...)
     
     if isinstance(result, Failure):
-        # RFC 7807 error response
+        # RFC 9457 error response
         return ErrorResponseBuilder.from_application_error(
             error=result.error,
             request_path="/api/v1/users"

--- a/docs/architecture/validation.md
+++ b/docs/architecture/validation.md
@@ -215,7 +215,7 @@ class RefreshTokenRequest(BaseModel):
 
 #### Validation Error Response
 
-FastAPI automatically returns RFC 7807-compliant error responses:
+FastAPI automatically returns RFC 9457-compliant error responses:
 
 ```json
 {
@@ -771,7 +771,7 @@ async def login(
     ))
     
     if isinstance(result, Failure):
-        # Convert to RFC 7807 error response
+        # Convert to RFC 9457 error response
         raise HTTPException(
             status_code=401,
             detail={"error": result.error}

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,12 +1,12 @@
 # Error Handling Guide
 
-**Purpose**: Comprehensive guide to RFC 7807 Problem Details error handling in Dashtam API.
+**Purpose**: Comprehensive guide to RFC 9457 Problem Details error handling in Dashtam API.
 
 **Audience**: Backend developers, API consumers, frontend developers.
 
 ## Overview
 
-Dashtam uses **RFC 7807 Problem Details** as the standard error format across all API endpoints. This provides consistent, machine-readable error responses with structured metadata for debugging and user-facing error messages.
+Dashtam uses **RFC 9457 Problem Details** as the standard error format across all API endpoints. This provides consistent, machine-readable error responses with structured metadata for debugging and user-facing error messages.
 
 **Key Benefits**:
 
@@ -14,11 +14,11 @@ Dashtam uses **RFC 7807 Problem Details** as the standard error format across al
 - **Machine-readable**: Clients can parse errors programmatically
 - **Debuggable**: Includes trace IDs for correlation with logs
 - **User-friendly**: Structured field-level errors for form validation
-- **Standards-compliant**: Follows IETF RFC 7807 specification
+- **Standards-compliant**: Follows IETF RFC 9457 specification
 
-## RFC 7807 Problem Details Standard
+## RFC 9457 Problem Details Standard
 
-RFC 7807 defines a standard JSON format for HTTP API errors. Every error response is a JSON object with these fields:
+RFC 9457 defines a standard JSON format for HTTP API errors. Every error response is a JSON object with these fields:
 
 ```json
 {
@@ -145,7 +145,7 @@ class FieldError(BaseModel):
     code: str | None = None
 
 class ProblemDetails(BaseModel):
-    """RFC 7807 Problem Details error response."""
+    """RFC 9457 Problem Details error response."""
     type: str
     title: str
     status: int
@@ -173,7 +173,7 @@ class ProblemDetails(BaseModel):
 
 ## ErrorResponseBuilder Usage
 
-`ErrorResponseBuilder` is the primary interface for creating RFC 7807 error responses.
+`ErrorResponseBuilder` is the primary interface for creating RFC 9457 error responses.
 
 ### Basic Usage
 
@@ -239,7 +239,7 @@ return response
 
 ## ApplicationErrorCode Reference
 
-`ApplicationErrorCode` enum maps error types to HTTP status codes and RFC 7807 metadata.
+`ApplicationErrorCode` enum maps error types to HTTP status codes and RFC 9457 metadata.
 
 Defined in `src/core/errors/application_error.py`:
 
@@ -696,7 +696,7 @@ fields @timestamp, @message
 
 ## Migration from AuthErrorResponse
 
-**Breaking Change in v1.6.3**: `AuthErrorResponse` removed, replaced with RFC 7807 `ProblemDetails`.
+**Breaking Change in v1.6.3**: `AuthErrorResponse` removed, replaced with RFC 9457 `ProblemDetails`.
 
 ### Old Format (Deprecated)
 
@@ -707,7 +707,7 @@ fields @timestamp, @message
 }
 ```
 
-### New Format (RFC 7807)
+### New Format (RFC 9457)
 
 ```json
 {
@@ -736,7 +736,7 @@ Dashtam uses **Result types** for explicit error handling across all layers. Dom
 
 - **Domain**: Returns `Result[T, DomainError]` (NO exceptions)
 - **Application**: Wraps domain errors in `ApplicationError`
-- **Presentation**: Converts to RFC 7807 `ProblemDetails` JSON
+- **Presentation**: Converts to RFC 9457 `ProblemDetails` JSON
 
 ### Domain Layer Patterns
 
@@ -969,7 +969,7 @@ async def test_command_handler_error_mapping():
 
 ```python
 def test_api_returns_rfc7807(client):
-    """Test API endpoint returns RFC 7807 response."""
+    """Test API endpoint returns RFC 9457 response."""
     response = client.post("/api/v1/users", json={"email": "invalid"})
     
     assert response.status_code == 400
@@ -986,8 +986,8 @@ def test_api_returns_rfc7807(client):
 
 1. **Always use Result types in domain layer** - No exceptions for business logic
 2. **Map domain errors to application errors** - Add application context
-3. **Use ErrorResponseBuilder for all API errors** - Consistent RFC 7807 format
-4. **Choose appropriate ApplicationErrorCode** - Maps to correct HTTP status + RFC 7807 metadata
+3. **Use ErrorResponseBuilder for all API errors** - Consistent RFC 9457 format
+4. **Choose appropriate ApplicationErrorCode** - Maps to correct HTTP status + RFC 9457 metadata
 5. **Include contextual detail** - Help users understand what went wrong
 6. **Add field errors for validation** - Use `errors` array for multi-field validation
 7. **Never expose internal errors** - Map exceptions to generic INTERNAL_ERROR with trace_id
@@ -1004,7 +1004,7 @@ def test_api_returns_rfc7807(client):
 
 ## References
 
-- **RFC 7807 Specification**: <https://tools.ietf.org/html/rfc7807>
+- **RFC 9457 Specification**: <https://tools.ietf.org/html/rfc7807>
 - **Source Code**: `src/schemas/error_schemas.py`, `src/presentation/api/error_response_builder.py`
 - **Route Metadata Registry**: `src/presentation/routers/api/v1/routes/registry.py` (error specs per endpoint)
 - **Application Errors**: `src/core/errors/application_error.py`

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ New to Dashtam? Start here:
 
 1. [Hexagonal Architecture](architecture/hexagonal.md) — Core pattern
 2. [Protocols](architecture/protocols.md) — Why Protocol over ABC
-3. [Error Handling](guides/error-handling.md) — RFC 7807, Result types
+3. [Error Handling](guides/error-handling.md) — RFC 9457, Result types
 4. [Registry Pattern](architecture/registry.md) — Auto-wiring, self-enforcing tests
 5. [Release Management](guides/releases.md) — Git flow, versioning
 

--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,7 @@ app = FastAPI(
 app.add_middleware(TraceMiddleware)
 app.add_middleware(RateLimitMiddleware)
 
-# Register global exception handlers (RFC 7807 error responses)
+# Register global exception handlers (RFC 9457 error responses)
 register_exception_handlers(app)
 
 # Include API v1 routers (RESTful resource-based endpoints)

--- a/src/presentation/routers/api/middleware/rate_limit_middleware.py
+++ b/src/presentation/routers/api/middleware/rate_limit_middleware.py
@@ -331,7 +331,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     ) -> JSONResponse:
         """Build HTTP 429 rate limit response.
 
-        Returns RFC 7807 compliant problem details response.
+        Returns RFC 9457 compliant problem details response.
 
         Args:
             request: Original request.
@@ -346,7 +346,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         # Round retry_after for cleaner display
         retry_after_int = max(1, int(retry_after + 0.5))
 
-        # RFC 7807 Problem Details
+        # RFC 9457 Problem Details
         content = {
             "type": f"{settings.api_base_url}/errors/rate-limit-exceeded",
             "title": "Rate Limit Exceeded",

--- a/src/presentation/routers/api/v1/accounts.py
+++ b/src/presentation/routers/api/v1/accounts.py
@@ -53,7 +53,7 @@ from src.schemas.account_schemas import (
 # Error Mapping (String → ApplicationError)
 # =============================================================================
 # Note: Handlers currently return Result[T, str]. This mapping converts
-# string errors to ApplicationError for RFC 7807 compliance.
+# string errors to ApplicationError for RFC 9457 compliance.
 # TODO (Phase 6): Refactor handlers to return Result[T, ApplicationError]
 # =============================================================================
 
@@ -62,7 +62,7 @@ def _map_account_error(error: str) -> ApplicationError:
     """Map handler string error to ApplicationError.
 
     Converts handler error strings to typed ApplicationError for
-    RFC 7807 compliant error responses.
+    RFC 9457 compliant error responses.
 
     Args:
         error: Error string from handler.
@@ -133,7 +133,7 @@ async def list_accounts(
 
     Returns:
         AccountListResponse with list of accounts.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     # Convert string to AccountType enum if provided
     account_type_enum: AccountType | None = None
@@ -180,7 +180,7 @@ async def get_account(
 
     Returns:
         AccountResponse with account details.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = GetAccount(
         account_id=account_id,
@@ -220,7 +220,7 @@ async def sync_accounts(
 
     Returns:
         SyncAccountsResponse with sync statistics.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     command = SyncAccounts(
         user_id=current_user.user_id,
@@ -283,7 +283,7 @@ async def list_accounts_by_connection(
 
     Returns:
         AccountListResponse with list of accounts.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = ListAccountsByConnection(
         connection_id=connection_id,

--- a/src/presentation/routers/api/v1/admin/token_rotation.py
+++ b/src/presentation/routers/api/v1/admin/token_rotation.py
@@ -238,7 +238,7 @@ def _error_response(
         message: Error message.
 
     Returns:
-        JSONResponse with RFC 7807 error format.
+        JSONResponse with RFC 9457 error format.
     """
     app_error = ApplicationError(
         code=error_code,

--- a/src/presentation/routers/api/v1/errors/__init__.py
+++ b/src/presentation/routers/api/v1/errors/__init__.py
@@ -1,12 +1,12 @@
-"""RFC 7807 error response schemas and exception handlers.
+"""RFC 9457 error response schemas and exception handlers.
 
-This package contains RFC 7807 (Problem Details for HTTP APIs) Pydantic models,
+This package contains RFC 9457 (Problem Details for HTTP APIs) Pydantic models,
 error response builders, and global exception handlers for the presentation layer.
 
 Exports:
     ErrorDetail: Individual field-specific error
-    ProblemDetails: RFC 7807 compliant error response schema
-    ErrorResponseBuilder: Utility for building RFC 7807 responses
+    ProblemDetails: RFC 9457 compliant error response schema
+    ErrorResponseBuilder: Utility for building RFC 9457 responses
     register_exception_handlers: Register global exception handlers with FastAPI
 """
 

--- a/src/presentation/routers/api/v1/errors/error_response_builder.py
+++ b/src/presentation/routers/api/v1/errors/error_response_builder.py
@@ -1,10 +1,10 @@
-"""Error response builder for RFC 7807 Problem Details.
+"""Error response builder for RFC 9457 Problem Details.
 
-This module provides utilities to build RFC 7807 compliant error responses
+This module provides utilities to build RFC 9457 compliant error responses
 from application layer errors.
 
 Exports:
-    ErrorResponseBuilder: Utility class for building RFC 7807 responses
+    ErrorResponseBuilder: Utility class for building RFC 9457 responses
 """
 
 from fastapi import Request, status
@@ -19,9 +19,9 @@ from src.presentation.routers.api.v1.errors.problem_details import (
 
 
 class ErrorResponseBuilder:
-    """Build RFC 7807 Problem Details error responses.
+    """Build RFC 9457 Problem Details error responses.
 
-    Converts application layer errors into standardized RFC 7807 JSON responses
+    Converts application layer errors into standardized RFC 9457 JSON responses
     with appropriate HTTP status codes and structured error information.
 
     Example:
@@ -42,7 +42,7 @@ class ErrorResponseBuilder:
         request: Request,
         trace_id: str,
     ) -> JSONResponse:
-        """Convert ApplicationError to RFC 7807 JSON response.
+        """Convert ApplicationError to RFC 9457 JSON response.
 
         Args:
             error: Application layer error to convert
@@ -50,7 +50,7 @@ class ErrorResponseBuilder:
             trace_id: Request trace ID for debugging
 
         Returns:
-            JSONResponse with RFC 7807 ProblemDetails content
+            JSONResponse with RFC 9457 ProblemDetails content
 
         Example:
             >>> error = ApplicationError(
@@ -65,7 +65,7 @@ class ErrorResponseBuilder:
         # Map application error code to HTTP status
         status_code = ErrorResponseBuilder._get_status_code(error.code)
 
-        # Build RFC 7807 Problem Details
+        # Build RFC 9457 Problem Details
         problem = ProblemDetails(
             type=f"{settings.api_base_url}/errors/{error.code.value}",
             title=ErrorResponseBuilder._get_title(error.code),

--- a/src/presentation/routers/api/v1/errors/problem_details.py
+++ b/src/presentation/routers/api/v1/errors/problem_details.py
@@ -1,13 +1,13 @@
-"""RFC 7807 Problem Details for HTTP APIs.
+"""RFC 9457 Problem Details for HTTP APIs.
 
-This module implements RFC 7807 (Problem Details for HTTP APIs) using Pydantic
+This module implements RFC 9457 (Problem Details for HTTP APIs) using Pydantic
 models for structured error responses.
 
-RFC 7807: https://tools.ietf.org/html/rfc7807
+RFC 9457: https://www.rfc-editor.org/rfc/rfc9457.html
 
 Exports:
     ErrorDetail: Individual field-specific error
-    ProblemDetails: RFC 7807 compliant error response schema
+    ProblemDetails: RFC 9457 compliant error response schema
 """
 
 from pydantic import BaseModel, Field
@@ -37,10 +37,10 @@ class ErrorDetail(BaseModel):
 
 
 class ProblemDetails(BaseModel):
-    """RFC 7807 Problem Details for HTTP APIs.
+    """RFC 9457 Problem Details for HTTP APIs.
 
     Standard error response format providing structured information about errors
-    in HTTP APIs. All fields follow RFC 7807 specification.
+    in HTTP APIs. All fields follow RFC 9457 specification.
 
     Attributes:
         type: URI reference identifying the problem type

--- a/src/presentation/routers/api/v1/holdings.py
+++ b/src/presentation/routers/api/v1/holdings.py
@@ -53,7 +53,7 @@ def _map_holding_error(error: str) -> ApplicationError:
     """Map handler string error to ApplicationError.
 
     Converts handler error strings to typed ApplicationError for
-    RFC 7807 compliant error responses.
+    RFC 9457 compliant error responses.
 
     Args:
         error: Error string from handler.
@@ -139,7 +139,7 @@ async def list_holdings(
 
     Returns:
         HoldingListResponse with list of holdings.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = ListHoldingsByUser(
         user_id=current_user.user_id,
@@ -195,7 +195,7 @@ async def list_holdings_by_account(
 
     Returns:
         HoldingListResponse with list of holdings.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = ListHoldingsByAccount(
         account_id=account_id,
@@ -239,7 +239,7 @@ async def sync_holdings(
 
     Returns:
         SyncHoldingsResponse with sync statistics.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     command = SyncHoldings(
         account_id=account_id,

--- a/src/presentation/routers/api/v1/imports.py
+++ b/src/presentation/routers/api/v1/imports.py
@@ -127,7 +127,7 @@ async def import_from_file(
 
     Returns:
         ImportResponse with import counts.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     # Get filename and extension
     filename = file.filename or "unknown"

--- a/src/presentation/routers/api/v1/providers.py
+++ b/src/presentation/routers/api/v1/providers.py
@@ -92,7 +92,7 @@ PROVIDER_REGISTRY: dict[str, UUID] = {
 # Error Mapping (String → ApplicationError)
 # =============================================================================
 # Note: Handlers currently return Result[T, str]. This mapping converts
-# string errors to ApplicationError for RFC 7807 compliance.
+# string errors to ApplicationError for RFC 9457 compliance.
 # TODO (Phase 6): Refactor handlers to return Result[T, ApplicationError]
 # =============================================================================
 
@@ -101,7 +101,7 @@ def _map_provider_error(error: str) -> ApplicationError:
     """Map handler string error to ApplicationError.
 
     Converts handler error strings to typed ApplicationError for
-    RFC 7807 compliant error responses.
+    RFC 9457 compliant error responses.
 
     Args:
         error: Error string from handler.
@@ -195,7 +195,7 @@ async def list_providers(
 
     Returns:
         ProviderConnectionListResponse with list of connections.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = ListProviderConnections(
         user_id=current_user.user_id,
@@ -234,7 +234,7 @@ async def get_provider_connection(
 
     Returns:
         ProviderConnectionResponse with connection details.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = GetProviderConnection(
         connection_id=connection_id,
@@ -274,7 +274,7 @@ async def initiate_connection(
 
     Returns:
         AuthorizationUrlResponse with authorization URL and state.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     # Validate provider is supported
     if data.provider_slug not in PROVIDER_REGISTRY:
@@ -333,7 +333,7 @@ async def oauth_callback(
 
     Returns:
         ProviderConnectionResponse with new connection details.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     trace_id = get_trace_id() or ""
 
@@ -538,7 +538,7 @@ async def update_provider(
 
     Returns:
         ProviderConnectionResponse with updated connection.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
 
     Note:
         Full update implementation requires repository update method.
@@ -589,7 +589,7 @@ async def disconnect_provider(
 
     Returns:
         Response (204 No Content) on success.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     command = DisconnectProvider(
         user_id=current_user.user_id,
@@ -639,7 +639,7 @@ async def refresh_provider_tokens(
 
     Returns:
         TokenRefreshResponse with refresh result.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     trace_id = get_trace_id() or ""
 

--- a/src/presentation/routers/api/v1/sessions.py
+++ b/src/presentation/routers/api/v1/sessions.py
@@ -159,7 +159,7 @@ def _create_auth_error_response(request: Request, error: str) -> JSONResponse:
         error: Error code from handler.
 
     Returns:
-        JSONResponse with RFC 7807 ProblemDetails error.
+        JSONResponse with RFC 9457 ProblemDetails error.
     """
     # Map string error codes to ApplicationError
     error_mapping = {

--- a/src/presentation/routers/api/v1/transactions.py
+++ b/src/presentation/routers/api/v1/transactions.py
@@ -54,7 +54,7 @@ from src.schemas.transaction_schemas import (
 # Error Mapping (String → ApplicationError)
 # =============================================================================
 # Note: Handlers currently return Result[T, str]. This mapping converts
-# string errors to ApplicationError for RFC 7807 compliance.
+# string errors to ApplicationError for RFC 9457 compliance.
 # TODO (Phase 6): Refactor handlers to return Result[T, ApplicationError]
 # =============================================================================
 
@@ -63,7 +63,7 @@ def _map_transaction_error(error: str) -> ApplicationError:
     """Map handler string error to ApplicationError.
 
     Converts handler error strings to typed ApplicationError for
-    RFC 7807 compliant error responses.
+    RFC 9457 compliant error responses.
 
     Args:
         error: Error string from handler.
@@ -124,7 +124,7 @@ async def get_transaction(
 
     Returns:
         TransactionResponse with transaction details.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     query = GetTransaction(
         transaction_id=transaction_id,
@@ -166,7 +166,7 @@ async def sync_transactions(
 
     Returns:
         SyncTransactionsResponse with sync statistics.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     command = SyncTransactions(
         user_id=current_user.user_id,
@@ -260,7 +260,7 @@ async def list_transactions_by_account(
 
     Returns:
         TransactionListResponse with list of transactions.
-        JSONResponse with RFC 7807 error on failure.
+        JSONResponse with RFC 9457 error on failure.
     """
     # Use date range handler if dates provided, otherwise use account handler
     if start_date and end_date:

--- a/tests/api/test_accounts_endpoints.py
+++ b/tests/api/test_accounts_endpoints.py
@@ -8,7 +8,7 @@ Tests the complete HTTP request/response cycle for account management:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 
@@ -281,7 +281,7 @@ class TestListAccounts:
         app.dependency_overrides.pop(factory_key, None)
 
     def test_list_accounts_handler_error_returns_rfc7807(self, client):
-        """GET /api/v1/accounts returns RFC 7807 error on handler failure."""
+        """GET /api/v1/accounts returns RFC 9457 error on handler failure."""
         factory_key = handler_factory(ListAccountsByUserHandler)
         app.dependency_overrides[factory_key] = lambda: MockListAccountsHandler(
             error="Database unavailable"

--- a/tests/api/test_admin_rotation_api.py
+++ b/tests/api/test_admin_rotation_api.py
@@ -9,7 +9,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers, database, and authentication dependencies
 - Tests validation, status codes, and error responses
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 - Verifies 401/403 for unauthenticated/unauthorized access
 """
 

--- a/tests/api/test_authorization_api.py
+++ b/tests/api/test_authorization_api.py
@@ -403,7 +403,7 @@ class TestRequireAllPermissions:
 
 @pytest.mark.api
 class TestErrorResponseFormat:
-    """Test that error responses follow RFC 7807 format."""
+    """Test that error responses follow RFC 9457 format."""
 
     def test_403_response_has_correct_structure(self, mock_authorization):
         """Test that 403 response has proper error structure."""

--- a/tests/api/test_balance_snapshots_endpoints.py
+++ b/tests/api/test_balance_snapshots_endpoints.py
@@ -7,7 +7,7 @@ Tests the complete HTTP request/response cycle for balance tracking:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 

--- a/tests/api/test_email_verifications_api.py
+++ b/tests/api/test_email_verifications_api.py
@@ -7,7 +7,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers to test request/response flow
 - Tests validation, error responses, and success paths
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 
 Note:
     These tests focus on request validation and error response formats.
@@ -122,7 +122,7 @@ class TestCreateEmailVerification:
             json={"token": "b" * 64},  # Valid length but invalid token
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 404
         data = response.json()
         assert data["type"].endswith("/errors/not_found")
@@ -143,7 +143,7 @@ class TestCreateEmailVerification:
             json={"token": "c" * 64},  # Valid length but expired
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -164,7 +164,7 @@ class TestCreateEmailVerification:
             json={"token": "d" * 64},  # Valid length but already used
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -185,7 +185,7 @@ class TestCreateEmailVerification:
             json={"token": "e" * 64},  # Valid length but orphaned
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 404
         data = response.json()
         assert data["type"].endswith("/errors/not_found")
@@ -197,7 +197,7 @@ class TestCreateEmailVerification:
         # Execute: Missing token field
         response = client.post("/api/v1/email-verifications", json={})
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -212,7 +212,7 @@ class TestCreateEmailVerification:
             json={"token": "short"},  # Less than 64 chars
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -227,7 +227,7 @@ class TestCreateEmailVerification:
             json={"token": "a" * 65},  # More than 64 chars
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -242,7 +242,7 @@ class TestCreateEmailVerification:
             json={"token": ""},
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")

--- a/tests/api/test_holdings_endpoints.py
+++ b/tests/api/test_holdings_endpoints.py
@@ -7,7 +7,7 @@ Tests the complete HTTP request/response cycle for holdings management:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 

--- a/tests/api/test_imports_api.py
+++ b/tests/api/test_imports_api.py
@@ -6,7 +6,7 @@ Tests the complete HTTP request/response cycle for file imports:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 
@@ -507,7 +507,7 @@ class TestImportResponseSchema:
             app.dependency_overrides.pop(factory_key, None)
 
     def test_error_response_is_rfc7807_compliant(self, client):
-        """Test error responses follow RFC 7807 Problem Details format."""
+        """Test error responses follow RFC 9457 Problem Details format."""
         # Act - trigger 415 error
         response = client.post(
             "/api/v1/imports",
@@ -518,7 +518,7 @@ class TestImportResponseSchema:
         assert response.status_code == 415
         data = response.json()
 
-        # RFC 7807 required fields
+        # RFC 9457 required fields
         assert "type" in data
         assert "title" in data
         assert "status" in data

--- a/tests/api/test_password_resets_api.py
+++ b/tests/api/test_password_resets_api.py
@@ -8,7 +8,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers to test request/response flow
 - Tests validation, error responses, and success paths
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 
 Note:
     These tests focus on request validation and error response formats.
@@ -145,7 +145,7 @@ class TestCreatePasswordResetToken:
             json={"email": "not-an-email"},
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -157,7 +157,7 @@ class TestCreatePasswordResetToken:
         # Execute: Missing email field
         response = client.post("/api/v1/password-reset-tokens", json={})
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -214,7 +214,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 404
         data = response.json()
         assert data["type"].endswith("/errors/not_found")
@@ -238,7 +238,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -262,7 +262,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -286,7 +286,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 404
         data = response.json()
         assert data["type"].endswith("/errors/not_found")
@@ -301,7 +301,7 @@ class TestCreatePasswordReset:
             json={"new_password": "NewSecurePass123!"},
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -316,7 +316,7 @@ class TestCreatePasswordReset:
             json={"token": "a" * 64},
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -334,7 +334,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -352,7 +352,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -370,7 +370,7 @@ class TestCreatePasswordReset:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")

--- a/tests/api/test_providers_callback_refresh.py
+++ b/tests/api/test_providers_callback_refresh.py
@@ -6,7 +6,7 @@ Tests coverage for missing lines in providers.py:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, error paths, and RFC 7807 compliance
+- Tests validation, error paths, and RFC 9457 compliance
 - Mocks handlers and services to test HTTP layer behavior
 """
 

--- a/tests/api/test_providers_endpoints.py
+++ b/tests/api/test_providers_endpoints.py
@@ -9,7 +9,7 @@ Tests the complete HTTP request/response cycle for provider management:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 
@@ -250,7 +250,7 @@ class TestListProviders:
         app.dependency_overrides.pop(factory_key, None)
 
     def test_list_providers_handler_error_returns_rfc7807(self, client):
-        """GET /api/v1/providers returns RFC 7807 error on handler failure."""
+        """GET /api/v1/providers returns RFC 9457 error on handler failure."""
         factory_key = handler_factory(ListProviderConnectionsHandler)
         app.dependency_overrides[factory_key] = (
             lambda: MockListProviderConnectionsHandler(error="Database unavailable")

--- a/tests/api/test_rate_limit_headers.py
+++ b/tests/api/test_rate_limit_headers.py
@@ -131,7 +131,7 @@ class TestRateLimitExceededHeaders:
         reason="Event loop issues with many consecutive requests - covered in integration tests"
     )
     def test_429_response_body_format(self, test_client: TestClient) -> None:
-        """429 response body should follow RFC 7807."""
+        """429 response body should follow RFC 9457."""
         pass
 
 

--- a/tests/api/test_rate_limit_middleware.py
+++ b/tests/api/test_rate_limit_middleware.py
@@ -77,7 +77,7 @@ class TestRateLimitMiddleware429Response:
         reason="Event loop issues with many consecutive requests - covered in integration tests"
     )
     def test_429_response_body_format(self, test_client, exhaust_rate_limit) -> None:
-        """429 response body should follow RFC 7807."""
+        """429 response body should follow RFC 9457."""
         pass
 
 

--- a/tests/api/test_sessions_api.py
+++ b/tests/api/test_sessions_api.py
@@ -12,7 +12,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers to test request/response flow
 - Tests validation, authorization, and error responses
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 
 Note:
     These tests focus on request validation, authorization checks,
@@ -693,13 +693,13 @@ class TestSessionResponseFormats:
         assert "is_revoked" in data
 
     def test_error_response_is_rfc7807_compliant(self, client):
-        """Test error responses follow RFC 7807 format."""
+        """Test error responses follow RFC 9457 format."""
         response = client.get("/api/v1/sessions")  # No auth token
 
         assert response.status_code == 401
         data = response.json()
 
-        # RFC 7807 required fields
+        # RFC 9457 required fields
         assert "type" in data
         assert "title" in data
         assert "status" in data

--- a/tests/api/test_tokens_api.py
+++ b/tests/api/test_tokens_api.py
@@ -7,7 +7,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers to test request/response flow
 - Tests validation, error responses, and success paths
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 
 Note:
     These tests focus on request validation and error response formats.
@@ -145,7 +145,7 @@ class TestCreateTokens:
             json={"refresh_token": "invalid_token"},
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -167,7 +167,7 @@ class TestCreateTokens:
             json={"refresh_token": "expired_token"},
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 401
         data = response.json()
         assert data["type"].endswith("/errors/unauthorized")
@@ -189,7 +189,7 @@ class TestCreateTokens:
             json={"refresh_token": "revoked_token"},
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 401
         data = response.json()
         assert data["type"].endswith("/errors/unauthorized")
@@ -211,7 +211,7 @@ class TestCreateTokens:
             json={"refresh_token": "orphaned_token"},
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 401
         data = response.json()
         assert data["type"].endswith("/errors/unauthorized")
@@ -231,7 +231,7 @@ class TestCreateTokens:
             json={"refresh_token": "inactive_user_token"},
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 401
         data = response.json()
         assert data["type"].endswith("/errors/unauthorized")
@@ -243,7 +243,7 @@ class TestCreateTokens:
         # Execute: Missing refresh_token field
         response = client.post("/api/v1/tokens", json={})
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -260,7 +260,7 @@ class TestCreateTokens:
             json={"refresh_token": ""},
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")

--- a/tests/api/test_transactions_endpoints.py
+++ b/tests/api/test_transactions_endpoints.py
@@ -7,7 +7,7 @@ Tests the complete HTTP request/response cycle for transaction management:
 
 Architecture:
 - Uses FastAPI TestClient with real app + dependency overrides
-- Tests validation, authorization, and RFC 7807 error responses
+- Tests validation, authorization, and RFC 9457 error responses
 - Mocks handlers to test HTTP layer behavior
 """
 

--- a/tests/api/test_users_api.py
+++ b/tests/api/test_users_api.py
@@ -7,7 +7,7 @@ Architecture:
 - Uses real app with dependency overrides
 - Mocks handlers to test request/response flow
 - Tests validation, error responses, and success paths
-- Verifies RFC 7807 compliance for errors
+- Verifies RFC 9457 compliance for errors
 
 Note:
     These tests focus on request validation and error response formats.
@@ -129,7 +129,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 409
         data = response.json()
         assert data["type"].endswith("/errors/conflict")
@@ -154,7 +154,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 error response
+        # Verify: RFC 9457 error response
         assert response.status_code == 400
         data = response.json()
         assert data["type"].endswith("/errors/command_validation_failed")
@@ -177,14 +177,14 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
         assert data["title"] == "Validation Failed"
         assert data["status"] == 422
         assert "errors" in data
-        # RFC 7807 returns errors array with field-level details
+        # RFC 9457 returns errors array with field-level details
         assert isinstance(data["errors"], list)
         assert any("email" in err.get("field", "").lower() for err in data["errors"])
 
@@ -198,7 +198,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -215,7 +215,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -233,7 +233,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -251,7 +251,7 @@ class TestCreateUser:
             },
         )
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")
@@ -263,7 +263,7 @@ class TestCreateUser:
         # Execute: Empty JSON body
         response = client.post("/api/v1/users", json={})
 
-        # Verify: RFC 7807 validation error response
+        # Verify: RFC 9457 validation error response
         assert response.status_code == 422
         data = response.json()
         assert data["type"].endswith("/errors/validation-failed")

--- a/tests/integration/test_error_handling_flow.py
+++ b/tests/integration/test_error_handling_flow.py
@@ -44,7 +44,7 @@ def test_app():
     # Test endpoint that returns application error
     @app.get("/test/application-error")
     async def test_application_error(request: Request):
-        """Test endpoint that returns ApplicationError as RFC 7807."""
+        """Test endpoint that returns ApplicationError as RFC 9457."""
         error = ApplicationError(
             code=ApplicationErrorCode.NOT_FOUND,
             message="Test resource not found",
@@ -100,7 +100,7 @@ class TestErrorHandlingFlow:
     """Integration tests for complete error handling flow."""
 
     def test_unhandled_exception_converts_to_rfc7807(self, client):
-        """Test unhandled exception converts to RFC 7807 Problem Details."""
+        """Test unhandled exception converts to RFC 9457 Problem Details."""
         # Act
         response = client.get("/test/exception")
 
@@ -108,7 +108,7 @@ class TestErrorHandlingFlow:
         assert response.status_code == 500
         data = response.json()
 
-        # Verify RFC 7807 structure (required fields)
+        # Verify RFC 9457 structure (required fields)
         assert "type" in data
         assert "title" in data
         assert "status" in data
@@ -122,7 +122,7 @@ class TestErrorHandlingFlow:
         assert data["instance"] == "/test/exception"
 
     def test_application_error_returns_rfc7807(self, client):
-        """Test ApplicationError converts to RFC 7807 response."""
+        """Test ApplicationError converts to RFC 9457 response."""
         # Act
         response = client.get("/test/application-error")
 
@@ -130,7 +130,7 @@ class TestErrorHandlingFlow:
         assert response.status_code == 404
         data = response.json()
 
-        # Verify RFC 7807 structure
+        # Verify RFC 9457 structure
         assert data["type"].endswith("/errors/not_found")
         assert data["title"] == "Resource Not Found"
         assert data["status"] == 404
@@ -147,7 +147,7 @@ class TestErrorHandlingFlow:
         assert response.status_code == 400
         data = response.json()
 
-        # Verify RFC 7807 structure
+        # Verify RFC 9457 structure
         assert data["status"] == 400
         assert data["title"] == "Validation Failed"
 
@@ -170,7 +170,7 @@ class TestErrorHandlingFlow:
         # Assert
         data = response.json()
         # In TestClient, trace_id might not be set by middleware
-        # We verify RFC 7807 structure is valid either way
+        # We verify RFC 9457 structure is valid either way
         if "trace_id" in data:
             # If present, should be non-empty
             assert data["trace_id"]
@@ -185,7 +185,7 @@ class TestErrorHandlingFlow:
         assert response.headers["content-type"] == "application/json"
 
     def test_error_response_excludes_none_fields(self, client):
-        """Test RFC 7807 response excludes fields with None values."""
+        """Test RFC 9457 response excludes fields with None values."""
         # Act
         response = client.get("/test/application-error")
 
@@ -195,10 +195,10 @@ class TestErrorHandlingFlow:
         assert "errors" not in data
 
     def test_multiple_requests_return_valid_rfc7807(self, client):
-        """Test multiple requests each return valid RFC 7807 responses.
+        """Test multiple requests each return valid RFC 9457 responses.
 
         Note: TestClient limitations prevent testing trace_id uniqueness,
-        but we verify each response has proper RFC 7807 structure.
+        but we verify each response has proper RFC 9457 structure.
         """
         # Act
         response1 = client.get("/test/exception")
@@ -208,7 +208,7 @@ class TestErrorHandlingFlow:
         data1 = response1.json()
         data2 = response2.json()
 
-        # Both should be valid RFC 7807 responses
+        # Both should be valid RFC 9457 responses
         for data in [data1, data2]:
             assert data["status"] == 500
             assert data["title"] == "Internal Server Error"
@@ -226,7 +226,7 @@ class TestErrorHandlingFlow:
         assert isinstance(data, dict)
 
     def test_rfc7807_type_url_is_well_formed(self, client):
-        """Test RFC 7807 type field contains valid URL."""
+        """Test RFC 9457 type field contains valid URL."""
         # Act
         response = client.get("/test/application-error")
 
@@ -239,7 +239,7 @@ class TestErrorHandlingFlow:
         assert "/errors/" in type_url
 
     def test_rfc7807_instance_matches_request_path(self, client):
-        """Test RFC 7807 instance field matches actual request path."""
+        """Test RFC 9457 instance field matches actual request path."""
         # Act
         response = client.get("/test/application-error")
 

--- a/tests/unit/test_presentation_error_response_builder.py
+++ b/tests/unit/test_presentation_error_response_builder.py
@@ -19,7 +19,7 @@ class TestErrorResponseBuilder:
     """Unit tests for ErrorResponseBuilder utility class."""
 
     def test_from_application_error_not_found(self):
-        """Test building RFC 7807 response for NOT_FOUND error."""
+        """Test building RFC 9457 response for NOT_FOUND error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.NOT_FOUND,
@@ -46,7 +46,7 @@ class TestErrorResponseBuilder:
         assert trace_id in content
 
     def test_from_application_error_validation_failed(self):
-        """Test building RFC 7807 response for COMMAND_VALIDATION_FAILED error."""
+        """Test building RFC 9457 response for COMMAND_VALIDATION_FAILED error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.COMMAND_VALIDATION_FAILED,
@@ -102,7 +102,7 @@ class TestErrorResponseBuilder:
         assert "invalid_email" in content
 
     def test_from_application_error_unauthorized(self):
-        """Test building RFC 7807 response for UNAUTHORIZED error."""
+        """Test building RFC 9457 response for UNAUTHORIZED error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.UNAUTHORIZED,
@@ -126,7 +126,7 @@ class TestErrorResponseBuilder:
         assert "Authentication Required" in content
 
     def test_from_application_error_forbidden(self):
-        """Test building RFC 7807 response for FORBIDDEN error."""
+        """Test building RFC 9457 response for FORBIDDEN error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.FORBIDDEN,
@@ -150,7 +150,7 @@ class TestErrorResponseBuilder:
         assert "Access Denied" in content
 
     def test_from_application_error_conflict(self):
-        """Test building RFC 7807 response for CONFLICT error."""
+        """Test building RFC 9457 response for CONFLICT error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.CONFLICT,
@@ -174,7 +174,7 @@ class TestErrorResponseBuilder:
         assert "Resource Conflict" in content
 
     def test_from_application_error_rate_limit_exceeded(self):
-        """Test building RFC 7807 response for RATE_LIMIT_EXCEEDED error."""
+        """Test building RFC 9457 response for RATE_LIMIT_EXCEEDED error."""
         # Arrange
         error = ApplicationError(
             code=ApplicationErrorCode.RATE_LIMIT_EXCEEDED,

--- a/tests/unit/test_presentation_problem_details.py
+++ b/tests/unit/test_presentation_problem_details.py
@@ -1,4 +1,4 @@
-"""Unit tests for RFC 7807 Problem Details schemas.
+"""Unit tests for RFC 9457 Problem Details schemas.
 
 Tests ProblemDetails and ErrorDetail Pydantic models following
 established testing patterns from Phase 0.
@@ -185,7 +185,7 @@ class TestProblemDetails:
         assert "status" in serialized
 
     def test_problem_details_validation_error_example(self):
-        """Test complete validation error RFC 7807 response."""
+        """Test complete validation error RFC 9457 response."""
         # Arrange
         field_errors = [
             ErrorDetail(
@@ -215,7 +215,7 @@ class TestProblemDetails:
         assert serialized["trace_id"] == "550e8400-e29b-41d4-a716-446655440000"
 
     def test_problem_details_unauthorized_example(self):
-        """Test complete unauthorized error RFC 7807 response."""
+        """Test complete unauthorized error RFC 9457 response."""
         # Arrange & Act
         problem = ProblemDetails(
             type="https://api.dashtam.com/errors/unauthorized",
@@ -250,7 +250,7 @@ class TestProblemDetails:
         assert "instance" in missing_fields
 
     def test_problem_details_conflict_example(self):
-        """Test complete conflict error RFC 7807 response."""
+        """Test complete conflict error RFC 9457 response."""
         # Arrange & Act
         problem = ProblemDetails(
             type="https://api.dashtam.com/errors/conflict",


### PR DESCRIPTION
- Update 222 references across source, docs, and tests
- RFC 9457 (July 2023) obsoletes RFC 7807 with backward-compatible changes
- No code changes required - JSON schema and behavior identical
- Remove hardcoded test count from README.md
- Preserve historical RFC 7807 references in CHANGELOG