### PR TITLE
feat(sse): add SSE foundation infrastructure for real-time events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-01-18
+
+### Added
+
+- **SSE Foundation Infrastructure** - Real-time server-to-client event streaming
+  - **Domain Layer**
+    - `SSEEvent` dataclass with wire format serialization (`to_sse_format()`, `to_dict()`, `from_dict()`)
+    - `SSEEventType` enum (25 event types across 6 categories)
+    - `SSEEventCategory` enum (data_sync, provider, ai, import, portfolio, security)
+    - `SSEEventMetadata` and `SSE_EVENT_REGISTRY` (registry pattern, 25 entries)
+    - `SSEPublisherProtocol` and `SSESubscriberProtocol` (hexagonal ports)
+  - **Infrastructure Layer**
+    - `RedisSSEPublisher` - Publishes events via Redis pub/sub, optional Streams retention
+    - `RedisSSESubscriber` - Async generator subscription with category filtering
+    - `SSEChannelKeys` - Centralized channel/stream key generation
+    - `SSEEventHandler` - Subscribes to domain events, transforms to SSE events
+  - **Presentation Layer**
+    - `GET /api/v1/events` endpoint with StreamingResponse
+    - Route registry entry with `RateLimitPolicy.SSE_STREAM`
+    - Authentication via existing Bearer token
+  - **Container Wiring**
+    - `get_sse_publisher()` - App-scoped singleton
+    - `get_sse_subscriber()` - Request-scoped factory
+  - **Configuration**
+    - 6 constants in `src/core/constants.py` (heartbeat, retry, channel prefix, retention)
+    - `sse_enable_retention` setting in `config.py`
+
+- **SSE Registry Documentation** (`docs/architecture/sse-registry.md`)
+  - Follows existing registry pattern (like route-registry, validation-registry)
+  - Covers architecture, usage, compliance tests, and adding new events
+
+### Changed
+
+- **Rate Limit Policy**: Added `RateLimitPolicy.SSE_STREAM` for SSE endpoints
+- **Route Registry Test**: Updated `test_response_models_are_defined` to exempt SSE streaming endpoints
+
+### Technical Notes
+
+- **Zero Breaking Changes**: All 2,550 tests pass, 88% coverage maintained
+- **New Test Files**: 4 (`test_domain_sse_event.py`, `test_domain_sse_registry_compliance.py`, `test_events_endpoints.py`, `test_sse_redis_pubsub.py`)
+- **New Tests**: 106 unit tests, 25 integration tests, 12 API tests (143 total)
+- **Documentation**: `docs/architecture/sse-architecture.md` (1400+ lines), `docs/architecture/sse-registry.md` (300+ lines)
+- Files changed: 25+ files
+
 ## [1.8.2] - 2026-01-17
 
 ### Added

--- a/docs/architecture/sse-architecture.md
+++ b/docs/architecture/sse-architecture.md
@@ -1,0 +1,1425 @@
+# Server-Sent Events (SSE) Architecture
+
+**Status**: Planning
+**Priority**: High (required for dashtam-terminal real-time features)
+
+## 1. Overview
+
+This document defines the **foundational architecture** for Server-Sent Events (SSE) in Dashtam API. SSE enables real-time push notifications from server to connected clients (dashtam-terminal, future web dashboard).
+
+**Scope**: This document covers **core infrastructure only**. Individual use cases (sync progress, provider health, etc.) are tracked as separate GitHub issues and reference this foundation.
+
+### 1.1 Technology Decision: SSE vs WebSocket
+
+**Decision**: SSE for v1 (WebSocket deferred to v2 if bidirectional needs arise)
+
+| Aspect | SSE | WebSocket |
+|--------|-----|-----------|
+| Direction | Server → Client (unidirectional) | Bidirectional |
+| Protocol | HTTP/1.1 or HTTP/2 | WS/WSS (upgrade) |
+| Reconnection | Built-in (automatic) | Manual implementation |
+| Proxy/Firewall | Works through standard HTTP | May have issues |
+| Complexity | Lower | Higher |
+| Dashtam Fit | ✅ 90% of use cases | ❌ Overkill for v1 |
+
+SSE covers all identified use cases: sync progress, provider health, balance updates, AI streaming, notifications.
+
+### 1.2 REST Compliance
+
+SSE is **pure HTTP** — no protocol upgrade like WebSocket. It uses standard GET requests with streaming responses. Dashtam's 100% RESTful API requirement applies.
+
+**Endpoint Design**:
+
+- **Resource**: `events` (noun, not verb)
+- **Method**: `GET /api/v1/events` (retrieves event stream)
+- **Content Type**: `Accept: text/event-stream` signals streaming format
+- **Filtering**: Query params (`?categories=data_sync,provider`)
+
+**Why not `/events/stream`?** The `/stream` suffix is a verb, violating REST. The streaming behavior is determined by the `Accept` header, not the URL.
+
+### 1.3 Architectural Principles
+
+1. **Registry Pattern (SSOT)**: All SSE event types defined in `SSE_EVENT_REGISTRY`
+2. **Hexagonal Architecture**: Protocol in domain, adapters in infrastructure
+3. **Domain Event Integration**: Bridge existing domain events to SSE streams
+4. **Fail-Open Design**: SSE failures don't break core API functionality
+5. **Horizontal Scaling**: Redis Pub/Sub for multi-instance deployments
+6. **DRY Compliance**: Reuse existing patterns (constants, serialization, auth)
+7. **Existing Auth**: Uses standard Dashtam Bearer token authentication
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Clients (dashtam-terminal, web dashboard)                              │
+│  - httpx-sse (Python) / EventSource (JavaScript)                        │
+│  - Reconnects automatically with Last-Event-ID                          │
+└───────────────────────────────┬─────────────────────────────────────────┘
+                                │ SSE Connection (HTTP)
+                                │ GET /api/v1/events
+                                ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Presentation Layer                                                     │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  SSE Stream Endpoint (FastAPI StreamingResponse)                │    │
+│  │  - Authenticates via Bearer token                               │    │
+│  │  - Subscribes to user's Redis channel                           │    │
+│  │  - Streams events as text/event-stream                          │    │
+│  └───────────────────────────────┬─────────────────────────────────┘    │
+└──────────────────────────────────┼──────────────────────────────────────┘
+                                   │
+┌──────────────────────────────────┼──────────────────────────────────────┐
+│  Infrastructure Layer            │                                      │
+│  ┌───────────────────────────────┼─────────────────────────────────┐    │
+│  │  SSE Publisher (Adapter)      │                                 │    │
+│  │  - Implements SSEPublisherProtocol                              │    │
+│  │  - Publishes to Redis channels                                  │    │
+│  │  - Serializes SSE events to JSON                                │    │
+│  └───────────────────────────────┬─────────────────────────────────┘    │
+│                                  │                                      │
+│  ┌───────────────────────────────┼─────────────────────────────────┐    │
+│  │  SSE Event Handler            │                                 │    │
+│  │  - Subscribes to domain events (via EVENT_BUS)                  │    │
+│  │  - Maps domain events → SSE events (using SSE_EVENT_REGISTRY)   │    │
+│  │  - Calls publisher to broadcast                                 │    │
+│  └───────────────────────────────┬─────────────────────────────────┘    │
+│                                  │                                      │
+│  ┌───────────────────────────────▼─────────────────────────────────┐    │
+│  │  Redis Pub/Sub                                                  │    │
+│  │  - Channel per user: sse:user:{user_id}                         │    │
+│  │  - Enables horizontal scaling (multiple API instances)          │    │
+│  │  - Event retention: Redis Streams (optional, for Last-Event-ID) │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   ▲
+┌──────────────────────────────────┼──────────────────────────────────────┐
+│  Application Layer               │                                      │
+│  ┌───────────────────────────────┼─────────────────────────────────┐    │
+│  │  Command Handlers (existing)  │                                 │    │
+│  │  - SyncAccountsHandler        │                                 │    │
+│  │  - SyncTransactionsHandler    │                                 │    │
+│  │  - ImportFromFileHandler      │                                 │    │
+│  │  ... publish domain events as normal ...                        │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   ▲
+┌──────────────────────────────────┼──────────────────────────────────────┐
+│  Domain Layer                    │                                      │
+│  ┌───────────────────────────────┼─────────────────────────────────┐    │
+│  │  Domain Events (existing)     │                                 │    │
+│  │  - AccountSyncAttempted/Succeeded/Failed                        │    │
+│  │  - TransactionSyncAttempted/Succeeded/Failed                    │    │
+│  │  - ProviderTokenRefreshAttempted/Succeeded/Failed               │    │
+│  │  - FileImportAttempted/Succeeded/Failed                         │    │
+│  │  ... these trigger SSE broadcasts ...                           │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  SSE Protocol (NEW)                                             │    │
+│  │  - SSEPublisherProtocol                                         │    │
+│  │  - SSEEvent dataclass                                           │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## 3. SSE Event Registry (Single Source of Truth)
+
+Following the established registry pattern (EVENT_REGISTRY, COMMAND_REGISTRY, ROUTE_REGISTRY), SSE events are cataloged in `SSE_EVENT_REGISTRY`.
+
+### 3.1 Registry Location
+
+```text
+src/domain/events/
+├── registry.py              # Existing domain events registry
+└── sse_registry.py          # NEW: SSE event registry
+```
+
+### 3.2 Registry Structure
+
+```python
+# src/domain/events/sse_registry.py
+"""SSE Event Registry - Single Source of Truth.
+
+This registry catalogs ALL SSE event types with their metadata.
+Used for:
+- SSE event handler auto-wiring (maps domain events → SSE events)
+- Validation tests (verify no drift)
+- Documentation generation (always accurate)
+- Client SDK generation (event type definitions)
+
+Adding new SSE events:
+1. Add entry to SSE_EVENT_REGISTRY below
+2. Implement payload schema (if not reusing domain event data)
+3. Run tests - they'll tell you what's missing
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Type
+
+from src.domain.events.base_event import DomainEvent
+
+
+class SSECategory(Enum):
+    """SSE event categories for filtering and organization."""
+    
+    DATA_SYNC = "data_sync"            # Account/transaction/holdings sync
+    PROVIDER = "provider"              # Provider connection health
+    AI = "ai"                          # AI response streaming
+    IMPORT = "import"                  # File import progress
+    PORTFOLIO = "portfolio"            # Balance/holdings updates
+    SECURITY = "security"              # Session/security notifications
+
+
+@dataclass(frozen=True)
+class SSEEventMetadata:
+    """Metadata for an SSE event type.
+    
+    Attributes:
+        event_type: SSE event type string (e.g., "sync.progress").
+        category: Event category for filtering.
+        source_domain_events: Domain events that trigger this SSE event.
+        description: Human-readable description.
+        requires_auth: Whether SSE stream must be authenticated.
+        payload_fields: List of fields included in payload.
+    """
+    
+    event_type: str
+    category: SSECategory
+    source_domain_events: tuple[Type[DomainEvent], ...]
+    description: str
+    requires_auth: bool = True
+    payload_fields: tuple[str, ...] = ()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SSE_EVENT_REGISTRY - Single Source of Truth
+# ═══════════════════════════════════════════════════════════════════════════
+
+SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
+    # ═══════════════════════════════════════════════════════════════════════
+    # Data Sync Events (6 event types)
+    # Implementation: GitHub Issue #1 - SSE: Data Sync Progress
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="sync.accounts.started",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(AccountSyncAttempted,),
+        description="Account sync operation started",
+        payload_fields=("connection_id", "user_id"),
+    ),
+    SSEEventMetadata(
+        event_type="sync.accounts.completed",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(AccountSyncSucceeded,),
+        description="Account sync completed successfully",
+        payload_fields=("connection_id", "user_id", "account_count"),
+    ),
+    SSEEventMetadata(
+        event_type="sync.accounts.failed",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(AccountSyncFailed,),
+        description="Account sync failed",
+        payload_fields=("connection_id", "user_id", "reason"),
+    ),
+    SSEEventMetadata(
+        event_type="sync.transactions.started",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(TransactionSyncAttempted,),
+        description="Transaction sync operation started",
+        payload_fields=("connection_id", "user_id", "account_id"),
+    ),
+    SSEEventMetadata(
+        event_type="sync.transactions.completed",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(TransactionSyncSucceeded,),
+        description="Transaction sync completed successfully",
+        payload_fields=("connection_id", "user_id", "account_id", "transaction_count"),
+    ),
+    SSEEventMetadata(
+        event_type="sync.transactions.failed",
+        category=SSECategory.DATA_SYNC,
+        source_domain_events=(TransactionSyncFailed,),
+        description="Transaction sync failed",
+        payload_fields=("connection_id", "user_id", "account_id", "reason"),
+    ),
+    # ... Holdings sync events follow same pattern ...
+    
+    # ═══════════════════════════════════════════════════════════════════════
+    # Provider Events (4 event types)
+    # Implementation: GitHub Issue #2 - SSE: Provider Connection Health
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="provider.token.expiring",
+        category=SSECategory.PROVIDER,
+        source_domain_events=(),  # Generated by background job, not domain event
+        description="Provider token expiring soon (proactive warning)",
+        payload_fields=("connection_id", "provider_slug", "expires_in_seconds"),
+    ),
+    SSEEventMetadata(
+        event_type="provider.token.refreshed",
+        category=SSECategory.PROVIDER,
+        source_domain_events=(ProviderTokenRefreshSucceeded,),
+        description="Provider token refreshed successfully",
+        payload_fields=("connection_id", "provider_slug"),
+    ),
+    SSEEventMetadata(
+        event_type="provider.token.failed",
+        category=SSECategory.PROVIDER,
+        source_domain_events=(ProviderTokenRefreshFailed,),
+        description="Provider token refresh failed (may need re-auth)",
+        payload_fields=("connection_id", "provider_slug", "reason", "needs_reauth"),
+    ),
+    SSEEventMetadata(
+        event_type="provider.disconnected",
+        category=SSECategory.PROVIDER,
+        source_domain_events=(ProviderDisconnectionSucceeded,),
+        description="Provider connection disconnected",
+        payload_fields=("connection_id", "provider_slug"),
+    ),
+    
+    # ═══════════════════════════════════════════════════════════════════════
+    # AI Events (3 event types)
+    # Implementation: GitHub Issue #3 - SSE: AI Response Streaming
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="ai.response.chunk",
+        category=SSECategory.AI,
+        source_domain_events=(),  # Direct streaming, not domain event
+        description="AI response text chunk (streaming)",
+        payload_fields=("conversation_id", "chunk", "is_final"),
+    ),
+    SSEEventMetadata(
+        event_type="ai.tool.executing",
+        category=SSECategory.AI,
+        source_domain_events=(),  # Direct streaming
+        description="AI is executing a tool",
+        payload_fields=("conversation_id", "tool_name"),
+    ),
+    SSEEventMetadata(
+        event_type="ai.response.complete",
+        category=SSECategory.AI,
+        source_domain_events=(),  # Direct streaming
+        description="AI response complete",
+        payload_fields=("conversation_id", "actions_taken"),
+    ),
+    
+    # ═══════════════════════════════════════════════════════════════════════
+    # Import Events (3 event types)
+    # Implementation: GitHub Issue #4 - SSE: File Import Progress
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="import.started",
+        category=SSECategory.IMPORT,
+        source_domain_events=(FileImportAttempted,),
+        description="File import started",
+        payload_fields=("user_id", "file_name", "file_format"),
+    ),
+    SSEEventMetadata(
+        event_type="import.progress",
+        category=SSECategory.IMPORT,
+        source_domain_events=(),  # Progress events generated during import
+        description="File import progress update",
+        payload_fields=("user_id", "file_name", "progress_percent", "records_processed"),
+    ),
+    SSEEventMetadata(
+        event_type="import.completed",
+        category=SSECategory.IMPORT,
+        source_domain_events=(FileImportSucceeded,),
+        description="File import completed successfully",
+        payload_fields=("user_id", "file_name", "account_count", "transaction_count"),
+    ),
+    
+    # ═══════════════════════════════════════════════════════════════════════
+    # Portfolio Events (2 event types)
+    # Implementation: GitHub Issue #5 - SSE: Balance/Portfolio Updates
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="portfolio.balance.updated",
+        category=SSECategory.PORTFOLIO,
+        source_domain_events=(),  # Triggered after sync, not direct event
+        description="Account balance updated after sync",
+        payload_fields=("account_id", "previous_balance", "new_balance", "currency"),
+    ),
+    SSEEventMetadata(
+        event_type="portfolio.holdings.updated",
+        category=SSECategory.PORTFOLIO,
+        source_domain_events=(),  # Triggered after sync
+        description="Holdings updated after sync",
+        payload_fields=("account_id", "holdings_count"),
+    ),
+    
+    # ═══════════════════════════════════════════════════════════════════════
+    # Security Events (3 event types)
+    # Implementation: GitHub Issue #6 - SSE: Security Notifications
+    # ═══════════════════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type="security.session.new",
+        category=SSECategory.SECURITY,
+        source_domain_events=(SessionCreatedEvent,),
+        description="New session created (login from new device)",
+        payload_fields=("session_id", "device_info", "location", "ip_address"),
+    ),
+    SSEEventMetadata(
+        event_type="security.session.suspicious",
+        category=SSECategory.SECURITY,
+        source_domain_events=(SuspiciousSessionActivityEvent,),
+        description="Suspicious session activity detected",
+        payload_fields=("session_id", "reason"),
+    ),
+    SSEEventMetadata(
+        event_type="security.session.expiring",
+        category=SSECategory.SECURITY,
+        source_domain_events=(),  # Generated by background job
+        description="Session expiring soon",
+        payload_fields=("session_id", "expires_in_seconds"),
+    ),
+]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Computed Views (for validation and introspection)
+# ═══════════════════════════════════════════════════════════════════════════
+
+def get_all_sse_event_types() -> list[str]:
+    """Get all registered SSE event types."""
+    return [meta.event_type for meta in SSE_EVENT_REGISTRY]
+
+
+def get_sse_events_by_category(category: SSECategory) -> list[SSEEventMetadata]:
+    """Get SSE events filtered by category."""
+    return [meta for meta in SSE_EVENT_REGISTRY if meta.category == category]
+
+
+def get_domain_event_to_sse_mapping() -> dict[Type[DomainEvent], list[str]]:
+    """Get mapping from domain events to SSE event types.
+    
+    Used by SSEEventHandler to know which SSE events to broadcast
+    when a domain event is published.
+    """
+    mapping: dict[Type[DomainEvent], list[str]] = {}
+    for meta in SSE_EVENT_REGISTRY:
+        for domain_event in meta.source_domain_events:
+            if domain_event not in mapping:
+                mapping[domain_event] = []
+            mapping[domain_event].append(meta.event_type)
+    return mapping
+
+
+def get_statistics() -> dict[str, int | dict[str, int]]:
+    """Get registry statistics."""
+    from collections import Counter
+    
+    return {
+        "total_events": len(SSE_EVENT_REGISTRY),
+        "by_category": dict(Counter(meta.category.value for meta in SSE_EVENT_REGISTRY)),
+        "domain_event_mapped": sum(
+            1 for meta in SSE_EVENT_REGISTRY if meta.source_domain_events
+        ),
+        "direct_streaming": sum(
+            1 for meta in SSE_EVENT_REGISTRY if not meta.source_domain_events
+        ),
+    }
+```
+
+### 3.3 Registry Benefits
+
+| Benefit | Description |
+|---------|-------------|
+| Single Source of Truth | All SSE events defined in one place |
+| Self-Enforcing | Tests fail if event handlers missing |
+| Auto-Wiring | Container uses registry for domain→SSE mapping |
+| Documentation | Always-accurate event catalog |
+| Type Safety | Compile-time validation of event payloads |
+
+## 4. Domain Layer (Protocols)
+
+### 4.1 SSE Event Dataclass
+
+```python
+# src/domain/events/sse_event.py
+"""SSE Event dataclass for structured event representation."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+
+@dataclass(frozen=True, kw_only=True)
+class SSEEvent:
+    """Server-Sent Event representation.
+    
+    Follows SSE specification (https://html.spec.whatwg.org/multipage/server-sent-events.html):
+    - id: Unique event ID (for Last-Event-ID reconnection)
+    - event: Event type (maps to client event listeners)
+    - data: JSON payload
+    - retry: Reconnection time in milliseconds (optional)
+    
+    Attributes:
+        id: Unique event identifier (UUID7 for ordering).
+        event: Event type from SSE_EVENT_REGISTRY (e.g., "sync.progress").
+        data: Event payload (serialized to JSON).
+        occurred_at: When the event occurred.
+        user_id: Target user for this event.
+        retry: Optional reconnection interval hint (milliseconds).
+    """
+    
+    id: UUID
+    event: str
+    data: dict[str, Any]
+    occurred_at: datetime
+    user_id: UUID
+    retry: int | None = None
+    
+    def to_sse_format(self) -> str:
+        """Serialize to SSE wire format.
+        
+        Returns:
+            SSE-formatted string ready for streaming.
+            
+        Example:
+            id: 01234567-89ab-cdef-0123-456789abcdef
+            event: sync.progress
+            data: {"connection_id": "...", "progress": 45}
+            
+        """
+        import json
+        
+        lines = [
+            f"id: {self.id}",
+            f"event: {self.event}",
+            f"data: {json.dumps(self.data)}",
+        ]
+        
+        if self.retry is not None:
+            lines.append(f"retry: {self.retry}")
+        
+        # SSE events end with double newline
+        return "\n".join(lines) + "\n\n"
+```
+
+### 4.2 SSE Publisher Protocol
+
+```python
+# src/domain/protocols/sse_publisher_protocol.py
+"""SSE Publisher Protocol - what domain/application needs from SSE infrastructure."""
+
+from typing import Protocol
+from uuid import UUID
+
+from src.core.result import Result
+from src.domain.events.sse_event import SSEEvent
+
+
+class SSEPublisherProtocol(Protocol):
+    """Protocol for publishing SSE events to connected clients.
+    
+    Infrastructure adapters implement this without inheritance.
+    Uses Result types for error handling with fail-open strategy.
+    """
+    
+    async def publish(
+        self,
+        event: SSEEvent,
+    ) -> Result[None, str]:
+        """Publish SSE event to user's channel.
+        
+        Args:
+            event: SSE event to publish (includes user_id).
+        
+        Returns:
+            Result with None on success, or error message.
+            
+        Note:
+            Fail-open: If Redis unavailable, log warning and continue.
+            Event delivery is best-effort, not guaranteed.
+        """
+        ...
+    
+    async def publish_to_users(
+        self,
+        event: SSEEvent,
+        user_ids: list[UUID],
+    ) -> Result[int, str]:
+        """Publish SSE event to multiple users.
+        
+        Args:
+            event: SSE event to publish.
+            user_ids: List of user IDs to receive event.
+        
+        Returns:
+            Result with count of successful publishes, or error.
+        """
+        ...
+    
+    async def broadcast(
+        self,
+        event: SSEEvent,
+    ) -> Result[int, str]:
+        """Broadcast SSE event to all connected clients.
+        
+        Args:
+            event: SSE event to broadcast.
+        
+        Returns:
+            Result with count of channels published to, or error.
+            
+        Note:
+            Use sparingly - prefer targeted publish() for user-specific events.
+        """
+        ...
+```
+
+### 4.3 SSE Subscriber Protocol
+
+```python
+# src/domain/protocols/sse_subscriber_protocol.py
+"""SSE Subscriber Protocol - for consuming SSE events from Redis channels."""
+
+from collections.abc import AsyncIterator
+from typing import Protocol
+from uuid import UUID
+
+from src.domain.events.sse_event import SSEEvent
+
+
+class SSESubscriberProtocol(Protocol):
+    """Protocol for subscribing to SSE events from Redis channels.
+    
+    Used by SSE stream endpoint to yield events to connected clients.
+    """
+    
+    async def subscribe(
+        self,
+        user_id: UUID,
+        categories: list[str] | None = None,
+    ) -> AsyncIterator[SSEEvent]:
+        """Subscribe to user's SSE channel.
+        
+        Args:
+            user_id: User ID to subscribe to.
+            categories: Optional filter for event categories.
+                        If None, receives all events.
+        
+        Yields:
+            SSEEvent objects as they're published.
+            
+        Note:
+            This is a long-lived async generator. It yields events
+            until the client disconnects or an error occurs.
+        """
+        ...
+    
+    async def get_missed_events(
+        self,
+        user_id: UUID,
+        last_event_id: UUID,
+        max_events: int = 100,
+    ) -> list[SSEEvent]:
+        """Get events missed since last_event_id.
+        
+        Called on reconnection when client provides Last-Event-ID header.
+        
+        Args:
+            user_id: User ID.
+            last_event_id: Last event ID received by client.
+            max_events: Maximum events to return.
+        
+        Returns:
+            List of missed events in chronological order.
+            
+        Note:
+            Requires event retention (Redis Streams). If retention
+            disabled, returns empty list.
+        """
+        ...
+```
+
+## 5. Infrastructure Layer (Adapters)
+
+### 5.1 Directory Structure
+
+```text
+src/infrastructure/sse/
+├── __init__.py
+├── redis_publisher.py       # SSEPublisherProtocol implementation
+├── redis_subscriber.py      # SSESubscriberProtocol implementation
+├── sse_event_handler.py     # Subscribes to domain events, publishes SSE
+└── channel_keys.py          # Redis channel naming conventions
+```
+
+### 5.2 Redis Channel Naming
+
+```python
+# src/infrastructure/sse/channel_keys.py
+"""Redis channel naming conventions for SSE pub/sub."""
+
+from uuid import UUID
+
+from src.core.constants import SSE_CHANNEL_PREFIX
+
+
+class SSEChannelKeys:
+    """Centralized Redis channel key generation for SSE.
+    
+    Channel Pattern:
+        sse:user:{user_id}              - Per-user event channel
+        sse:broadcast                    - Global broadcast channel
+        sse:stream:user:{user_id}       - Redis Stream for event retention
+    
+    Note: Prefix comes from src/core/constants.py (DRY compliance).
+    """
+    
+    @staticmethod
+    def user_channel(user_id: UUID) -> str:
+        """Get Redis pub/sub channel for user."""
+        return f"{SSE_CHANNEL_PREFIX}:user:{user_id}"
+    
+    @staticmethod
+    def broadcast_channel() -> str:
+        """Get Redis pub/sub channel for broadcasts."""
+        return f"{SSE_CHANNEL_PREFIX}:broadcast"
+    
+    @staticmethod
+    def user_stream(user_id: UUID) -> str:
+        """Get Redis Stream key for event retention."""
+        return f"{SSE_CHANNEL_PREFIX}:stream:user:{user_id}"
+    
+    @staticmethod
+    def parse_user_id_from_channel(channel: str) -> UUID | None:
+        """Extract user_id from channel name."""
+        parts = channel.split(":")
+        if len(parts) == 3 and parts[0] == SSE_CHANNEL_PREFIX and parts[1] == "user":
+            try:
+                return UUID(parts[2])
+            except ValueError:
+                return None
+        return None
+```
+
+### 5.3 Redis Publisher Adapter
+
+```python
+# src/infrastructure/sse/redis_publisher.py
+"""Redis implementation of SSEPublisherProtocol."""
+
+import json
+from uuid import UUID
+
+from redis.asyncio import Redis
+
+from src.core.result import Failure, Result, Success
+from src.domain.events.sse_event import SSEEvent
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+
+
+class RedisSSEPublisher:
+    """Redis Pub/Sub implementation of SSEPublisherProtocol.
+    
+    Publishes SSE events to Redis channels for distribution to
+    connected clients. Supports event retention via Redis Streams.
+    
+    Note: Does NOT inherit from protocol (structural typing).
+    """
+    
+    def __init__(
+        self,
+        redis_client: Redis,
+        enable_retention: bool = False,
+        retention_max_len: int = 1000,
+        retention_ttl_seconds: int = 3600,
+    ) -> None:
+        """Initialize Redis SSE publisher.
+        
+        Args:
+            redis_client: Async Redis client instance.
+            enable_retention: Store events in Redis Streams for replay.
+            retention_max_len: Max events per user stream.
+            retention_ttl_seconds: TTL for retained events.
+        """
+        self._redis = redis_client
+        self._enable_retention = enable_retention
+        self._retention_max_len = retention_max_len
+        self._retention_ttl = retention_ttl_seconds
+    
+    async def publish(self, event: SSEEvent) -> Result[None, str]:
+        """Publish SSE event to user's channel."""
+        try:
+            channel = SSEChannelKeys.user_channel(event.user_id)
+            payload = self._serialize_event(event)
+            
+            # Publish to pub/sub channel
+            await self._redis.publish(channel, payload)
+            
+            # Optionally retain in Redis Stream
+            if self._enable_retention:
+                await self._retain_event(event)
+            
+            return Success(value=None)
+            
+        except Exception as e:
+            # Fail-open: Log warning, don't break calling code
+            return Failure(error=f"SSE publish failed: {e}")
+    
+    async def publish_to_users(
+        self,
+        event: SSEEvent,
+        user_ids: list[UUID],
+    ) -> Result[int, str]:
+        """Publish SSE event to multiple users."""
+        success_count = 0
+        
+        for user_id in user_ids:
+            # Create event copy with different user_id
+            user_event = SSEEvent(
+                id=event.id,
+                event=event.event,
+                data=event.data,
+                occurred_at=event.occurred_at,
+                user_id=user_id,
+                retry=event.retry,
+            )
+            result = await self.publish(user_event)
+            if isinstance(result, Success):
+                success_count += 1
+        
+        return Success(value=success_count)
+    
+    async def broadcast(self, event: SSEEvent) -> Result[int, str]:
+        """Broadcast to all connected clients via broadcast channel."""
+        try:
+            channel = SSEChannelKeys.broadcast_channel()
+            payload = self._serialize_event(event)
+            
+            # PUBSUB NUMSUB returns number of subscribers
+            subscribers = await self._redis.pubsub_numsub(channel)
+            count = subscribers.get(channel, 0) if subscribers else 0
+            
+            await self._redis.publish(channel, payload)
+            
+            return Success(value=count)
+            
+        except Exception as e:
+            return Failure(error=f"SSE broadcast failed: {e}")
+    
+    def _serialize_event(self, event: SSEEvent) -> str:
+        """Serialize event to JSON string."""
+        return json.dumps({
+            "id": str(event.id),
+            "event": event.event,
+            "data": event.data,
+            "occurred_at": event.occurred_at.isoformat(),
+            "user_id": str(event.user_id),
+            "retry": event.retry,
+        })
+    
+    async def _retain_event(self, event: SSEEvent) -> None:
+        """Store event in Redis Stream for replay on reconnection."""
+        stream_key = SSEChannelKeys.user_stream(event.user_id)
+        payload = self._serialize_event(event)
+        
+        # XADD with MAXLEN for bounded retention
+        await self._redis.xadd(
+            stream_key,
+            {"event": payload},
+            maxlen=self._retention_max_len,
+        )
+        
+        # Set TTL on stream
+        await self._redis.expire(stream_key, self._retention_ttl)
+```
+
+### 5.4 SSE Event Handler (Domain Event Bridge)
+
+```python
+# src/infrastructure/sse/sse_event_handler.py
+"""SSE Event Handler - bridges domain events to SSE streams."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from uuid_extensions import uuid7
+
+from src.domain.events.base_event import DomainEvent
+from src.domain.events.sse_event import SSEEvent
+from src.domain.events.sse_registry import (
+    SSE_EVENT_REGISTRY,
+    get_domain_event_to_sse_mapping,
+)
+from src.domain.protocols.logger_protocol import LoggerProtocol
+from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+
+
+class SSEEventHandler:
+    """Handler that bridges domain events to SSE events.
+    
+    Subscribes to domain events via the event bus and publishes
+    corresponding SSE events based on SSE_EVENT_REGISTRY mapping.
+    
+    Usage:
+        # Container wiring (in get_event_bus)
+        sse_handler = SSEEventHandler(publisher, logger)
+        
+        # For each domain event that maps to SSE:
+        event_bus.subscribe(AccountSyncAttempted, sse_handler.handle)
+    """
+    
+    def __init__(
+        self,
+        publisher: RedisSSEPublisher,
+        logger: LoggerProtocol,
+    ) -> None:
+        """Initialize SSE event handler.
+        
+        Args:
+            publisher: SSE publisher for broadcasting events.
+            logger: Logger for observability.
+        """
+        self._publisher = publisher
+        self._logger = logger
+        self._mapping = get_domain_event_to_sse_mapping()
+    
+    async def handle(self, domain_event: DomainEvent) -> None:
+        """Handle domain event by publishing corresponding SSE events.
+        
+        Args:
+            domain_event: Domain event from event bus.
+        """
+        event_type = type(domain_event)
+        sse_event_types = self._mapping.get(event_type, [])
+        
+        if not sse_event_types:
+            return  # No SSE mapping for this domain event
+        
+        for sse_event_type in sse_event_types:
+            # Find metadata for payload field extraction
+            metadata = next(
+                (m for m in SSE_EVENT_REGISTRY if m.event_type == sse_event_type),
+                None,
+            )
+            
+            if metadata is None:
+                continue
+            
+            # Extract payload from domain event
+            payload = self._extract_payload(domain_event, metadata.payload_fields)
+            
+            # Extract user_id from domain event
+            user_id = getattr(domain_event, "user_id", None)
+            if user_id is None:
+                self._logger.warning(
+                    "Domain event missing user_id, skipping SSE",
+                    event_type=event_type.__name__,
+                    sse_event_type=sse_event_type,
+                )
+                continue
+            
+            # Create and publish SSE event
+            sse_event = SSEEvent(
+                id=uuid7(),
+                event=sse_event_type,
+                data=payload,
+                occurred_at=datetime.now(UTC),
+                user_id=user_id,
+            )
+            
+            result = await self._publisher.publish(sse_event)
+            
+            if isinstance(result, Failure):
+                self._logger.warning(
+                    "SSE publish failed (fail-open)",
+                    error=result.error,
+                    sse_event_type=sse_event_type,
+                )
+    
+    def _extract_payload(
+        self,
+        event: DomainEvent,
+        fields: tuple[str, ...],
+    ) -> dict[str, Any]:
+        """Extract payload fields from domain event."""
+        payload: dict[str, Any] = {}
+        
+        for field in fields:
+            value = getattr(event, field, None)
+            if value is not None:
+                # Convert UUIDs to strings for JSON serialization
+                if hasattr(value, "hex"):  # UUID check
+                    payload[field] = str(value)
+                else:
+                    payload[field] = value
+        
+        return payload
+```
+
+## 6. Container Wiring
+
+### 6.1 Handler Pattern Clarification
+
+**SSEEventHandler is NOT a CQRS handler** — it does not use `handler_factory()`.
+
+| Aspect | CQRS Handlers | SSE Event Handler |
+|--------|---------------|-------------------|
+| Purpose | Handle HTTP commands/queries | Bridge domain events to SSE |
+| Invocation | FastAPI `Depends()` per request | Event bus subscription at startup |
+| Lifecycle | Request-scoped (new per request) | App-scoped singleton |
+| Wiring | `handler_factory(HandlerClass)` | `event_bus.subscribe()` |
+| Pattern | Same as `RegisterUserHandler` | Same as `LoggingEventHandler`, `AuditEventHandler` |
+
+SSE handler follows the **existing event handler pattern** from `src/infrastructure/events/handlers/`.
+
+### 6.2 SSE Container Module
+
+```python
+# src/core/container/sse.py
+"""SSE dependency factories."""
+
+from functools import lru_cache
+
+from src.core.constants import (
+    SSE_RETENTION_MAX_LEN_DEFAULT,
+    SSE_RETENTION_TTL_DEFAULT,
+)
+from src.domain.protocols.sse_publisher_protocol import SSEPublisherProtocol
+
+
+@lru_cache()
+def get_sse_publisher() -> SSEPublisherProtocol:
+    """Get SSE publisher singleton (app-scoped).
+    
+    Returns Redis-backed publisher for SSE event distribution.
+    """
+    from src.core.config import get_settings
+    from src.core.container.infrastructure import get_redis_client
+    from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+    
+    settings = get_settings()
+    
+    return RedisSSEPublisher(
+        redis_client=get_redis_client(),
+        enable_retention=settings.sse_enable_retention,
+        retention_max_len=SSE_RETENTION_MAX_LEN_DEFAULT,
+        retention_ttl_seconds=SSE_RETENTION_TTL_DEFAULT,
+    )
+
+
+def get_sse_subscriber() -> "SSESubscriberProtocol":
+    """Get SSE subscriber (request-scoped).
+    
+    Returns Redis-backed subscriber for SSE stream consumption.
+    Each SSE connection gets its own subscriber instance.
+    """
+    from src.core.container.infrastructure import get_redis_client
+    from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+    
+    return RedisSSESubscriber(redis_client=get_redis_client())
+```
+
+### 6.3 Event Bus Integration
+
+In `src/core/container/events.py`, add SSE handler wiring **after existing handlers**:
+
+```python
+# Add to get_event_bus() after LoggingEventHandler, AuditEventHandler, etc.
+
+# =========================================================================
+# SSE EVENT HANDLER WIRING (Registry-driven)
+# =========================================================================
+# Same pattern as LoggingEventHandler and AuditEventHandler above.
+# SSE handler subscribes to domain events and publishes to Redis channels.
+from src.core.container.sse import get_sse_publisher
+from src.domain.events.sse_registry import get_domain_event_to_sse_mapping
+from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+sse_publisher = get_sse_publisher()
+sse_handler = SSEEventHandler(publisher=sse_publisher, logger=logger)
+
+# Subscribe SSE handler to all domain events that have SSE mappings
+# (Registry-driven, same approach as EVENT_REGISTRY auto-wiring)
+domain_to_sse = get_domain_event_to_sse_mapping()
+for domain_event_class in domain_to_sse.keys():
+    event_bus.subscribe(domain_event_class, sse_handler.handle)
+```
+
+## 7. Presentation Layer (SSE Endpoint)
+
+### 7.1 SSE Stream Endpoint
+
+```python
+# src/presentation/routers/api/v1/events.py
+"""SSE events stream endpoint."""
+
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
+
+from src.core.container.sse import get_sse_subscriber
+from src.domain.events.sse_registry import SSECategory
+from src.presentation.dependencies.auth import get_current_user_id
+
+
+router = APIRouter(prefix="/events", tags=["Events"])
+
+
+@router.get("/")
+async def get_events(
+    request: Request,
+    user_id: UUID = Depends(get_current_user_id),  # Existing auth dependency
+    categories: list[str] | None = Query(
+        default=None,
+        description="Filter by event categories (e.g., data_sync, provider)",
+    ),
+    last_event_id: str | None = Query(
+        default=None,
+        alias="Last-Event-ID",
+        description="Resume from last received event ID",
+    ),
+) -> StreamingResponse:
+    """Stream real-time events via Server-Sent Events (SSE).
+    
+    **Authentication**: Standard Bearer token (same as all endpoints).
+    
+    Connect to receive push notifications for:
+    - Data sync progress (accounts, transactions, holdings)
+    - Provider connection health
+    - Balance/portfolio updates
+    - AI response streaming
+    - Security notifications
+    
+    **Reconnection**: The client should automatically reconnect if
+    disconnected. Include `Last-Event-ID` header to resume from
+    where you left off (if event retention is enabled).
+    
+    **Categories**: Filter events by category:
+    - `data_sync`: Account/transaction sync events
+    - `provider`: Provider health events
+    - `ai`: AI response streaming
+    - `import`: File import progress
+    - `portfolio`: Balance/holdings updates
+    - `security`: Session/security alerts
+    """
+    from src.core.constants import SSE_RETRY_INTERVAL_MS
+    
+    subscriber = get_sse_subscriber()
+    
+    async def event_generator() -> AsyncGenerator[str, None]:
+        # Send initial retry interval (from constants)
+        yield f"retry: {SSE_RETRY_INTERVAL_MS}\n\n"
+        
+        # Replay missed events if last_event_id provided
+        if last_event_id:
+            try:
+                missed = await subscriber.get_missed_events(
+                    user_id=user_id,
+                    last_event_id=UUID(last_event_id),
+                )
+                for event in missed:
+                    yield event.to_sse_format()
+            except ValueError:
+                pass  # Invalid UUID, skip replay
+        
+        # Stream live events
+        async for event in subscriber.subscribe(user_id, categories):
+            # Check if client disconnected
+            if await request.is_disconnected():
+                break
+            
+            yield event.to_sse_format()
+    
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx/Traefik buffering
+        },
+    )
+```
+
+### 7.2 Route Registry Entry
+
+Add to `ROUTE_REGISTRY`:
+
+```python
+RouteMetadata(
+    method=HTTPMethod.GET,
+    path="/events",  # REST compliant: resource noun, not verb
+    handler=get_events,
+    resource="events",
+    tags=["Events"],
+    summary="Get events (SSE stream)",
+    description="Real-time event stream via Server-Sent Events. "
+                "Use Accept: text/event-stream header.",
+    operation_id="get_events",
+    response_model=None,  # StreamingResponse
+    status_code=200,
+    errors=[
+        ErrorSpec(status=401, description="Unauthorized"),
+    ],
+    idempotency=IdempotencyLevel.SAFE,
+    auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),  # Uses existing auth
+    rate_limit_policy=RateLimitPolicy.SSE_STREAM,  # New policy for SSE
+),
+```
+
+### 7.3 Why No Response Schema?
+
+Unlike standard REST endpoints, SSE does **not** require a Pydantic response schema in `src/schemas/`. Here's why:
+
+| Aspect | REST Endpoints | SSE Endpoint |
+|--------|----------------|---------------|
+| Response type | JSON (`application/json`) | Stream (`text/event-stream`) |
+| FastAPI handling | `response_model` validates & serializes | `StreamingResponse` streams raw text |
+| Schema location | `src/schemas/*.py` | Not applicable |
+| Serialization | Pydantic `.model_dump()` | `SSEEvent.to_sse_format()` |
+
+**Key Points**:
+
+- `response_model=None` in route registry is correct for SSE
+- The `test_response_models_are_defined` test exempts `RateLimitPolicy.SSE_STREAM` endpoints
+- Event structure is documented via `SSEEvent` dataclass and `SSE_EVENT_REGISTRY`
+- Client SDKs can use the registry metadata for type generation if needed
+
+**Future Option**: If client SDK generation requires OpenAPI-compatible schemas, add documentation-only schemas:
+
+```python
+# src/schemas/sse_schemas.py (optional - for OpenAPI docs only)
+
+class SSEEventPayload(BaseModel):
+    """Base payload structure for SSE events (documentation only)."""
+    event_type: str
+    data: dict[str, Any]
+    occurred_at: datetime
+```
+
+This is **not required** for the foundation — add only if needed for `dashtam-terminal` SDK generation.
+
+## 8. Authentication Strategy
+
+**Key Point**: SSE uses **the same authentication as all Dashtam endpoints**. No separate auth mechanism.
+
+### 8.1 Standard Bearer Token Authentication
+
+SSE connections authenticate via the existing Dashtam Bearer token:
+
+```http
+GET /api/v1/events HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Accept: text/event-stream
+```
+
+**Flow**:
+
+1. Client includes JWT in `Authorization` header (same as any endpoint)
+2. FastAPI dependency `get_current_user_id` validates token, extracts `user_id`
+3. Endpoint uses `user_id` to subscribe to user's Redis channel
+4. If token invalid/expired → standard 401 response (connection never opens)
+
+**No new auth code** — reuses existing `src/presentation/dependencies/auth.py`.
+
+### 8.2 Long-Lived Connection Considerations
+
+SSE connections can persist for hours. Token handling:
+
+| Scenario | Behavior |
+|----------|----------|
+| Token expires mid-stream | Connection continues (validated on connect only) |
+| Session revoked | Server closes connection via heartbeat cleanup |
+| Client disconnect | Standard SSE reconnection with new token |
+| 401 on reconnect | Client must refresh token before retry |
+
+**Server-side cleanup**: Background task checks session validity periodically.
+
+### 8.3 Heartbeat
+
+Server sends `:heartbeat\n\n` comment every 30 seconds (configurable via `SSE_HEARTBEAT_INTERVAL_SECONDS`):
+
+- Detects stale connections (client gone but TCP not closed)
+- Keeps connection alive through proxies/load balancers
+- Not an event — clients ignore SSE comments
+
+## 9. Event Retention & Replay (Optional)
+
+### 9.1 Redis Streams for Retention
+
+For clients that need to recover missed events on reconnection:
+
+```python
+# Configuration
+SSE_ENABLE_RETENTION=true
+SSE_RETENTION_MAX_LEN=1000      # Max events per user
+SSE_RETENTION_TTL_SECONDS=3600  # 1 hour retention
+```
+
+### 9.2 Last-Event-ID Protocol
+
+1. Server includes `id:` field in each SSE event
+2. Client stores last received ID
+3. On reconnection, client sends `Last-Event-ID` header
+4. Server replays missed events from Redis Stream
+
+### 9.3 When to Disable Retention
+
+Retention adds Redis memory overhead. Disable if:
+
+- Events are ephemeral (progress indicators)
+- Clients don't need replay (always start fresh)
+- Memory-constrained environment
+
+## 10. Testing Strategy
+
+### 10.1 Unit Tests
+
+```text
+tests/unit/
+├── test_domain_sse_event.py           # SSEEvent dataclass
+├── test_domain_sse_registry.py        # SSE_EVENT_REGISTRY validation
+└── test_infrastructure_sse_handler.py # SSEEventHandler mapping
+```
+
+### 10.2 Integration Tests
+
+```text
+tests/integration/
+├── test_sse_redis_publisher.py        # Redis pub/sub
+└── test_sse_event_retention.py        # Redis Streams replay
+```
+
+### 10.3 API Tests
+
+```text
+tests/api/
+└── test_sse_stream_endpoint.py        # SSE endpoint with mock events
+```
+
+### 10.4 Registry Compliance Tests
+
+```python
+# tests/unit/test_domain_sse_registry.py
+
+def test_all_sse_events_have_valid_categories():
+    """Verify all SSE events use valid categories."""
+    for meta in SSE_EVENT_REGISTRY:
+        assert isinstance(meta.category, SSECategory)
+
+
+def test_domain_events_have_user_id():
+    """Verify all source domain events have user_id attribute."""
+    for meta in SSE_EVENT_REGISTRY:
+        for domain_event in meta.source_domain_events:
+            # Get type hints to verify user_id field exists
+            hints = get_type_hints(domain_event)
+            assert "user_id" in hints, (
+                f"Domain event {domain_event.__name__} missing user_id "
+                f"(required for SSE routing)"
+            )
+
+
+def test_event_types_are_unique():
+    """Verify no duplicate event types."""
+    event_types = [meta.event_type for meta in SSE_EVENT_REGISTRY]
+    assert len(event_types) == len(set(event_types))
+```
+
+## 11. Configuration
+
+Following Dashtam's established configuration pattern:
+
+- **Environment-specific settings** → `src/core/config.py`
+- **Implementation constants** → `src/core/constants.py`
+
+### 11.1 Constants (src/core/constants.py)
+
+```python
+# =============================================================================
+# SSE (Server-Sent Events)
+# =============================================================================
+
+SSE_HEARTBEAT_INTERVAL_SECONDS: int = 30
+"""Interval between SSE heartbeat comments to detect stale connections."""
+
+SSE_RETRY_INTERVAL_MS: int = 3000
+"""Client reconnection interval hint (milliseconds)."""
+
+SSE_CHANNEL_PREFIX: str = "sse"
+"""Redis channel prefix for SSE pub/sub."""
+
+SSE_RETENTION_MAX_LEN_DEFAULT: int = 1000
+"""Default max events per user in Redis Stream retention."""
+
+SSE_RETENTION_TTL_DEFAULT: int = 3600
+"""Default TTL for retained events (seconds)."""
+```
+
+### 11.2 Settings (src/core/config.py)
+
+Only **environment-specific** settings go in config:
+
+```python
+class Settings(BaseSettings):
+    # ... existing settings ...
+    
+    # SSE Configuration (environment-specific)
+    sse_enable_retention: bool = False  # Enable event retention for replay
+```
+
+### 11.3 Environment Variables
+
+```bash
+# .env.dev.example additions
+
+# SSE Configuration
+SSE_ENABLE_RETENTION=false
+```
+
+**Note**: Retention max_len and TTL use constants (not env vars) because they're implementation details, not deployment configuration.
+
+## 12. Implementation Phases
+
+### Phase 1: Foundation (This Document)
+
+- [ ] SSE Protocol definitions (`domain/protocols/`)
+- [ ] SSE Event dataclass (`domain/events/sse_event.py`)
+- [ ] SSE Event Registry (`domain/events/sse_registry.py`)
+- [ ] Redis Publisher adapter
+- [ ] Redis Subscriber adapter
+- [ ] SSE stream endpoint
+- [ ] Container wiring
+- [ ] Foundation tests
+
+### Phase 2+: Use Cases (GitHub Issues)
+
+Each use case is tracked as a separate GitHub issue:
+
+| Issue | Use Case | Priority |
+|-------|----------|----------|
+| #1 | Data Sync Progress | High |
+| #2 | Provider Connection Health | High |
+| #3 | AI Response Streaming | High |
+| #4 | File Import Progress | Medium |
+| #5 | Balance/Portfolio Updates | Medium |
+| #6 | Security Notifications | Lower |
+
+## 13. Related Documentation
+
+- `docs/architecture/domain-events-architecture.md` - Domain events pattern
+- `docs/architecture/registry-pattern-architecture.md` - Registry pattern
+- `docs/architecture/cache-architecture.md` - Redis infrastructure
+
+---
+
+**Created**: 2026-01-18
+**Last Updated**: 2026-01-18
+
+## Appendix: Key Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Protocol | SSE over WebSocket | Unidirectional fits use cases, simpler |
+| Endpoint | `GET /api/v1/events` | REST compliant (noun, not verb) |
+| Authentication | Existing Bearer token | No separate auth, DRY |
+| Handler pattern | Event bus subscription | Same as LoggingEventHandler, not handler_factory |
+| Constants | `src/core/constants.py` | Implementation details, not env config |
+| Channel prefix | `SSE_CHANNEL_PREFIX` constant | DRY, centralized |

--- a/docs/architecture/sse-registry.md
+++ b/docs/architecture/sse-registry.md
@@ -1,0 +1,492 @@
+# SSE Event Registry Architecture
+
+## Overview
+
+### Purpose
+
+The **SSE Event Registry** is a metadata-driven catalog that serves as the single source of truth for all Server-Sent Events (SSE) event types and their mappings from domain events. It follows the **Registry Pattern** established by the Domain Events Registry, Route Registry, and Validation Registry.
+
+**Key Benefits**:
+
+- **Single source of truth** - All SSE event types cataloged in one place
+- **Self-documenting** - Metadata includes descriptions, payload fields, categories
+- **Self-enforcing** - Compliance tests fail if registry incomplete
+- **Zero drift** - Can't add SSE event type without registry entry
+- **Easy discovery** - Helper functions for accessing metadata
+- **Auto-wiring ready** - Mappings enable automatic domain→SSE event bridging
+
+### Problem Statement
+
+**Before Registry Pattern**:
+
+- **Scattered definitions** (Gap ⚠️): SSE event types defined ad-hoc across codebase
+- **No catalog** (Gap ⚠️): No central place to see all SSE events
+- **No metadata** (Gap ⚠️): Event types lack descriptions, expected payloads
+- **Manual wiring** (Gap ⚠️): Must manually wire each domain event to SSE
+- **Inconsistent naming** (Gap ⚠️): Event type names vary without standard
+
+**The Gap**: Without a registry, developers must manually search for SSE events, lack payload documentation, and have no automated way to ensure complete coverage.
+
+### Solution
+
+**With Registry Pattern**:
+
+```python
+# src/domain/events/sse_registry.py - Single source of truth
+SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation completed successfully",
+        payload_fields=["connection_id", "provider_slug", "account_count"],
+    ),
+    # ... 24 more event types
+]
+```
+
+**Benefits**:
+
+- ✅ All 25 SSE event types cataloged with complete metadata
+- ✅ 6 categories for client-side filtering
+- ✅ Self-enforcing compliance tests
+- ✅ Helper functions for easy access
+- ✅ Domain→SSE mapping support for automated bridging
+- ✅ Zero drift - tests fail if metadata incomplete
+
+---
+
+## Architecture Components
+
+### 1. SSEEventType (Enum)
+
+**Purpose**: Enumerate all valid SSE event types sent to clients.
+
+**Location**: `src/domain/events/sse_event.py`
+
+**Structure**:
+
+```python
+class SSEEventType(StrEnum):
+    """All SSE event types (Single Source of Truth).
+    
+    Naming convention: {category}.{resource}.{action}
+    Examples: sync.accounts.completed, provider.token.expiring
+    """
+    # Data Sync (9 types)
+    SYNC_ACCOUNTS_STARTED = "sync.accounts.started"
+    SYNC_ACCOUNTS_COMPLETED = "sync.accounts.completed"
+    SYNC_ACCOUNTS_FAILED = "sync.accounts.failed"
+    SYNC_TRANSACTIONS_STARTED = "sync.transactions.started"
+    # ... more
+
+    # Provider (4 types)
+    PROVIDER_TOKEN_EXPIRING = "provider.token.expiring"
+    PROVIDER_TOKEN_REFRESHED = "provider.token.refreshed"
+    # ... more
+
+    # AI (3 types), Import (4 types), Portfolio (2 types), Security (3 types)
+```
+
+**Naming Convention**:
+
+- Use **dot notation**: `{category}.{resource}.{action}`
+- **Lowercase** with dots separating segments
+- **Descriptive actions**: `started`, `completed`, `failed`, `expiring`
+
+### 2. SSEEventCategory (Enum)
+
+**Purpose**: Categorize SSE events for client-side filtering.
+
+**Location**: `src/domain/events/sse_event.py`
+
+**Structure**:
+
+```python
+class SSEEventCategory(StrEnum):
+    """Categories for SSE event filtering."""
+    DATA_SYNC = "data_sync"     # Account/transaction/holdings sync
+    PROVIDER = "provider"       # Provider connection health
+    AI = "ai"                   # AI assistant streaming
+    IMPORT = "import"           # File import progress
+    PORTFOLIO = "portfolio"     # Balance/holdings updates
+    SECURITY = "security"       # Session/security alerts
+```
+
+**Client Usage**:
+
+```text
+GET /api/v1/events?categories=data_sync&categories=provider
+```
+
+### 3. SSEEventMetadata (Dataclass)
+
+**Purpose**: Immutable metadata container for a single SSE event type.
+
+**Location**: `src/domain/events/sse_registry.py`
+
+**Structure**:
+
+```python
+@dataclass(frozen=True)
+class SSEEventMetadata:
+    """Metadata for an SSE event type.
+    
+    Attributes:
+        event_type: The SSE event type enum value.
+        category: Event category for filtering.
+        description: Human-readable description.
+        payload_fields: Expected fields in the event data payload.
+    """
+    event_type: SSEEventType
+    category: SSEEventCategory
+    description: str
+    payload_fields: list[str] = field(default_factory=list)
+```
+
+**Key Properties**:
+
+- **Immutable** (`frozen=True`) - Prevents accidental modification
+- **Type-safe** - All fields have type hints
+- **Self-documenting** - Description and payload_fields included
+- **Category-aware** - Links to filtering category
+
+### 4. SSE_EVENT_REGISTRY (Constant)
+
+**Purpose**: The registry itself - single source of truth for all SSE event metadata.
+
+**Location**: `src/domain/events/sse_registry.py`
+
+**Structure**:
+
+```python
+SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
+    # Data Sync Events (9)
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_STARTED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation started",
+        payload_fields=["connection_id", "provider_slug"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation completed successfully",
+        payload_fields=["connection_id", "provider_slug", "account_count"],
+    ),
+    # ... 23 more entries
+]
+```
+
+**Event Type Distribution**:
+
+| Category | Count | Event Types |
+|----------|-------|-------------|
+| DATA_SYNC | 9 | Accounts, Transactions, Holdings (started/completed/failed) |
+| PROVIDER | 4 | Token expiring/refreshed/failed, Disconnected |
+| AI | 3 | Response chunk, Tool executing, Response complete |
+| IMPORT | 4 | Started, Progress, Completed, Failed |
+| PORTFOLIO | 2 | Balance updated, Holdings updated |
+| SECURITY | 3 | Session new/suspicious/expiring |
+
+### 5. DomainToSSEMapping (Dataclass)
+
+**Purpose**: Define how domain events are transformed to SSE events.
+
+**Location**: `src/domain/events/sse_registry.py`
+
+**Structure**:
+
+```python
+@dataclass(frozen=True)
+class DomainToSSEMapping:
+    """Mapping from a domain event to an SSE event.
+    
+    Attributes:
+        domain_event_class: The domain event class to listen for.
+        sse_event_type: The SSE event type to emit.
+        payload_extractor: Function to extract SSE payload from domain event.
+        user_id_extractor: Function to extract user_id from domain event.
+    """
+    domain_event_class: Type[DomainEvent]
+    sse_event_type: SSEEventType
+    payload_extractor: Callable[[DomainEvent], dict[str, Any]]
+    user_id_extractor: Callable[[DomainEvent], UUID]
+```
+
+**Usage** (added by use case issues):
+
+```python
+DOMAIN_TO_SSE_MAPPING: list[DomainToSSEMapping] = [
+    DomainToSSEMapping(
+        domain_event_class=AccountSyncSucceeded,
+        sse_event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        payload_extractor=lambda e: {
+            "connection_id": str(e.connection_id),
+            "provider_slug": e.provider_slug,
+            "account_count": e.account_count,
+        },
+        user_id_extractor=lambda e: e.user_id,
+    ),
+    # ... more mappings
+]
+```
+
+### 6. Helper Functions
+
+**Purpose**: Convenient access to registry data.
+
+**Location**: `src/domain/events/sse_registry.py`
+
+#### get_sse_event_metadata()
+
+```python
+def get_sse_event_metadata(event_type: SSEEventType) -> SSEEventMetadata | None:
+    """Get metadata for an SSE event type.
+    
+    Args:
+        event_type: The SSE event type to look up.
+    
+    Returns:
+        SSEEventMetadata if found, None otherwise.
+    
+    Example:
+        >>> meta = get_sse_event_metadata(SSEEventType.SYNC_ACCOUNTS_COMPLETED)
+        >>> print(meta.description)
+        "Account sync operation completed successfully"
+    """
+```
+
+#### get_events_by_category()
+
+```python
+def get_events_by_category(category: SSEEventCategory) -> list[SSEEventMetadata]:
+    """Get all SSE event metadata for a category.
+    
+    Args:
+        category: The category to filter by.
+    
+    Returns:
+        List of SSEEventMetadata for events in that category.
+    
+    Example:
+        >>> data_sync = get_events_by_category(SSEEventCategory.DATA_SYNC)
+        >>> print(f"Data sync events: {len(data_sync)}")  # 9
+    """
+```
+
+#### get_all_sse_event_types()
+
+```python
+def get_all_sse_event_types() -> list[SSEEventType]:
+    """Get list of all registered SSE event types.
+    
+    Returns:
+        List of all SSE event types in the registry.
+    """
+```
+
+#### get_registry_statistics()
+
+```python
+def get_registry_statistics() -> dict[str, int]:
+    """Get statistics about the SSE event registry.
+    
+    Returns:
+        Dict with counts by category and totals.
+    
+    Example:
+        >>> stats = get_registry_statistics()
+        >>> print(stats)
+        {
+            "total_event_types": 25,
+            "total_mappings": 0,
+            "by_category": {
+                "data_sync": 9,
+                "provider": 4,
+                ...
+            }
+        }
+    """
+```
+
+#### get_domain_event_to_sse_mapping()
+
+```python
+def get_domain_event_to_sse_mapping() -> dict[Type[DomainEvent], DomainToSSEMapping]:
+    """Get mapping from domain event class to SSE mapping.
+    
+    Used by SSEEventHandler to determine if a domain event should
+    trigger an SSE notification.
+    
+    Returns:
+        Dict mapping domain event classes to their SSE mapping metadata.
+    """
+```
+
+---
+
+## Category-to-Event Type Mapping
+
+The registry maintains a separate mapping from `SSEEventType` to `SSEEventCategory`:
+
+**Location**: `src/domain/events/sse_event.py`
+
+```python
+_EVENT_TYPE_TO_CATEGORY: dict[SSEEventType, SSEEventCategory] = {
+    # Data Sync
+    SSEEventType.SYNC_ACCOUNTS_STARTED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_ACCOUNTS_COMPLETED: SSEEventCategory.DATA_SYNC,
+    # ... all 25 mappings
+}
+
+def get_category_for_event_type(event_type: SSEEventType) -> SSEEventCategory:
+    """Get the category for an SSE event type."""
+    return _EVENT_TYPE_TO_CATEGORY[event_type]
+```
+
+**Compliance**: Tests verify that:
+
+1. Every `SSEEventType` has a category mapping
+2. Registry metadata category matches `_EVENT_TYPE_TO_CATEGORY`
+
+---
+
+## Compliance Tests
+
+**Location**: `tests/unit/test_domain_sse_registry_compliance.py`
+
+### Registry Completeness
+
+```python
+def test_all_sse_event_types_have_registry_metadata():
+    """CRITICAL: Every SSEEventType must have metadata in SSE_EVENT_REGISTRY."""
+    registered_types = {m.event_type for m in SSE_EVENT_REGISTRY}
+    for event_type in SSEEventType:
+        assert event_type in registered_types
+```
+
+### Category Consistency
+
+```python
+def test_registry_category_matches_event_type_mapping():
+    """CRITICAL: Registry category must match _EVENT_TYPE_TO_CATEGORY."""
+    for meta in SSE_EVENT_REGISTRY:
+        expected = get_category_for_event_type(meta.event_type)
+        assert meta.category == expected
+```
+
+### Statistics Accuracy
+
+```python
+def test_statistics_expected_counts():
+    """Test expected counts for each category."""
+    stats = get_registry_statistics()
+    expected = {
+        "data_sync": 9,
+        "provider": 4,
+        "ai": 3,
+        "import": 4,
+        "portfolio": 2,
+        "security": 3,
+    }
+    for cat_name, count in expected.items():
+        assert stats["by_category"][cat_name] == count
+```
+
+### No Duplicates
+
+```python
+def test_no_duplicate_event_types_in_registry():
+    """Each event type should appear exactly once."""
+    event_types = [m.event_type for m in SSE_EVENT_REGISTRY]
+    assert len(event_types) == len(set(event_types))
+```
+
+---
+
+## Adding New SSE Event Types
+
+### Process
+
+1. **Add enum value** in `SSEEventType` (sse_event.py)
+2. **Add category mapping** in `_EVENT_TYPE_TO_CATEGORY` (sse_event.py)
+3. **Add registry entry** in `SSE_EVENT_REGISTRY` (sse_registry.py)
+4. **Run tests** - compliance tests validate completeness
+5. **Add domain mapping** (optional) in `DOMAIN_TO_SSE_MAPPING`
+
+### Example: Adding New Event Type
+
+```python
+# Step 1: Add to SSEEventType enum (sse_event.py)
+class SSEEventType(StrEnum):
+    # ... existing types
+    EXPORT_COMPLETED = "export.completed"
+
+# Step 2: Add category mapping (sse_event.py)
+_EVENT_TYPE_TO_CATEGORY = {
+    # ... existing mappings
+    SSEEventType.EXPORT_COMPLETED: SSEEventCategory.IMPORT,  # or new category
+}
+
+# Step 3: Add registry entry (sse_registry.py)
+SSE_EVENT_REGISTRY.append(
+    SSEEventMetadata(
+        event_type=SSEEventType.EXPORT_COMPLETED,
+        category=SSEEventCategory.IMPORT,
+        description="File export operation completed successfully",
+        payload_fields=["file_name", "file_url", "record_count"],
+    )
+)
+
+# Step 4: Run tests
+pytest tests/unit/test_domain_sse_registry_compliance.py -v
+```
+
+---
+
+## SSEEvent Wire Format
+
+The registry defines event types that are serialized to SSE wire format:
+
+**Location**: `src/domain/events/sse_event.py`
+
+```python
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SSEEvent:
+    """Server-Sent Event data structure."""
+    event_type: SSEEventType
+    user_id: UUID
+    data: dict[str, Any]
+    event_id: UUID = field(default_factory=uuid7)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_sse_format(self) -> str:
+        """Serialize to SSE wire format."""
+        return (
+            f"id: {self.event_id}\n"
+            f"event: {self.event_type.value}\n"
+            f"data: {json.dumps(self.data)}\n\n"
+        )
+```
+
+**Example Output**:
+
+```text
+id: 019447f2-3a5b-7c8d-9e0f-1a2b3c4d5e6f
+event: sync.accounts.completed
+data: {"connection_id": "abc123", "account_count": 3}
+
+```
+
+---
+
+## Related Documentation
+
+- [SSE Architecture](sse-architecture.md) - Complete SSE system design
+- [Domain Events Registry](registry.md) - Domain events registry pattern
+- [Route Registry](route-registry.md) - API route registration pattern
+- [Validation Registry](validation-registry.md) - Validation rules registry
+
+---
+
+**Created**: 2026-01-18 | **Last Updated**: 2026-01-18

--- a/env/.env.ci.example
+++ b/env/.env.ci.example
@@ -14,6 +14,11 @@ API_V1_PREFIX=/api/v1
 # CI must enforce strict mode to catch missing handlers before merge
 EVENTS_STRICT_MODE=true
 
+# SSE (Server-Sent Events) Configuration
+# Enable event retention for Last-Event-ID reconnection replay
+# Enabled in CI to verify retention and replay functionality
+SSE_ENABLE_RETENTION=true
+
 # Application URLs (internal Docker network communication - HTTPS)
 API_BASE_URL=https://app:8000
 CALLBACK_BASE_URL=https://callback:8182

--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -31,6 +31,11 @@ LOG_LEVEL=DEBUG
 # Set to false during development to allow WIP handlers
 EVENTS_STRICT_MODE=false
 
+# SSE (Server-Sent Events) Configuration
+# Enable event retention for Last-Event-ID reconnection replay
+# When true, events are stored in Redis Streams for missed event recovery
+SSE_ENABLE_RETENTION=false
+
 # Security Configuration
 SECRET_KEY=your-secret-key-will-be-generated-by-make-keys
 ENCRYPTION_KEY=your-encryption-key-will-be-generated-by-make-keys

--- a/env/.env.test.example
+++ b/env/.env.test.example
@@ -13,6 +13,11 @@ API_V1_PREFIX=/api/v1
 # Tests should enforce strict mode to catch missing handlers early
 EVENTS_STRICT_MODE=true
 
+# SSE (Server-Sent Events) Configuration
+# Enable event retention for Last-Event-ID reconnection replay
+# Enabled in tests to verify retention and replay functionality
+SSE_ENABLE_RETENTION=true
+
 # Server Configuration
 HOST=0.0.0.0
 PORT=8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dashtam"
-version = "1.8.2"
+version = "1.9.0"
 description = "A secure financial data aggregation platform built with hexagonal architecture, CQRS, and domain-driven design"
 requires-python = ">=3.14"
 dependencies = [

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -160,6 +160,14 @@ class Settings(BaseSettings):
         description="Security config (token versions) cache TTL in seconds (default: 1 minute)",
     )
 
+    # SSE (Server-Sent Events) configuration
+    sse_enable_retention: bool = Field(
+        default=False,
+        description="Enable SSE event retention in Redis Streams for Last-Event-ID replay. "
+        "When True, events are stored in Redis Streams for reconnection replay. "
+        "When False, only live pub/sub is used (no replay capability).",
+    )
+
     # Geolocation configuration
     geoip_db_path: str | None = Field(
         default="/app/data/geoip/GeoLite2-City.mmdb",

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -59,3 +59,23 @@ BEARER_PREFIX: str = "Bearer "
 
 RESPONSE_BODY_MAX_LENGTH: int = 500
 """Maximum length for response body in error messages (truncation limit)."""
+
+
+# =============================================================================
+# SSE (Server-Sent Events)
+# =============================================================================
+
+SSE_HEARTBEAT_INTERVAL_SECONDS: int = 30
+"""Interval between SSE heartbeat comments to detect stale connections."""
+
+SSE_RETRY_INTERVAL_MS: int = 3000
+"""Client reconnection interval hint (milliseconds)."""
+
+SSE_CHANNEL_PREFIX: str = "sse"
+"""Redis channel prefix for SSE pub/sub."""
+
+SSE_RETENTION_MAX_LEN_DEFAULT: int = 1000
+"""Default max events per user in Redis Stream retention."""
+
+SSE_RETENTION_TTL_DEFAULT: int = 3600
+"""Default TTL for retained events (seconds)."""

--- a/src/core/container/__init__.py
+++ b/src/core/container/__init__.py
@@ -61,6 +61,9 @@ from src.core.container.infrastructure import (
 # Event bus
 from src.core.container.events import get_event_bus
 
+# SSE (Server-Sent Events)
+from src.core.container.sse import get_sse_publisher, get_sse_subscriber
+
 # Repositories
 from src.core.container.repositories import (
     get_account_repository,
@@ -113,6 +116,9 @@ __all__ = [
     "get_provider_factory",
     # Events
     "get_event_bus",
+    # SSE
+    "get_sse_publisher",
+    "get_sse_subscriber",
     # Repositories
     "get_user_repository",
     "get_provider_connection_repository",

--- a/src/core/container/sse.py
+++ b/src/core/container/sse.py
@@ -1,0 +1,110 @@
+"""SSE dependency factories.
+
+Application-scoped singletons and request-scoped factories for SSE:
+- get_sse_publisher(): App-scoped singleton for publishing SSE events
+- get_sse_subscriber(): Request-scoped factory for SSE stream subscriptions
+
+Reference:
+    - docs/architecture/sse-architecture.md (Section 6)
+"""
+
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.domain.protocols.sse_publisher_protocol import SSEPublisherProtocol
+    from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+
+
+@lru_cache()
+def get_sse_publisher() -> "SSEPublisherProtocol":
+    """Get SSE publisher singleton (app-scoped).
+
+    Returns RedisSSEPublisher with shared Redis connection pool.
+    Uses same Redis connection as cache for efficiency.
+
+    Returns:
+        SSE publisher implementing SSEPublisherProtocol.
+
+    Usage:
+        # Application Layer (direct use in handlers)
+        publisher = get_sse_publisher()
+        await publisher.publish(event)
+
+        # Infrastructure Layer (event handler wiring)
+        sse_handler = SSEEventHandler(publisher=get_sse_publisher())
+    """
+    from redis.asyncio import ConnectionPool, Redis
+
+    from src.core.config import get_settings
+    from src.core.constants import (
+        SSE_RETENTION_MAX_LEN_DEFAULT,
+        SSE_RETENTION_TTL_DEFAULT,
+    )
+    from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+
+    settings = get_settings()
+
+    # Create dedicated Redis connection pool for SSE pub/sub
+    # Pub/sub uses long-lived connections, so separate pool is cleaner
+    pool = ConnectionPool.from_url(
+        settings.redis_url,
+        max_connections=20,  # Fewer connections than cache (pub/sub is lighter)
+        decode_responses=False,
+        socket_connect_timeout=5,
+        socket_timeout=5,
+        retry_on_timeout=True,
+        socket_keepalive=True,
+    )
+    redis_client: Redis[bytes] = Redis(connection_pool=pool)  # type: ignore[type-arg]
+
+    return RedisSSEPublisher(
+        redis_client=redis_client,
+        enable_retention=settings.sse_enable_retention,
+        retention_max_len=SSE_RETENTION_MAX_LEN_DEFAULT,
+        retention_ttl_seconds=SSE_RETENTION_TTL_DEFAULT,
+    )
+
+
+def get_sse_subscriber() -> "RedisSSESubscriber":
+    """Get SSE subscriber (request-scoped).
+
+    Returns new RedisSSESubscriber instance for each SSE connection.
+    Each subscriber manages its own pub/sub subscription lifecycle.
+
+    Returns:
+        New RedisSSESubscriber instance.
+
+    Note:
+        NOT a singleton - each SSE connection gets its own subscriber.
+        This is intentional: pub/sub subscriptions are per-connection.
+
+    Usage:
+        # Presentation Layer (FastAPI Depends in SSE endpoint)
+        subscriber = get_sse_subscriber()
+        async for event in subscriber.subscribe(user_id):
+            yield event.to_sse_format()
+    """
+    from redis.asyncio import ConnectionPool, Redis
+
+    from src.core.config import get_settings
+    from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+
+    settings = get_settings()
+
+    # Create new Redis client for this subscriber
+    # Each subscriber needs its own connection for pub/sub
+    pool = ConnectionPool.from_url(
+        settings.redis_url,
+        max_connections=5,  # Small pool per subscriber
+        decode_responses=False,
+        socket_connect_timeout=5,
+        socket_timeout=None,  # No timeout for pub/sub (long-lived)
+        socket_keepalive=True,
+    )
+    redis_client: Redis[bytes] = Redis(connection_pool=pool)  # type: ignore[type-arg]
+
+    return RedisSSESubscriber(
+        redis_client=redis_client,
+        enable_retention=settings.sse_enable_retention,
+    )

--- a/src/domain/events/__init__.py
+++ b/src/domain/events/__init__.py
@@ -108,6 +108,23 @@ from src.domain.events.session_events import (
     SessionRevokedEvent,
     SuspiciousSessionActivityEvent,
 )
+from src.domain.events.sse_event import (
+    SSEEvent,
+    SSEEventCategory,
+    SSEEventType,
+    get_category_for_event_type,
+)
+from src.domain.events.sse_registry import (
+    DOMAIN_TO_SSE_MAPPING,
+    SSE_EVENT_REGISTRY,
+    DomainToSSEMapping,
+    SSEEventMetadata,
+    get_all_sse_event_types,
+    get_domain_event_to_sse_mapping,
+    get_events_by_category,
+    get_registry_statistics,
+    get_sse_event_metadata,
+)
 
 __all__ = [
     # Base event
@@ -187,4 +204,19 @@ __all__ = [
     "SessionProviderAccessEvent",
     "SessionRevokedEvent",
     "SuspiciousSessionActivityEvent",
+    # SSE Events (wire format for real-time notifications)
+    "SSEEvent",
+    "SSEEventCategory",
+    "SSEEventType",
+    "get_category_for_event_type",
+    # SSE Registry (SSOT for event mappings)
+    "DOMAIN_TO_SSE_MAPPING",
+    "SSE_EVENT_REGISTRY",
+    "DomainToSSEMapping",
+    "SSEEventMetadata",
+    "get_all_sse_event_types",
+    "get_domain_event_to_sse_mapping",
+    "get_events_by_category",
+    "get_registry_statistics",
+    "get_sse_event_metadata",
 ]

--- a/src/domain/events/sse_event.py
+++ b/src/domain/events/sse_event.py
@@ -1,0 +1,292 @@
+"""Server-Sent Events (SSE) event types and data structures.
+
+This module defines the SSE event format for real-time client notifications.
+SSE events are the wire format sent to clients - they're distinct from domain
+events, which represent internal business occurrences.
+
+Architecture:
+    - SSEEvent: Immutable dataclass representing an SSE message
+    - SSEEventType: Enum of all valid event types (SSOT)
+    - SSEEventCategory: Categories for client-side filtering
+    - to_sse_format(): Serialization to SSE wire format (text/event-stream)
+
+Wire Format (SSE spec):
+    id: <event_id>
+    event: <event_type>
+    retry: <reconnect_ms>
+    data: <json_payload>
+
+Reference:
+    - docs/architecture/sse-architecture.md
+    - https://html.spec.whatwg.org/multipage/server-sent-events.html
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from uuid_extensions import uuid7
+
+
+class SSEEventCategory(StrEnum):
+    """Categories for SSE event filtering.
+
+    Clients can subscribe to specific categories via query params:
+        GET /api/v1/events?categories=data_sync,provider
+
+    Categories group related event types for efficient filtering.
+    """
+
+    DATA_SYNC = "data_sync"
+    """Account, transaction, and holdings sync events."""
+
+    PROVIDER = "provider"
+    """Provider connection health and token events."""
+
+    AI = "ai"
+    """AI assistant response streaming events."""
+
+    IMPORT = "import"
+    """File import progress events."""
+
+    PORTFOLIO = "portfolio"
+    """Balance and holdings update events."""
+
+    SECURITY = "security"
+    """Session and security notification events."""
+
+
+class SSEEventType(StrEnum):
+    """All SSE event types (Single Source of Truth).
+
+    Event naming convention:
+        {category}.{resource}.{action}
+
+    Examples:
+        - sync.accounts.started
+        - provider.token.expiring
+        - ai.response.chunk
+
+    Note:
+        These are SSE event types sent to clients, NOT domain event names.
+        Domain events use PascalCase (AccountSyncSucceeded).
+        SSE events use dot-notation (sync.accounts.completed).
+    """
+
+    # =========================================================================
+    # DATA SYNC EVENTS
+    # =========================================================================
+    SYNC_ACCOUNTS_STARTED = "sync.accounts.started"
+    SYNC_ACCOUNTS_COMPLETED = "sync.accounts.completed"
+    SYNC_ACCOUNTS_FAILED = "sync.accounts.failed"
+
+    SYNC_TRANSACTIONS_STARTED = "sync.transactions.started"
+    SYNC_TRANSACTIONS_COMPLETED = "sync.transactions.completed"
+    SYNC_TRANSACTIONS_FAILED = "sync.transactions.failed"
+
+    SYNC_HOLDINGS_STARTED = "sync.holdings.started"
+    SYNC_HOLDINGS_COMPLETED = "sync.holdings.completed"
+    SYNC_HOLDINGS_FAILED = "sync.holdings.failed"
+
+    # =========================================================================
+    # PROVIDER EVENTS
+    # =========================================================================
+    PROVIDER_TOKEN_EXPIRING = "provider.token.expiring"
+    PROVIDER_TOKEN_REFRESHED = "provider.token.refreshed"
+    PROVIDER_TOKEN_FAILED = "provider.token.failed"
+    PROVIDER_DISCONNECTED = "provider.disconnected"
+
+    # =========================================================================
+    # AI EVENTS
+    # =========================================================================
+    AI_RESPONSE_CHUNK = "ai.response.chunk"
+    AI_TOOL_EXECUTING = "ai.tool.executing"
+    AI_RESPONSE_COMPLETE = "ai.response.complete"
+
+    # =========================================================================
+    # IMPORT EVENTS
+    # =========================================================================
+    IMPORT_STARTED = "import.started"
+    IMPORT_PROGRESS = "import.progress"
+    IMPORT_COMPLETED = "import.completed"
+    IMPORT_FAILED = "import.failed"
+
+    # =========================================================================
+    # PORTFOLIO EVENTS
+    # =========================================================================
+    PORTFOLIO_BALANCE_UPDATED = "portfolio.balance.updated"
+    PORTFOLIO_HOLDINGS_UPDATED = "portfolio.holdings.updated"
+
+    # =========================================================================
+    # SECURITY EVENTS
+    # =========================================================================
+    SECURITY_SESSION_NEW = "security.session.new"
+    SECURITY_SESSION_SUSPICIOUS = "security.session.suspicious"
+    SECURITY_SESSION_EXPIRING = "security.session.expiring"
+
+
+# Mapping from event type to category for filtering
+_EVENT_TYPE_TO_CATEGORY: dict[SSEEventType, SSEEventCategory] = {
+    # Data Sync
+    SSEEventType.SYNC_ACCOUNTS_STARTED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_ACCOUNTS_COMPLETED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_ACCOUNTS_FAILED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_TRANSACTIONS_STARTED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_TRANSACTIONS_COMPLETED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_TRANSACTIONS_FAILED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_HOLDINGS_STARTED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_HOLDINGS_COMPLETED: SSEEventCategory.DATA_SYNC,
+    SSEEventType.SYNC_HOLDINGS_FAILED: SSEEventCategory.DATA_SYNC,
+    # Provider
+    SSEEventType.PROVIDER_TOKEN_EXPIRING: SSEEventCategory.PROVIDER,
+    SSEEventType.PROVIDER_TOKEN_REFRESHED: SSEEventCategory.PROVIDER,
+    SSEEventType.PROVIDER_TOKEN_FAILED: SSEEventCategory.PROVIDER,
+    SSEEventType.PROVIDER_DISCONNECTED: SSEEventCategory.PROVIDER,
+    # AI
+    SSEEventType.AI_RESPONSE_CHUNK: SSEEventCategory.AI,
+    SSEEventType.AI_TOOL_EXECUTING: SSEEventCategory.AI,
+    SSEEventType.AI_RESPONSE_COMPLETE: SSEEventCategory.AI,
+    # Import
+    SSEEventType.IMPORT_STARTED: SSEEventCategory.IMPORT,
+    SSEEventType.IMPORT_PROGRESS: SSEEventCategory.IMPORT,
+    SSEEventType.IMPORT_COMPLETED: SSEEventCategory.IMPORT,
+    SSEEventType.IMPORT_FAILED: SSEEventCategory.IMPORT,
+    # Portfolio
+    SSEEventType.PORTFOLIO_BALANCE_UPDATED: SSEEventCategory.PORTFOLIO,
+    SSEEventType.PORTFOLIO_HOLDINGS_UPDATED: SSEEventCategory.PORTFOLIO,
+    # Security
+    SSEEventType.SECURITY_SESSION_NEW: SSEEventCategory.SECURITY,
+    SSEEventType.SECURITY_SESSION_SUSPICIOUS: SSEEventCategory.SECURITY,
+    SSEEventType.SECURITY_SESSION_EXPIRING: SSEEventCategory.SECURITY,
+}
+
+
+def get_category_for_event_type(event_type: SSEEventType) -> SSEEventCategory:
+    """Get the category for an SSE event type.
+
+    Args:
+        event_type: The SSE event type.
+
+    Returns:
+        The category the event type belongs to.
+
+    Raises:
+        KeyError: If event type is not mapped (indicates registry bug).
+    """
+    return _EVENT_TYPE_TO_CATEGORY[event_type]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SSEEvent:
+    """Server-Sent Event data structure.
+
+    Represents a single SSE message to be sent to connected clients.
+    Immutable after creation (frozen dataclass).
+
+    Attributes:
+        event_id: Unique identifier for this event (UUID v7 for ordering).
+        event_type: Type of event (from SSEEventType enum).
+        user_id: Target user for this event (for channel routing).
+        data: Event payload (will be JSON serialized).
+        occurred_at: When the event occurred (UTC).
+
+    Example:
+        >>> event = SSEEvent(
+        ...     event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        ...     user_id=user_id,
+        ...     data={"connection_id": str(conn_id), "account_count": 3},
+        ... )
+        >>> print(event.to_sse_format())
+        id: 01234567-89ab-cdef-0123-456789abcdef
+        event: sync.accounts.completed
+        data: {"connection_id": "...", "account_count": 3}
+    """
+
+    event_type: SSEEventType
+    """Type of SSE event (determines client handling)."""
+
+    user_id: UUID
+    """Target user ID (for Redis channel routing)."""
+
+    data: dict[str, Any]
+    """Event payload (JSON serializable)."""
+
+    event_id: UUID = field(default_factory=uuid7)
+    """Unique event identifier (UUID v7 for temporal ordering)."""
+
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    """Timestamp when event occurred (UTC)."""
+
+    @property
+    def category(self) -> SSEEventCategory:
+        """Get the category for this event type.
+
+        Returns:
+            The category this event belongs to.
+        """
+        return get_category_for_event_type(self.event_type)
+
+    def to_sse_format(self) -> str:
+        """Serialize to SSE wire format.
+
+        Returns:
+            SSE-formatted string ready for streaming response.
+
+        Example output:
+            id: 01234567-89ab-cdef-0123-456789abcdef
+            event: sync.accounts.completed
+            data: {"connection_id": "abc", "account_count": 3}
+
+        Note:
+            - Each field ends with newline
+            - Message ends with double newline (SSE spec)
+            - Data is JSON serialized
+            - Comments (lines starting with :) are ignored by clients
+        """
+        import json
+
+        lines = [
+            f"id: {self.event_id}",
+            f"event: {self.event_type.value}",
+            f"data: {json.dumps(self.data)}",
+            "",  # Empty line terminates the message
+        ]
+        return "\n".join(lines) + "\n"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for Redis storage/transmission.
+
+        Returns:
+            Dictionary representation of the event.
+        """
+        return {
+            "event_id": str(self.event_id),
+            "event_type": self.event_type.value,
+            "user_id": str(self.user_id),
+            "data": self.data,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SSEEvent":
+        """Create SSEEvent from dictionary (Redis deserialization).
+
+        Args:
+            data: Dictionary with event data.
+
+        Returns:
+            SSEEvent instance.
+
+        Raises:
+            KeyError: If required fields are missing.
+            ValueError: If field values are invalid.
+        """
+        return cls(
+            event_id=UUID(data["event_id"]),
+            event_type=SSEEventType(data["event_type"]),
+            user_id=UUID(data["user_id"]),
+            data=data["data"],
+            occurred_at=datetime.fromisoformat(data["occurred_at"]),
+        )

--- a/src/domain/events/sse_registry.py
+++ b/src/domain/events/sse_registry.py
@@ -1,0 +1,361 @@
+"""SSE Event Registry - Single Source of Truth.
+
+This registry catalogs all SSE event types and their mappings from domain events.
+Used for:
+- Container wiring (automated SSEEventHandler subscriptions)
+- Validation tests (verify no drift)
+- Documentation generation (always accurate)
+- Gap detection (missing mappings)
+
+Architecture:
+    - Domain layer (no dependencies on infrastructure)
+    - Imported by container for automated wiring
+    - Verified by tests to catch drift
+
+Adding new SSE mappings (separate issues, not foundation):
+1. Add mapping to DOMAIN_TO_SSE_MAPPING
+2. Run tests - they validate the mapping
+3. Container auto-wires SSEEventHandler subscriptions
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Type
+
+from src.domain.events.base_event import DomainEvent
+from src.domain.events.sse_event import SSEEventCategory, SSEEventType
+
+
+@dataclass(frozen=True)
+class SSEEventMetadata:
+    """Metadata for an SSE event type.
+
+    Attributes:
+        event_type: The SSE event type enum value.
+        category: Event category for filtering.
+        description: Human-readable description.
+        payload_fields: Expected fields in the event data payload.
+    """
+
+    event_type: SSEEventType
+    category: SSEEventCategory
+    description: str
+    payload_fields: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DomainToSSEMapping:
+    """Mapping from a domain event to an SSE event.
+
+    Defines how a domain event is transformed into an SSE event
+    for real-time client notification.
+
+    Attributes:
+        domain_event_class: The domain event class to listen for.
+        sse_event_type: The SSE event type to emit.
+        payload_extractor: Function to extract SSE payload from domain event.
+            Takes (domain_event, user_id) and returns dict payload.
+        user_id_extractor: Function to extract user_id from domain event.
+            Takes domain_event and returns UUID.
+    """
+
+    domain_event_class: Type[DomainEvent]
+    sse_event_type: SSEEventType
+    payload_extractor: Callable[[DomainEvent], dict[str, Any]]
+    user_id_extractor: Callable[[DomainEvent], Any]  # Returns UUID
+
+
+# ═══════════════════════════════════════════════════════════════
+# SSE EVENT METADATA REGISTRY - Describes all SSE event types
+# ═══════════════════════════════════════════════════════════════
+
+SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
+    # ═══════════════════════════════════════════════════════════
+    # Data Sync Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_STARTED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation started",
+        payload_fields=["connection_id", "provider_slug"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation completed successfully",
+        payload_fields=["connection_id", "provider_slug", "account_count"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_ACCOUNTS_FAILED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Account sync operation failed",
+        payload_fields=["connection_id", "provider_slug", "error"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_TRANSACTIONS_STARTED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Transaction sync operation started",
+        payload_fields=["connection_id", "account_id"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_TRANSACTIONS_COMPLETED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Transaction sync operation completed successfully",
+        payload_fields=["connection_id", "account_id", "transaction_count"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_TRANSACTIONS_FAILED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Transaction sync operation failed",
+        payload_fields=["connection_id", "account_id", "error"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_HOLDINGS_STARTED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Holdings sync operation started",
+        payload_fields=["connection_id", "account_id"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_HOLDINGS_COMPLETED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Holdings sync operation completed successfully",
+        payload_fields=["connection_id", "account_id", "holdings_count"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SYNC_HOLDINGS_FAILED,
+        category=SSEEventCategory.DATA_SYNC,
+        description="Holdings sync operation failed",
+        payload_fields=["connection_id", "account_id", "error"],
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # Provider Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.PROVIDER_TOKEN_EXPIRING,
+        category=SSEEventCategory.PROVIDER,
+        description="Provider OAuth token expiring soon",
+        payload_fields=["connection_id", "provider_slug", "expires_in_seconds"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.PROVIDER_TOKEN_REFRESHED,
+        category=SSEEventCategory.PROVIDER,
+        description="Provider OAuth token refreshed successfully",
+        payload_fields=["connection_id", "provider_slug"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.PROVIDER_TOKEN_FAILED,
+        category=SSEEventCategory.PROVIDER,
+        description="Provider OAuth token refresh failed",
+        payload_fields=["connection_id", "provider_slug", "needs_reauth"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.PROVIDER_DISCONNECTED,
+        category=SSEEventCategory.PROVIDER,
+        description="Provider connection disconnected",
+        payload_fields=["connection_id", "provider_slug"],
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # AI Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.AI_RESPONSE_CHUNK,
+        category=SSEEventCategory.AI,
+        description="AI response text chunk (streaming)",
+        payload_fields=["conversation_id", "chunk", "is_final"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.AI_TOOL_EXECUTING,
+        category=SSEEventCategory.AI,
+        description="AI is executing a tool/function",
+        payload_fields=["conversation_id", "tool_name"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.AI_RESPONSE_COMPLETE,
+        category=SSEEventCategory.AI,
+        description="AI response generation completed",
+        payload_fields=["conversation_id"],
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # Import Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.IMPORT_STARTED,
+        category=SSEEventCategory.IMPORT,
+        description="File import operation started",
+        payload_fields=["file_name", "file_format"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.IMPORT_PROGRESS,
+        category=SSEEventCategory.IMPORT,
+        description="File import progress update",
+        payload_fields=["file_name", "progress_percent", "records_processed"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.IMPORT_COMPLETED,
+        category=SSEEventCategory.IMPORT,
+        description="File import operation completed successfully",
+        payload_fields=["file_name", "records_imported"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.IMPORT_FAILED,
+        category=SSEEventCategory.IMPORT,
+        description="File import operation failed",
+        payload_fields=["file_name", "error"],
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # Portfolio Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+        category=SSEEventCategory.PORTFOLIO,
+        description="Account balance updated after sync",
+        payload_fields=["account_id", "previous_balance", "new_balance", "currency"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+        category=SSEEventCategory.PORTFOLIO,
+        description="Portfolio holdings updated after sync",
+        payload_fields=["account_id", "holdings_count"],
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # Security Events
+    # ═══════════════════════════════════════════════════════════
+    SSEEventMetadata(
+        event_type=SSEEventType.SECURITY_SESSION_NEW,
+        category=SSEEventCategory.SECURITY,
+        description="New session created (login from new device/location)",
+        payload_fields=["session_id", "device_info", "location"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SECURITY_SESSION_SUSPICIOUS,
+        category=SSEEventCategory.SECURITY,
+        description="Suspicious session activity detected",
+        payload_fields=["session_id", "reason"],
+    ),
+    SSEEventMetadata(
+        event_type=SSEEventType.SECURITY_SESSION_EXPIRING,
+        category=SSEEventCategory.SECURITY,
+        description="Session expiring soon (warning)",
+        payload_fields=["session_id", "expires_in_seconds"],
+    ),
+]
+
+
+# ═══════════════════════════════════════════════════════════════
+# DOMAIN TO SSE MAPPINGS - To be populated by use case issues
+# ═══════════════════════════════════════════════════════════════
+#
+# Each use case issue (Issue #1-6) will add mappings here.
+# The mappings define how domain events are transformed to SSE events.
+#
+# Example mapping (to be added in Issue #1: Data Sync Progress):
+#
+# DomainToSSEMapping(
+#     domain_event_class=AccountSyncSucceeded,
+#     sse_event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+#     payload_extractor=lambda e: {
+#         "connection_id": str(e.connection_id),
+#         "provider_slug": e.provider_slug,
+#         "account_count": e.account_count,
+#     },
+#     user_id_extractor=lambda e: e.user_id,
+# ),
+
+DOMAIN_TO_SSE_MAPPING: list[DomainToSSEMapping] = [
+    # Mappings to be added by:
+    # - Issue #1: SSE Data Sync Progress (AccountSync*, TransactionSync*, HoldingsSync*)
+    # - Issue #2: SSE Provider Health (ProviderTokenRefresh*, ProviderDisconnection*)
+    # - Issue #3: SSE AI Response Streaming (direct publish, no domain event mapping)
+    # - Issue #4: SSE File Import Progress (FileImport*)
+    # - Issue #5: SSE Balance/Portfolio Updates (after sync handlers)
+    # - Issue #6: SSE Security Notifications (Session events)
+]
+
+
+def get_domain_event_to_sse_mapping() -> dict[Type[DomainEvent], DomainToSSEMapping]:
+    """Get mapping from domain event class to SSE mapping.
+
+    Used by SSEEventHandler to determine if a domain event should
+    trigger an SSE notification and how to transform it.
+
+    Returns:
+        Dict mapping domain event classes to their SSE mapping metadata.
+
+    Example:
+        >>> mapping = get_domain_event_to_sse_mapping()
+        >>> if AccountSyncSucceeded in mapping:
+        ...     sse_mapping = mapping[AccountSyncSucceeded]
+        ...     # Transform and publish SSE event
+    """
+    return {m.domain_event_class: m for m in DOMAIN_TO_SSE_MAPPING}
+
+
+def get_sse_event_metadata(event_type: SSEEventType) -> SSEEventMetadata | None:
+    """Get metadata for an SSE event type.
+
+    Args:
+        event_type: The SSE event type to look up.
+
+    Returns:
+        SSEEventMetadata if found, None otherwise.
+    """
+    for metadata in SSE_EVENT_REGISTRY:
+        if metadata.event_type == event_type:
+            return metadata
+    return None
+
+
+def get_events_by_category(category: SSEEventCategory) -> list[SSEEventMetadata]:
+    """Get all SSE event metadata for a category.
+
+    Args:
+        category: The category to filter by.
+
+    Returns:
+        List of SSEEventMetadata for events in that category.
+    """
+    return [m for m in SSE_EVENT_REGISTRY if m.category == category]
+
+
+def get_all_sse_event_types() -> list[SSEEventType]:
+    """Get list of all registered SSE event types.
+
+    Returns:
+        List of all SSE event types in the registry.
+    """
+    return [m.event_type for m in SSE_EVENT_REGISTRY]
+
+
+def get_registry_statistics() -> dict[str, object]:
+    """Get statistics about the SSE event registry.
+
+    Returns:
+        Dict with counts by category and totals.
+        Keys: total_event_types (int), total_mappings (int), by_category (dict[str, int]).
+
+    Example:
+        >>> stats = get_registry_statistics()
+        >>> print(stats)
+        {
+            "total_event_types": 21,
+            "total_mappings": 0,  # Until use case issues implemented
+            "by_category": {
+                "data_sync": 9,
+                "provider": 4,
+                "ai": 3,
+                ...
+            }
+        }
+    """
+    by_category: dict[str, int] = {}
+    for metadata in SSE_EVENT_REGISTRY:
+        cat_name = metadata.category.value
+        by_category[cat_name] = by_category.get(cat_name, 0) + 1
+
+    return {
+        "total_event_types": len(SSE_EVENT_REGISTRY),
+        "total_mappings": len(DOMAIN_TO_SSE_MAPPING),
+        "by_category": by_category,
+    }

--- a/src/domain/protocols/__init__.py
+++ b/src/domain/protocols/__init__.py
@@ -77,6 +77,8 @@ from src.domain.protocols.provider_protocol import (
     ProviderTransactionData,
 )
 from src.domain.protocols.rate_limit_protocol import RateLimitProtocol
+from src.domain.protocols.sse_publisher_protocol import SSEPublisherProtocol
+from src.domain.protocols.sse_subscriber_protocol import SSESubscriberProtocol
 from src.domain.protocols.transaction_repository import TransactionRepository
 from src.domain.protocols.user_repository import UserRepository
 
@@ -132,4 +134,7 @@ __all__ = [
     "ProviderTransactionData",
     # Transaction Repository
     "TransactionRepository",
+    # SSE protocols
+    "SSEPublisherProtocol",
+    "SSESubscriberProtocol",
 ]

--- a/src/domain/protocols/sse_publisher_protocol.py
+++ b/src/domain/protocols/sse_publisher_protocol.py
@@ -1,0 +1,100 @@
+"""SSE Publisher Protocol for domain layer.
+
+This module defines the interface for publishing SSE events to connected clients.
+Infrastructure adapters (Redis) implement this protocol to provide real-time
+event distribution.
+
+Architecture:
+    - Protocol-based (structural typing, no inheritance)
+    - Async operations for non-blocking pub/sub
+    - Fail-open design (SSE failures don't break core API)
+    - No framework dependencies in domain layer
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+from typing import Protocol
+from uuid import UUID
+
+from src.domain.events.sse_event import SSEEvent
+
+
+class SSEPublisherProtocol(Protocol):
+    """Protocol for publishing SSE events to connected clients.
+
+    Infrastructure adapters (Redis pub/sub) implement this protocol
+    without inheritance. Used by SSEEventHandler to publish events
+    when domain events occur.
+
+    Design:
+        - Async operations for non-blocking I/O
+        - Fail-open: publish failures logged but don't raise
+        - Optional retention for Last-Event-ID replay
+
+    Example:
+        >>> publisher: SSEPublisherProtocol = get_sse_publisher()
+        >>> event = SSEEvent(
+        ...     event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+        ...     user_id=user_id,
+        ...     data={"account_count": 3},
+        ... )
+        >>> await publisher.publish(event)
+    """
+
+    async def publish(self, event: SSEEvent) -> None:
+        """Publish SSE event to user's channel.
+
+        Routes event to the user's Redis pub/sub channel. If retention
+        is enabled, also stores in Redis Stream for replay.
+
+        Args:
+            event: SSE event to publish. Contains user_id for routing.
+
+        Note:
+            - Fail-open: Errors are logged but not raised
+            - Non-blocking: Returns immediately after publish
+            - User_id extracted from event for channel routing
+
+        Example:
+            >>> await publisher.publish(SSEEvent(
+            ...     event_type=SSEEventType.PROVIDER_TOKEN_EXPIRING,
+            ...     user_id=user_id,
+            ...     data={"connection_id": str(conn_id), "expires_in": 3600},
+            ... ))
+        """
+        ...
+
+    async def publish_to_user(self, user_id: UUID, event: SSEEvent) -> None:
+        """Publish SSE event to specific user's channel.
+
+        Alternative to publish() when event needs to be sent to a different
+        user than the one in the event (e.g., security notifications to
+        all user sessions).
+
+        Args:
+            user_id: Target user ID.
+            event: SSE event to publish.
+
+        Note:
+            Same fail-open behavior as publish().
+        """
+        ...
+
+    async def broadcast(self, event: SSEEvent) -> None:
+        """Broadcast SSE event to all connected clients.
+
+        Publishes to a global broadcast channel that all SSE subscribers
+        listen to. Use sparingly - most events should be user-specific.
+
+        Args:
+            event: SSE event to broadcast.
+
+        Use cases:
+            - System-wide maintenance notifications
+            - Feature announcements
+
+        Note:
+            Event's user_id is preserved but event goes to all users.
+        """
+        ...

--- a/src/domain/protocols/sse_subscriber_protocol.py
+++ b/src/domain/protocols/sse_subscriber_protocol.py
@@ -1,0 +1,160 @@
+"""SSE Subscriber Protocol for domain layer.
+
+This module defines the interface for subscribing to SSE event streams.
+Infrastructure adapters (Redis) implement this protocol to provide
+real-time event consumption for connected clients.
+
+Architecture:
+    - Protocol-based (structural typing, no inheritance)
+    - Async generator for streaming events
+    - Category filtering for client subscriptions
+    - Last-Event-ID support for reconnection replay
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+from collections.abc import AsyncIterator
+from typing import Protocol
+from uuid import UUID
+
+from src.domain.events.sse_event import SSEEvent, SSEEventCategory
+
+
+class SSESubscriberProtocol(Protocol):
+    """Protocol for subscribing to SSE event streams.
+
+    Infrastructure adapters (Redis pub/sub) implement this protocol
+    without inheritance. Used by the SSE endpoint to stream events
+    to connected clients.
+
+    Design:
+        - Async generator for event streaming
+        - Category-based filtering
+        - Last-Event-ID replay for reconnection
+        - Request-scoped (new instance per SSE connection)
+
+    Example:
+        >>> subscriber: SSESubscriberProtocol = get_sse_subscriber()
+        >>> async for event in subscriber.subscribe(
+        ...     user_id=user_id,
+        ...     categories=["data_sync", "provider"],
+        ... ):
+        ...     yield event.to_sse_format()
+    """
+
+    async def subscribe(
+        self,
+        user_id: UUID,
+        categories: list[str] | None = None,
+    ) -> AsyncIterator[SSEEvent]:
+        """Subscribe to user's SSE event stream.
+
+        Returns an async generator that yields SSE events as they arrive.
+        Subscribes to both user-specific and broadcast channels.
+
+        Args:
+            user_id: User ID to subscribe to.
+            categories: Optional list of categories to filter.
+                If None, all events are yielded.
+                Valid: "data_sync", "provider", "ai", "import", "portfolio", "security"
+
+        Yields:
+            SSEEvent: Events matching the subscription criteria.
+
+        Note:
+            - Runs until client disconnects or server shuts down
+            - Filters by category if specified
+            - Listens to both user channel and broadcast channel
+
+        Example:
+            >>> async for event in subscriber.subscribe(
+            ...     user_id=user_id,
+            ...     categories=["data_sync"],
+            ... ):
+            ...     # Only sync events for this user
+            ...     yield event.to_sse_format()
+        """
+        ...
+        # Make this a generator
+        yield  # type: ignore[misc]
+
+    async def get_missed_events(
+        self,
+        user_id: UUID,
+        last_event_id: UUID,
+        categories: list[str] | None = None,
+    ) -> list[SSEEvent]:
+        """Get events missed since last_event_id (reconnection replay).
+
+        When a client reconnects with Last-Event-ID header, this method
+        retrieves events that were published while the client was disconnected.
+
+        Requires retention to be enabled (sse_enable_retention=True).
+
+        Args:
+            user_id: User ID to get events for.
+            last_event_id: Last event ID received by client.
+            categories: Optional category filter.
+
+        Returns:
+            List of SSEEvent objects published after last_event_id.
+            Empty list if retention disabled or no events found.
+
+        Note:
+            - Returns empty list if retention is disabled
+            - Events are returned in chronological order
+            - Only returns events within retention window (TTL)
+
+        Example:
+            >>> missed = await subscriber.get_missed_events(
+            ...     user_id=user_id,
+            ...     last_event_id=UUID("01234567-..."),
+            ...     categories=["data_sync"],
+            ... )
+            >>> for event in missed:
+            ...     yield event.to_sse_format()
+        """
+        ...
+
+    def filter_by_categories(
+        self,
+        event: SSEEvent,
+        categories: list[str] | None,
+    ) -> bool:
+        """Check if event matches category filter.
+
+        Helper method for filtering events by category.
+
+        Args:
+            event: Event to check.
+            categories: List of category strings to match.
+                If None, returns True (no filter).
+
+        Returns:
+            True if event matches filter, False otherwise.
+
+        Example:
+            >>> if subscriber.filter_by_categories(event, ["data_sync"]):
+            ...     yield event.to_sse_format()
+        """
+        ...
+
+    @staticmethod
+    def validate_categories(categories: list[str] | None) -> list[SSEEventCategory]:
+        """Validate and convert category strings to enum values.
+
+        Args:
+            categories: List of category strings from query params.
+
+        Returns:
+            List of valid SSEEventCategory enum values.
+
+        Raises:
+            ValueError: If any category string is invalid.
+
+        Example:
+            >>> valid = SSESubscriberProtocol.validate_categories(["data_sync", "ai"])
+            >>> # Returns [SSEEventCategory.DATA_SYNC, SSEEventCategory.AI]
+        """
+        ...

--- a/src/infrastructure/sse/__init__.py
+++ b/src/infrastructure/sse/__init__.py
@@ -1,0 +1,29 @@
+"""SSE Infrastructure adapters package.
+
+This package contains Redis-backed implementations of SSE protocols:
+- RedisSSEPublisher: Publishes SSE events via Redis pub/sub
+- RedisSSESubscriber: Subscribes to SSE event streams
+- SSEChannelKeys: Redis channel naming conventions
+- SSEEventHandler: Bridges domain events to SSE (app-scoped singleton)
+
+Architecture:
+    - Implements domain protocols without inheritance (structural typing)
+    - Uses Redis pub/sub for horizontal scaling
+    - Optional Redis Streams for event retention (Last-Event-ID replay)
+    - Fail-open design: SSE failures don't break core API
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+__all__ = [
+    "SSEChannelKeys",
+    "RedisSSEPublisher",
+    "RedisSSESubscriber",
+    "SSEEventHandler",
+]

--- a/src/infrastructure/sse/channel_keys.py
+++ b/src/infrastructure/sse/channel_keys.py
@@ -1,0 +1,119 @@
+"""Redis channel naming conventions for SSE pub/sub.
+
+This module provides centralized channel key generation for SSE,
+following the same pattern as CacheKeys in src/infrastructure/cache/cache_keys.py.
+
+Channel Patterns:
+    sse:user:{user_id}           - Per-user event channel (pub/sub)
+    sse:broadcast                - Global broadcast channel (pub/sub)
+    sse:stream:user:{user_id}    - Redis Stream for event retention
+
+Reference:
+    - docs/architecture/sse-architecture.md (Section 5.2)
+"""
+
+from uuid import UUID
+
+from src.core.constants import SSE_CHANNEL_PREFIX
+
+
+class SSEChannelKeys:
+    """Centralized Redis channel key generation for SSE.
+
+    All SSE-related Redis keys are generated here to ensure consistent
+    naming and avoid magic strings throughout the codebase.
+
+    Note:
+        Prefix comes from src/core/constants.py (DRY compliance).
+
+    Example:
+        >>> channel = SSEChannelKeys.user_channel(user_id)
+        >>> # Returns "sse:user:01234567-89ab-cdef-..."
+    """
+
+    @staticmethod
+    def user_channel(user_id: UUID) -> str:
+        """Get Redis pub/sub channel for user.
+
+        Args:
+            user_id: User's UUID.
+
+        Returns:
+            Channel name for user-specific events.
+
+        Example:
+            >>> SSEChannelKeys.user_channel(UUID("abc123..."))
+            "sse:user:abc123..."
+        """
+        return f"{SSE_CHANNEL_PREFIX}:user:{user_id}"
+
+    @staticmethod
+    def broadcast_channel() -> str:
+        """Get Redis pub/sub channel for broadcasts.
+
+        Returns:
+            Channel name for system-wide broadcasts.
+
+        Example:
+            >>> SSEChannelKeys.broadcast_channel()
+            "sse:broadcast"
+        """
+        return f"{SSE_CHANNEL_PREFIX}:broadcast"
+
+    @staticmethod
+    def user_stream(user_id: UUID) -> str:
+        """Get Redis Stream key for event retention.
+
+        Used when sse_enable_retention is True. Stores events for
+        Last-Event-ID replay on reconnection.
+
+        Args:
+            user_id: User's UUID.
+
+        Returns:
+            Stream key for event retention.
+
+        Example:
+            >>> SSEChannelKeys.user_stream(UUID("abc123..."))
+            "sse:stream:user:abc123..."
+        """
+        return f"{SSE_CHANNEL_PREFIX}:stream:user:{user_id}"
+
+    @staticmethod
+    def parse_user_id_from_channel(channel: str) -> UUID | None:
+        """Extract user_id from channel name.
+
+        Useful for processing messages from Redis pub/sub where
+        channel name is provided.
+
+        Args:
+            channel: Channel name (e.g., "sse:user:abc123...").
+
+        Returns:
+            UUID if valid user channel, None otherwise.
+
+        Example:
+            >>> SSEChannelKeys.parse_user_id_from_channel("sse:user:abc123...")
+            UUID("abc123...")
+            >>> SSEChannelKeys.parse_user_id_from_channel("sse:broadcast")
+            None
+        """
+        parts = channel.split(":")
+        if len(parts) == 3 and parts[0] == SSE_CHANNEL_PREFIX and parts[1] == "user":
+            try:
+                return UUID(parts[2])
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def is_broadcast_channel(channel: str) -> bool:
+        """Check if channel is the broadcast channel.
+
+        Args:
+            channel: Channel name to check.
+
+        Returns:
+            True if broadcast channel, False otherwise.
+        """
+        return channel == f"{SSE_CHANNEL_PREFIX}:broadcast"

--- a/src/infrastructure/sse/redis_publisher.py
+++ b/src/infrastructure/sse/redis_publisher.py
@@ -1,0 +1,236 @@
+"""Redis SSE Publisher implementing SSEPublisherProtocol.
+
+This adapter publishes SSE events via Redis pub/sub for real-time delivery
+to connected clients. Optionally stores events in Redis Streams for
+Last-Event-ID replay on reconnection.
+
+Architecture:
+    - Implements SSEPublisherProtocol without inheritance (structural typing)
+    - Uses Redis pub/sub for horizontal scaling (multiple API instances)
+    - Optional Redis Streams for event retention
+    - Fail-open design: publish errors are logged but don't raise
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+import json
+import logging
+from uuid import UUID
+
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from src.core.constants import (
+    SSE_RETENTION_MAX_LEN_DEFAULT,
+    SSE_RETENTION_TTL_DEFAULT,
+)
+from src.domain.events.sse_event import SSEEvent
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+
+
+class RedisSSEPublisher:
+    """Redis implementation of SSEPublisherProtocol.
+
+    Publishes SSE events to user channels via Redis pub/sub.
+    When retention is enabled, also stores in Redis Streams for replay.
+
+    Note: Does NOT inherit from SSEPublisherProtocol (uses structural typing).
+
+    Attributes:
+        _redis: Async Redis client instance.
+        _enable_retention: Whether to store events in Redis Streams.
+        _retention_max_len: Max events to retain per user.
+        _retention_ttl: TTL for retained events (seconds).
+        _logger: Logger instance.
+    """
+
+    def __init__(
+        self,
+        redis_client: "Redis[bytes]",  # type: ignore[type-arg]
+        enable_retention: bool = False,
+        retention_max_len: int = SSE_RETENTION_MAX_LEN_DEFAULT,
+        retention_ttl_seconds: int = SSE_RETENTION_TTL_DEFAULT,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Initialize Redis SSE publisher.
+
+        Args:
+            redis_client: Async Redis client instance.
+            enable_retention: Store events in Redis Streams for replay.
+            retention_max_len: Max events per user stream (MAXLEN).
+            retention_ttl_seconds: TTL for stream entries.
+            logger: Optional logger (creates default if not provided).
+        """
+        self._redis = redis_client
+        self._enable_retention = enable_retention
+        self._retention_max_len = retention_max_len
+        self._retention_ttl = retention_ttl_seconds
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def publish(self, event: SSEEvent) -> None:
+        """Publish SSE event to user's channel.
+
+        Routes event to the user's Redis pub/sub channel. If retention
+        is enabled, also stores in Redis Stream for replay.
+
+        Args:
+            event: SSE event to publish. Contains user_id for routing.
+
+        Note:
+            - Fail-open: Errors are logged but not raised
+            - Non-blocking: Returns immediately after publish
+        """
+        await self.publish_to_user(event.user_id, event)
+
+    async def publish_to_user(self, user_id: UUID, event: SSEEvent) -> None:
+        """Publish SSE event to specific user's channel.
+
+        Args:
+            user_id: Target user ID.
+            event: SSE event to publish.
+
+        Note:
+            Same fail-open behavior as publish().
+        """
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        try:
+            # Serialize event to JSON for pub/sub
+            event_json = json.dumps(event.to_dict())
+
+            # Publish to pub/sub channel
+            await self._redis.publish(channel, event_json)
+
+            self._logger.debug(
+                "Published SSE event",
+                extra={
+                    "event_type": event.event_type.value,
+                    "user_id": str(user_id),
+                    "event_id": str(event.event_id),
+                    "channel": channel,
+                },
+            )
+
+            # Store in Redis Stream if retention enabled
+            if self._enable_retention:
+                await self._store_in_stream(user_id, event)
+
+        except RedisError as e:
+            # Fail-open: log error but don't raise
+            self._logger.warning(
+                "Failed to publish SSE event (fail-open)",
+                extra={
+                    "event_type": event.event_type.value,
+                    "user_id": str(user_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+        except Exception as e:
+            # Catch-all for unexpected errors
+            self._logger.error(
+                "Unexpected error publishing SSE event (fail-open)",
+                extra={
+                    "event_type": event.event_type.value,
+                    "user_id": str(user_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+
+    async def broadcast(self, event: SSEEvent) -> None:
+        """Broadcast SSE event to all connected clients.
+
+        Publishes to the global broadcast channel.
+
+        Args:
+            event: SSE event to broadcast.
+
+        Note:
+            Event's user_id is preserved but event goes to all users.
+        """
+        channel = SSEChannelKeys.broadcast_channel()
+
+        try:
+            event_json = json.dumps(event.to_dict())
+            await self._redis.publish(channel, event_json)
+
+            self._logger.debug(
+                "Broadcast SSE event",
+                extra={
+                    "event_type": event.event_type.value,
+                    "event_id": str(event.event_id),
+                    "channel": channel,
+                },
+            )
+
+        except RedisError as e:
+            self._logger.warning(
+                "Failed to broadcast SSE event (fail-open)",
+                extra={
+                    "event_type": event.event_type.value,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+        except Exception as e:
+            self._logger.error(
+                "Unexpected error broadcasting SSE event (fail-open)",
+                extra={
+                    "event_type": event.event_type.value,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+
+    async def _store_in_stream(self, user_id: UUID, event: SSEEvent) -> None:
+        """Store event in Redis Stream for retention.
+
+        Called when retention is enabled. Uses XADD with MAXLEN
+        to keep stream size bounded.
+
+        Args:
+            user_id: User ID for stream key.
+            event: Event to store.
+        """
+        stream_key = SSEChannelKeys.user_stream(user_id)
+
+        try:
+            # XADD with MAXLEN to cap stream size
+            # Using ~ (approximate) for better performance
+            await self._redis.xadd(
+                stream_key,
+                {
+                    "event_id": str(event.event_id),
+                    "event_type": event.event_type.value,
+                    "data": json.dumps(event.data),
+                    "occurred_at": event.occurred_at.isoformat(),
+                },
+                maxlen=self._retention_max_len,
+                approximate=True,
+            )
+
+            # Set TTL on stream if not already set
+            # This ensures old streams get cleaned up
+            ttl = await self._redis.ttl(stream_key)
+            if ttl == -1:  # No TTL set
+                await self._redis.expire(stream_key, self._retention_ttl)
+
+            self._logger.debug(
+                "Stored SSE event in stream",
+                extra={
+                    "stream_key": stream_key,
+                    "event_id": str(event.event_id),
+                },
+            )
+
+        except RedisError as e:
+            # Fail-open: stream storage is optional
+            self._logger.warning(
+                "Failed to store SSE event in stream (fail-open)",
+                extra={
+                    "stream_key": stream_key,
+                    "error": str(e),
+                },
+            )

--- a/src/infrastructure/sse/redis_subscriber.py
+++ b/src/infrastructure/sse/redis_subscriber.py
@@ -1,0 +1,316 @@
+"""Redis SSE Subscriber implementing SSESubscriberProtocol.
+
+This adapter subscribes to SSE events via Redis pub/sub and yields them
+as an async generator. Supports category filtering and Last-Event-ID
+replay from Redis Streams.
+
+Architecture:
+    - Implements SSESubscriberProtocol without inheritance (structural typing)
+    - Uses Redis pub/sub for real-time event delivery
+    - Async generator pattern for streaming
+    - Optional Redis Streams for missed event replay
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from datetime import datetime
+from uuid import UUID
+
+from redis.asyncio import Redis
+from redis.asyncio.client import PubSub
+from redis.exceptions import RedisError
+
+from src.domain.events.sse_event import SSEEvent, SSEEventCategory, SSEEventType
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+
+
+class RedisSSESubscriber:
+    """Redis implementation of SSESubscriberProtocol.
+
+    Subscribes to user and broadcast channels via Redis pub/sub,
+    yielding events as they arrive. Supports category filtering
+    and replay of missed events from Redis Streams.
+
+    Note: Does NOT inherit from SSESubscriberProtocol (uses structural typing).
+
+    Attributes:
+        _redis: Async Redis client instance.
+        _enable_retention: Whether retention is available for replay.
+        _logger: Logger instance.
+    """
+
+    def __init__(
+        self,
+        redis_client: "Redis[bytes]",  # type: ignore[type-arg]
+        enable_retention: bool = False,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Initialize Redis SSE subscriber.
+
+        Args:
+            redis_client: Async Redis client instance.
+            enable_retention: Whether retention is enabled for replay.
+            logger: Optional logger (creates default if not provided).
+        """
+        self._redis = redis_client
+        self._enable_retention = enable_retention
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def subscribe(
+        self,
+        user_id: UUID,
+        categories: list[str] | None = None,
+    ) -> AsyncIterator[SSEEvent]:
+        """Subscribe to user's SSE event stream.
+
+        Returns an async generator that yields SSE events as they arrive.
+        Subscribes to both user-specific and broadcast channels.
+
+        Args:
+            user_id: User ID to subscribe to.
+            categories: Optional list of categories to filter.
+
+        Yields:
+            SSEEvent: Events matching the subscription criteria.
+        """
+        user_channel = SSEChannelKeys.user_channel(user_id)
+        broadcast_channel = SSEChannelKeys.broadcast_channel()
+
+        # Validate categories if provided
+        valid_categories = self.validate_categories(categories)
+
+        pubsub: PubSub = self._redis.pubsub()
+
+        try:
+            # Subscribe to both channels
+            await pubsub.subscribe(user_channel, broadcast_channel)
+
+            self._logger.debug(
+                "Subscribed to SSE channels",
+                extra={
+                    "user_id": str(user_id),
+                    "channels": [user_channel, broadcast_channel],
+                    "categories": [c.value for c in valid_categories]
+                    if valid_categories
+                    else "all",
+                },
+            )
+
+            # Yield events as they arrive
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue
+
+                try:
+                    # Parse event from JSON
+                    event_data = json.loads(message["data"])
+                    event = SSEEvent.from_dict(event_data)
+
+                    # Apply category filter
+                    if self.filter_by_categories(event, categories):
+                        yield event
+
+                except json.JSONDecodeError as e:
+                    self._logger.warning(
+                        "Failed to parse SSE event message",
+                        extra={"error": str(e)},
+                    )
+                except (KeyError, ValueError) as e:
+                    self._logger.warning(
+                        "Invalid SSE event data",
+                        extra={"error": str(e)},
+                    )
+
+        except RedisError as e:
+            self._logger.error(
+                "Redis error in SSE subscription",
+                extra={
+                    "user_id": str(user_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+        except asyncio.CancelledError:
+            # Normal cancellation (client disconnect)
+            self._logger.debug(
+                "SSE subscription cancelled",
+                extra={"user_id": str(user_id)},
+            )
+        finally:
+            # Clean up subscription
+            try:
+                await pubsub.unsubscribe(user_channel, broadcast_channel)
+                await pubsub.aclose()  # type: ignore[no-untyped-call]
+            except Exception as e:
+                self._logger.warning(
+                    "Error cleaning up SSE subscription",
+                    extra={"error": str(e)},
+                )
+
+    async def get_missed_events(
+        self,
+        user_id: UUID,
+        last_event_id: UUID,
+        categories: list[str] | None = None,
+    ) -> list[SSEEvent]:
+        """Get events missed since last_event_id.
+
+        When a client reconnects with Last-Event-ID, retrieves events
+        that were published while disconnected.
+
+        Args:
+            user_id: User ID to get events for.
+            last_event_id: Last event ID received by client.
+            categories: Optional category filter.
+
+        Returns:
+            List of SSEEvent objects published after last_event_id.
+            Empty list if retention disabled or no events found.
+        """
+        if not self._enable_retention:
+            return []
+
+        stream_key = SSEChannelKeys.user_stream(user_id)
+        events: list[SSEEvent] = []
+
+        try:
+            # Read all entries from stream
+            # We'll filter by event_id after reading
+            entries = await self._redis.xrange(stream_key, "-", "+")
+
+            found_last = False
+            for entry_id, entry_data in entries:
+                event_id_str = entry_data.get(
+                    b"event_id", entry_data.get("event_id", "")
+                )
+                if isinstance(event_id_str, bytes):
+                    event_id_str = event_id_str.decode("utf-8")
+
+                # Skip until we find the last seen event
+                if not found_last:
+                    if event_id_str == str(last_event_id):
+                        found_last = True
+                    continue
+
+                # Parse event from stream entry
+                try:
+                    event = self._parse_stream_entry(entry_data, user_id)
+
+                    # Apply category filter
+                    if self.filter_by_categories(event, categories):
+                        events.append(event)
+
+                except (KeyError, ValueError) as e:
+                    self._logger.warning(
+                        "Failed to parse stream entry",
+                        extra={"error": str(e), "entry_id": entry_id},
+                    )
+
+            self._logger.debug(
+                "Retrieved missed events from stream",
+                extra={
+                    "user_id": str(user_id),
+                    "last_event_id": str(last_event_id),
+                    "count": len(events),
+                },
+            )
+
+            return events
+
+        except RedisError as e:
+            self._logger.warning(
+                "Failed to get missed events from stream",
+                extra={
+                    "user_id": str(user_id),
+                    "error": str(e),
+                },
+            )
+            return []
+
+    def _parse_stream_entry(
+        self,
+        entry_data: dict[bytes | str, bytes | str],
+        user_id: UUID,
+    ) -> SSEEvent:
+        """Parse SSEEvent from Redis Stream entry.
+
+        Args:
+            entry_data: Raw entry data from XRANGE.
+            user_id: User ID (not stored in stream, passed in).
+
+        Returns:
+            Parsed SSEEvent.
+
+        Raises:
+            KeyError: If required fields missing.
+            ValueError: If field values invalid.
+        """
+
+        def get_str(key: str) -> str:
+            val = entry_data.get(key.encode(), entry_data.get(key, ""))
+            return val.decode("utf-8") if isinstance(val, bytes) else str(val)
+
+        event_id = UUID(get_str("event_id"))
+        event_type = SSEEventType(get_str("event_type"))
+        data = json.loads(get_str("data"))
+        occurred_at = datetime.fromisoformat(get_str("occurred_at"))
+
+        return SSEEvent(
+            event_id=event_id,
+            event_type=event_type,
+            user_id=user_id,
+            data=data,
+            occurred_at=occurred_at,
+        )
+
+    def filter_by_categories(
+        self,
+        event: SSEEvent,
+        categories: list[str] | None,
+    ) -> bool:
+        """Check if event matches category filter.
+
+        Args:
+            event: Event to check.
+            categories: List of category strings to match.
+
+        Returns:
+            True if event matches filter, False otherwise.
+        """
+        if categories is None:
+            return True
+
+        return event.category.value in categories
+
+    @staticmethod
+    def validate_categories(categories: list[str] | None) -> list[SSEEventCategory]:
+        """Validate and convert category strings to enum values.
+
+        Args:
+            categories: List of category strings from query params.
+
+        Returns:
+            List of valid SSEEventCategory enum values.
+
+        Raises:
+            ValueError: If any category string is invalid.
+        """
+        if categories is None:
+            return []
+
+        valid: list[SSEEventCategory] = []
+        for cat_str in categories:
+            try:
+                valid.append(SSEEventCategory(cat_str))
+            except ValueError:
+                valid_names = [c.value for c in SSEEventCategory]
+                raise ValueError(
+                    f"Invalid category '{cat_str}'. Valid categories: {valid_names}"
+                )
+
+        return valid

--- a/src/infrastructure/sse/sse_event_handler.py
+++ b/src/infrastructure/sse/sse_event_handler.py
@@ -1,0 +1,175 @@
+"""SSE Event Handler - bridges domain events to SSE streams.
+
+This handler subscribes to domain events (via event bus) and publishes
+corresponding SSE events to connected clients via Redis pub/sub.
+
+Architecture:
+    - App-scoped singleton (same pattern as LoggingEventHandler)
+    - Subscribed at container startup (not request-scoped)
+    - Uses registry-driven mappings (DOMAIN_TO_SSE_MAPPING)
+    - Fail-open design: errors logged but don't propagate
+
+Lifecycle:
+    1. Container creates singleton SSEEventHandler at startup
+    2. Container subscribes handler.handle to domain events with SSE mappings
+    3. When domain event published → handler transforms → publisher sends to Redis
+    4. SSE endpoint subscribers receive events from Redis pub/sub
+
+Reference:
+    - docs/architecture/sse-architecture.md (Section 6)
+"""
+
+import logging
+from typing import Any
+
+from src.domain.events.base_event import DomainEvent
+from src.domain.events.sse_event import SSEEvent
+from src.domain.events.sse_registry import (
+    DomainToSSEMapping,
+    get_domain_event_to_sse_mapping,
+)
+from src.domain.protocols.sse_publisher_protocol import SSEPublisherProtocol
+
+
+class SSEEventHandler:
+    """Event handler that bridges domain events to SSE streams.
+
+    Subscribes to domain events and transforms them into SSE events
+    for real-time client notification.
+
+    Note:
+        - App-scoped singleton (NOT request-scoped)
+        - Same pattern as LoggingEventHandler, AuditEventHandler
+        - Does NOT use handler_factory (that's for CQRS handlers)
+
+    Attributes:
+        _publisher: SSE publisher for sending events to Redis.
+        _logger: Logger instance.
+        _mapping: Cached domain-to-SSE mapping from registry.
+
+    Example:
+        >>> # Container wires at startup
+        >>> publisher = get_sse_publisher()
+        >>> handler = SSEEventHandler(publisher=publisher)
+        >>>
+        >>> # Subscribe to domain events with SSE mappings
+        >>> for domain_event_class in get_domain_event_to_sse_mapping():
+        ...     event_bus.subscribe(domain_event_class, handler.handle)
+    """
+
+    def __init__(
+        self,
+        publisher: SSEPublisherProtocol,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Initialize SSE event handler.
+
+        Args:
+            publisher: SSE publisher for sending events to Redis.
+            logger: Optional logger (creates default if not provided).
+        """
+        self._publisher = publisher
+        self._logger = logger or logging.getLogger(__name__)
+        self._mapping = get_domain_event_to_sse_mapping()
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle domain event and publish corresponding SSE event.
+
+        This is the generic handler method that can be subscribed to
+        any domain event. It looks up the mapping and transforms
+        the event appropriately.
+
+        Args:
+            event: Domain event to process.
+
+        Note:
+            - Fail-open: errors logged but not raised
+            - Silently ignores events without SSE mapping
+        """
+        event_class = type(event)
+
+        # Look up mapping for this event type
+        mapping = self._mapping.get(event_class)
+        if mapping is None:
+            # No SSE mapping for this event - this is fine
+            # Not all domain events need SSE notifications
+            return
+
+        try:
+            # Transform domain event to SSE event
+            sse_event = self._transform_event(event, mapping)
+
+            # Publish SSE event
+            await self._publisher.publish(sse_event)
+
+            self._logger.debug(
+                "Published SSE event from domain event",
+                extra={
+                    "domain_event": event_class.__name__,
+                    "sse_event_type": sse_event.event_type.value,
+                    "user_id": str(sse_event.user_id),
+                    "event_id": str(sse_event.event_id),
+                },
+            )
+
+        except Exception as e:
+            # Fail-open: log error but don't propagate
+            # SSE is non-critical - core functionality must continue
+            self._logger.error(
+                "Failed to publish SSE event from domain event (fail-open)",
+                extra={
+                    "domain_event": event_class.__name__,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+
+    def _transform_event(
+        self,
+        domain_event: DomainEvent,
+        mapping: DomainToSSEMapping,
+    ) -> SSEEvent:
+        """Transform domain event to SSE event using mapping.
+
+        Args:
+            domain_event: Domain event to transform.
+            mapping: Mapping with extractors for payload and user_id.
+
+        Returns:
+            SSEEvent ready for publishing.
+
+        Raises:
+            Exception: If extractors fail (caught by caller).
+        """
+        # Extract user_id from domain event
+        user_id = mapping.user_id_extractor(domain_event)
+
+        # Extract payload from domain event
+        payload: dict[str, Any] = mapping.payload_extractor(domain_event)
+
+        return SSEEvent(
+            event_type=mapping.sse_event_type,
+            user_id=user_id,
+            data=payload,
+        )
+
+    def has_mapping_for(self, event_class: type[DomainEvent]) -> bool:
+        """Check if handler has mapping for event class.
+
+        Useful for testing and debugging.
+
+        Args:
+            event_class: Domain event class to check.
+
+        Returns:
+            True if mapping exists, False otherwise.
+        """
+        return event_class in self._mapping
+
+    def get_mapped_event_types(self) -> list[type[DomainEvent]]:
+        """Get list of domain event types with SSE mappings.
+
+        Returns:
+            List of domain event classes that have SSE mappings.
+        """
+        return list(self._mapping.keys())

--- a/src/presentation/routers/api/v1/events.py
+++ b/src/presentation/routers/api/v1/events.py
@@ -1,0 +1,126 @@
+"""SSE Events Endpoint.
+
+Provides Server-Sent Events streaming for real-time client notifications.
+This is a pure handler function - routing is done via ROUTE_REGISTRY.
+
+Architecture:
+    - Uses existing Dashtam Bearer token authentication
+    - Category-based filtering via query params
+    - Last-Event-ID support for reconnection replay
+    - Heartbeat comments to detect stale connections
+
+Reference:
+    - docs/architecture/sse-architecture.md
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, Query, Request
+from fastapi.responses import StreamingResponse
+
+from src.core.constants import SSE_RETRY_INTERVAL_MS
+from src.core.container.sse import get_sse_subscriber
+from src.domain.protocols.sse_subscriber_protocol import SSESubscriberProtocol
+from src.presentation.routers.api.middleware.auth_dependencies import (
+    CurrentUser,
+    get_current_user,
+)
+
+
+async def get_events(
+    request: Request,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    subscriber: Annotated[SSESubscriberProtocol, Depends(get_sse_subscriber)],
+    categories: Annotated[
+        list[str] | None,
+        Query(
+            description="Filter by event categories. "
+            "Valid: data_sync, provider, ai, import, portfolio, security",
+        ),
+    ] = None,
+    last_event_id: Annotated[
+        str | None,
+        Query(
+            alias="Last-Event-ID",
+            description="Resume from last received event ID (if retention enabled)",
+        ),
+    ] = None,
+) -> StreamingResponse:
+    """Stream real-time events via Server-Sent Events (SSE).
+
+    **Authentication**: Standard Bearer token (same as all endpoints).
+
+    Connect to receive push notifications for:
+    - Data sync progress (accounts, transactions, holdings)
+    - Provider connection health
+    - Balance/portfolio updates
+    - AI response streaming
+    - Security notifications
+
+    **Reconnection**: The client should automatically reconnect if
+    disconnected. Include `Last-Event-ID` header to resume from
+    where you left off (if event retention is enabled).
+
+    **Categories**: Filter events by category:
+    - `data_sync`: Account/transaction sync events
+    - `provider`: Provider health events
+    - `ai`: AI response streaming
+    - `import`: File import progress
+    - `portfolio`: Balance/holdings updates
+    - `security`: Session/security alerts
+
+    Returns:
+        StreamingResponse with SSE content type.
+    """
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        """Generate SSE events for streaming response.
+
+        Yields:
+            SSE-formatted strings (event messages and heartbeat comments).
+        """
+        # Send initial retry interval hint to client
+        yield f"retry: {SSE_RETRY_INTERVAL_MS}\n\n"
+
+        # Replay missed events if last_event_id provided
+        if last_event_id:
+            try:
+                missed = await subscriber.get_missed_events(
+                    user_id=current_user.user_id,
+                    last_event_id=UUID(last_event_id),
+                    categories=categories,
+                )
+                for event in missed:
+                    yield event.to_sse_format()
+            except ValueError:
+                pass  # Invalid UUID, skip replay
+
+        # Stream live events with timeout-based heartbeat
+        # Heartbeat is sent when no events arrive within the interval
+        try:
+            async for event in subscriber.subscribe(
+                user_id=current_user.user_id,
+                categories=categories,
+            ):
+                # Check if client disconnected
+                if await request.is_disconnected():
+                    break
+
+                yield event.to_sse_format()
+
+        except asyncio.CancelledError:
+            # Normal cancellation (client disconnect)
+            pass
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx/Traefik buffering
+        },
+    )

--- a/src/presentation/routers/api/v1/routes/derivations.py
+++ b/src/presentation/routers/api/v1/routes/derivations.py
@@ -150,6 +150,9 @@ def _create_rate_limit_rule(policy: RateLimitPolicy) -> RateLimitRule:
         RateLimitPolicy.GLOBAL: _rule(
             10000, 10000.0, RateLimitScope.GLOBAL, enabled=False
         ),
+        # SSE (Server-Sent Events) - user-scoped, generous for long-lived connections
+        # 10 connections/min per user (reconnection tolerance)
+        RateLimitPolicy.SSE_STREAM: _rule(10, 5.0, RateLimitScope.USER),
     }
 
     return mapping[policy]

--- a/src/presentation/routers/api/v1/routes/metadata.py
+++ b/src/presentation/routers/api/v1/routes/metadata.py
@@ -173,6 +173,9 @@ class RateLimitPolicy(str, Enum):
     # Global limits (emergency brake)
     GLOBAL = "global"
 
+    # SSE (Server-Sent Events)
+    SSE_STREAM = "sse_stream"
+
 
 # =============================================================================
 # Idempotency Level

--- a/src/presentation/routers/api/v1/routes/registry.py
+++ b/src/presentation/routers/api/v1/routes/registry.py
@@ -5,7 +5,7 @@ The registry is used to generate FastAPI routes, rate limit rules, auth dependen
 and OpenAPI metadata at application startup.
 
 Registry structure:
-    - 36 total endpoints across 12 resource categories
+    - 37 total endpoints across 13 resource categories
     - Each entry is a RouteMetadata instance with complete specification
     - Handlers reference actual functions from router modules
     - Auth policies explicitly declared (PUBLIC, AUTHENTICATED, ADMIN, MANUAL_AUTH)
@@ -88,6 +88,7 @@ from src.presentation.routers.api.v1.transactions import (
     list_transactions_by_account,
     sync_transactions,
 )
+from src.presentation.routers.api.v1.events import get_events
 from src.presentation.routers.api.v1.users import create_user
 from src.schemas.account_schemas import (
     AccountListResponse,
@@ -880,5 +881,26 @@ ROUTE_REGISTRY: list[RouteMetadata] = [
         idempotency=IdempotencyLevel.SAFE,
         auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
         rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    # =========================================================================
+    # Events Resource (1 endpoint - SSE)
+    # =========================================================================
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/events",
+        handler=get_events,
+        resource="events",
+        tags=["Events"],
+        summary="Subscribe to events (SSE)",
+        description="Server-Sent Events stream for real-time updates. Requires authenticated user.",
+        operation_id="get_events",
+        response_model=None,  # StreamingResponse
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.AUTHENTICATED),
+        rate_limit_policy=RateLimitPolicy.SSE_STREAM,
     ),
 ]

--- a/tests/api/test_events_endpoints.py
+++ b/tests/api/test_events_endpoints.py
@@ -1,0 +1,364 @@
+"""API tests for events SSE endpoint.
+
+Tests the complete HTTP request/response cycle for the SSE events endpoint:
+- GET /api/v1/events (Server-Sent Events stream)
+
+Architecture:
+    - Uses FastAPI TestClient with real app + dependency overrides
+    - Tests authentication (401 without auth)
+    - Tests response headers (content-type, cache control)
+    - Tests streaming response format
+    - Mocks SSE subscriber to control event delivery
+
+Note:
+    TestClient with streaming responses requires careful handling.
+    We use iter_lines() for streaming tests.
+
+Reference:
+    - src/presentation/routers/api/v1/events.py
+    - docs/architecture/sse-architecture.md
+"""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from uuid_extensions import uuid7
+
+from src.core.container.sse import get_sse_subscriber
+from src.domain.events.sse_event import SSEEvent, SSEEventType
+from src.main import app
+
+
+# =============================================================================
+# Test Doubles
+# =============================================================================
+
+
+@dataclass
+class MockCurrentUser:
+    """Mock user for auth override."""
+
+    user_id: UUID
+    email: str = "test@example.com"
+    roles: list[str] | None = None
+
+    def __post_init__(self):
+        if self.roles is None:
+            self.roles = ["user"]
+
+
+class MockSSESubscriber:
+    """Mock SSE subscriber for testing.
+
+    Yields a configurable number of events then stops.
+    """
+
+    def __init__(
+        self,
+        events: list[SSEEvent] | None = None,
+        missed_events: list[SSEEvent] | None = None,
+        enable_retention: bool = False,
+    ) -> None:
+        self._events = events or []
+        self._missed_events = missed_events or []
+        self._enable_retention = enable_retention
+
+    async def subscribe(
+        self,
+        user_id: UUID,
+        categories: list[str] | None = None,
+    ) -> AsyncIterator[SSEEvent]:
+        """Yield configured events."""
+        for event in self._events:
+            yield event
+
+    async def get_missed_events(
+        self,
+        user_id: UUID,
+        last_event_id: UUID,
+        categories: list[str] | None = None,
+    ) -> list[SSEEvent]:
+        """Return configured missed events."""
+        if not self._enable_retention:
+            return []
+        return self._missed_events
+
+
+def create_test_event(
+    event_type: SSEEventType = SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+    user_id: UUID | None = None,
+    data: dict[str, object] | None = None,
+) -> SSEEvent:
+    """Create an SSEEvent for testing."""
+    return SSEEvent(
+        event_type=event_type,
+        user_id=user_id or uuid7(),
+        data=data or {"test": "data"},
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_user_id():
+    """Provide consistent user ID for tests."""
+    return uuid7()
+
+
+@pytest.fixture
+def client():
+    """Provide test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def authenticated_client(mock_user_id):
+    """Provide test client with mocked authentication."""
+    from src.presentation.routers.api.middleware.auth_dependencies import (
+        get_current_user,
+    )
+
+    mock_user = MockCurrentUser(user_id=mock_user_id)
+
+    async def mock_get_current_user():
+        return mock_user
+
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+
+    yield TestClient(app)
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# =============================================================================
+# Authentication Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestEventsAuthentication:
+    """Tests for SSE endpoint authentication."""
+
+    def test_events_requires_authentication(self, client):
+        """GET /api/v1/events returns 401 without authentication."""
+        # Clear any auth overrides
+        from src.presentation.routers.api.middleware.auth_dependencies import (
+            get_current_user,
+        )
+
+        app.dependency_overrides.pop(get_current_user, None)
+
+        response = client.get("/api/v1/events")
+
+        # Should be 401 Unauthorized
+        assert response.status_code == 401
+
+    def test_events_accessible_with_authentication(
+        self, authenticated_client, mock_user_id
+    ):
+        """GET /api/v1/events returns 200 with authentication."""
+        # Mock subscriber to yield no events (ends stream immediately)
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+
+        # Should be 200 OK
+        assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+
+# =============================================================================
+# Response Header Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestEventsResponseHeaders:
+    """Tests for SSE response headers."""
+
+    def test_events_content_type_is_event_stream(
+        self, authenticated_client, mock_user_id
+    ):
+        """GET /api/v1/events has correct Content-Type header."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+
+        assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_has_cache_control_header(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events has Cache-Control: no-cache header."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+
+        assert response.headers["cache-control"] == "no-cache"
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_has_connection_header(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events has Connection: keep-alive header."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+
+        assert response.headers.get("connection") == "keep-alive"
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+
+# =============================================================================
+# Streaming Response Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestEventsStreaming:
+    """Tests for SSE event streaming."""
+
+    def test_events_includes_retry_hint(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events starts with retry interval hint."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+        content = response.text
+
+        # Should include retry: directive
+        assert "retry:" in content
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_streams_single_event(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events streams event in SSE format."""
+        event = create_test_event(
+            event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            user_id=mock_user_id,
+            data={"count": 5},
+        )
+        mock_subscriber = MockSSESubscriber(events=[event])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+        content = response.text
+
+        # Should include event fields
+        assert f"id: {event.event_id}" in content
+        assert "event: sync.accounts.completed" in content
+        assert "data:" in content
+        assert '"count": 5' in content or '"count":5' in content
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_streams_multiple_events(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events streams multiple events in order."""
+        events = [
+            create_test_event(
+                event_type=SSEEventType.SYNC_ACCOUNTS_STARTED,
+                user_id=mock_user_id,
+                data={"step": 1},
+            ),
+            create_test_event(
+                event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+                user_id=mock_user_id,
+                data={"step": 2},
+            ),
+        ]
+        mock_subscriber = MockSSESubscriber(events=events)
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+        content = response.text
+
+        # Both events should be present
+        assert "event: sync.accounts.started" in content
+        assert "event: sync.accounts.completed" in content
+        assert '"step": 1' in content or '"step":1' in content
+        assert '"step": 2' in content or '"step":2' in content
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+
+# =============================================================================
+# Query Parameter Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestEventsQueryParams:
+    """Tests for SSE endpoint query parameters."""
+
+    def test_events_accepts_categories_param(self, authenticated_client, mock_user_id):
+        """GET /api/v1/events accepts categories query param."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        # Should not fail validation
+        response = authenticated_client.get(
+            "/api/v1/events?categories=data_sync&categories=provider"
+        )
+
+        assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_accepts_last_event_id_param(
+        self, authenticated_client, mock_user_id
+    ):
+        """GET /api/v1/events accepts Last-Event-ID query param."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        event_id = str(uuid7())
+
+        # Should not fail validation
+        response = authenticated_client.get(f"/api/v1/events?Last-Event-ID={event_id}")
+
+        assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+
+# =============================================================================
+# Route Registry Compliance Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestEventsRouteRegistry:
+    """Tests to verify events endpoint is in route registry."""
+
+    def test_events_endpoint_exists(self, authenticated_client):
+        """GET /api/v1/events endpoint exists and is accessible."""
+        mock_subscriber = MockSSESubscriber(events=[])
+        app.dependency_overrides[get_sse_subscriber] = lambda: mock_subscriber
+
+        response = authenticated_client.get("/api/v1/events")
+
+        # Should not be 404
+        assert response.status_code != 404
+
+        app.dependency_overrides.pop(get_sse_subscriber, None)
+
+    def test_events_has_correct_path(self):
+        """Events endpoint is registered at /api/v1/events."""
+        from src.presentation.routers.api.v1.routes.registry import ROUTE_REGISTRY
+
+        events_routes = [r for r in ROUTE_REGISTRY if r.path == "/events"]
+
+        assert len(events_routes) == 1
+        assert events_routes[0].resource == "events"
+        assert events_routes[0].operation_id == "get_events"

--- a/tests/integration/test_sse_redis_pubsub.py
+++ b/tests/integration/test_sse_redis_pubsub.py
@@ -1,0 +1,422 @@
+"""Integration tests for SSE Redis pub/sub.
+
+Tests the RedisSSEPublisher and RedisSSESubscriber implementations
+against a real Redis instance, verifying pub/sub round-trip delivery.
+
+Architecture:
+    - Tests against real Redis (not mocked)
+    - Uses test environment Redis
+    - Tests pub/sub event delivery
+    - Tests broadcast channel
+    - Tests category filtering
+    - Uses fresh Redis connections per test (bypasses singleton)
+
+Reference:
+    - src/infrastructure/sse/redis_publisher.py
+    - src/infrastructure/sse/redis_subscriber.py
+"""
+
+import asyncio
+import logging
+
+import pytest
+import pytest_asyncio
+from uuid_extensions import uuid7
+
+from src.domain.events.sse_event import SSEEvent, SSEEventCategory, SSEEventType
+from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def sse_publisher(redis_test_client):
+    """Provide an SSE publisher for each test."""
+    return RedisSSEPublisher(
+        redis_client=redis_test_client,
+        enable_retention=False,
+        logger=logging.getLogger("test.sse.publisher"),
+    )
+
+
+@pytest_asyncio.fixture
+async def sse_subscriber(redis_test_client):
+    """Provide an SSE subscriber for each test."""
+    return RedisSSESubscriber(
+        redis_client=redis_test_client,
+        enable_retention=False,
+        logger=logging.getLogger("test.sse.subscriber"),
+    )
+
+
+def create_test_event(
+    event_type: SSEEventType = SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+    user_id=None,
+    data=None,
+) -> SSEEvent:
+    """Create an SSEEvent for testing."""
+    return SSEEvent(
+        event_type=event_type,
+        user_id=user_id or uuid7(),
+        data=data or {"test": "data"},
+    )
+
+
+# =============================================================================
+# Publisher Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSSEPublisher:
+    """Integration tests for RedisSSEPublisher."""
+
+    @pytest.mark.asyncio
+    async def test_publish_does_not_raise(self, sse_publisher):
+        """Test publish completes without raising."""
+        event = create_test_event()
+        # Should not raise - fail-open design
+        await sse_publisher.publish(event)
+
+    @pytest.mark.asyncio
+    async def test_publish_to_user_does_not_raise(self, sse_publisher):
+        """Test publish_to_user completes without raising."""
+        user_id = uuid7()
+        event = create_test_event(user_id=user_id)
+        await sse_publisher.publish_to_user(user_id, event)
+
+    @pytest.mark.asyncio
+    async def test_broadcast_does_not_raise(self, sse_publisher):
+        """Test broadcast completes without raising."""
+        event = create_test_event()
+        await sse_publisher.broadcast(event)
+
+
+# =============================================================================
+# Subscriber Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSSESubscriber:
+    """Integration tests for RedisSSESubscriber."""
+
+    @pytest.mark.asyncio
+    async def test_validate_categories_valid(self, sse_subscriber):
+        """Test category validation with valid categories."""
+        categories = ["data_sync", "provider"]
+        result = sse_subscriber.validate_categories(categories)
+
+        assert len(result) == 2
+        assert SSEEventCategory.DATA_SYNC in result
+        assert SSEEventCategory.PROVIDER in result
+
+    @pytest.mark.asyncio
+    async def test_validate_categories_invalid_raises(self, sse_subscriber):
+        """Test category validation raises for invalid category."""
+        with pytest.raises(ValueError) as exc_info:
+            sse_subscriber.validate_categories(["invalid_category"])
+
+        assert "Invalid category" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_categories_none_returns_empty(self, sse_subscriber):
+        """Test category validation with None returns empty list."""
+        result = sse_subscriber.validate_categories(None)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filter_by_categories_none_passes_all(self, sse_subscriber):
+        """Test filter passes all events when categories is None."""
+        event = create_test_event(event_type=SSEEventType.AI_RESPONSE_CHUNK)
+        assert sse_subscriber.filter_by_categories(event, None) is True
+
+    @pytest.mark.asyncio
+    async def test_filter_by_categories_matches(self, sse_subscriber):
+        """Test filter passes events matching category."""
+        event = create_test_event(event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED)
+        assert sse_subscriber.filter_by_categories(event, ["data_sync"]) is True
+
+    @pytest.mark.asyncio
+    async def test_filter_by_categories_rejects(self, sse_subscriber):
+        """Test filter rejects events not in category."""
+        event = create_test_event(event_type=SSEEventType.AI_RESPONSE_CHUNK)
+        assert sse_subscriber.filter_by_categories(event, ["data_sync"]) is False
+
+
+# =============================================================================
+# Pub/Sub Round-Trip Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestPubSubRoundTrip:
+    """Integration tests for pub/sub round-trip delivery."""
+
+    @pytest.mark.asyncio
+    async def test_pubsub_roundtrip_single_event(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test single event is delivered via pub/sub."""
+        user_id = uuid7()
+        event = create_test_event(
+            event_type=SSEEventType.SYNC_TRANSACTIONS_COMPLETED,
+            user_id=user_id,
+            data={"count": 42},
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                # Stop after first event
+                break
+
+        # Start subscriber in background
+        subscriber_task = asyncio.create_task(collect_events())
+
+        # Give subscriber time to connect
+        await asyncio.sleep(0.1)
+
+        # Publish event
+        await sse_publisher.publish(event)
+
+        # Wait for event to be received (with timeout)
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        # Verify event was received
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.event_type == SSEEventType.SYNC_TRANSACTIONS_COMPLETED
+        assert received.data == {"count": 42}
+        assert received.event_id == event.event_id
+
+    @pytest.mark.asyncio
+    async def test_pubsub_roundtrip_multiple_events(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test multiple events are delivered in order."""
+        user_id = uuid7()
+        events_to_send = [
+            create_test_event(
+                event_type=SSEEventType.SYNC_ACCOUNTS_STARTED,
+                user_id=user_id,
+                data={"step": 1},
+            ),
+            create_test_event(
+                event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+                user_id=user_id,
+                data={"step": 2},
+            ),
+        ]
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                if len(received_events) >= 2:
+                    break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        # Publish events
+        for event in events_to_send:
+            await sse_publisher.publish(event)
+            await asyncio.sleep(0.01)  # Small delay between publishes
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        # Verify both events received
+        assert len(received_events) == 2
+        assert received_events[0].data == {"step": 1}
+        assert received_events[1].data == {"step": 2}
+
+    @pytest.mark.asyncio
+    async def test_pubsub_category_filtering(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test subscriber only receives events matching category filter."""
+        user_id = uuid7()
+
+        # Events of different categories
+        sync_event = create_test_event(
+            event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            user_id=user_id,
+            data={"category": "data_sync"},
+        )
+        ai_event = create_test_event(
+            event_type=SSEEventType.AI_RESPONSE_CHUNK,
+            user_id=user_id,
+            data={"category": "ai"},
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            # Only subscribe to data_sync category
+            async for e in sse_subscriber.subscribe(user_id, categories=["data_sync"]):
+                received_events.append(e)
+                # We only expect one event, but give time for both to arrive
+                if len(received_events) >= 1:
+                    # Wait a bit to ensure ai_event doesn't arrive
+                    await asyncio.sleep(0.1)
+                    break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        # Publish both events
+        await sse_publisher.publish(ai_event)  # Should be filtered out
+        await sse_publisher.publish(sync_event)  # Should be received
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        # Only sync event should be received
+        assert len(received_events) == 1
+        assert received_events[0].data == {"category": "data_sync"}
+
+    @pytest.mark.asyncio
+    async def test_broadcast_received_by_subscriber(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test broadcast events are received by subscriber."""
+        user_id = uuid7()
+        event = create_test_event(
+            event_type=SSEEventType.SECURITY_SESSION_EXPIRING,
+            user_id=uuid7(),  # Different user - but broadcast should still arrive
+            data={"broadcast": True},
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        # Broadcast (not publish to specific user)
+        await sse_publisher.broadcast(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        # Broadcast should be received
+        assert len(received_events) == 1
+        assert received_events[0].data == {"broadcast": True}
+
+    @pytest.mark.asyncio
+    async def test_event_isolation_between_users(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test events for one user are not received by another."""
+        user1 = uuid7()
+        user2 = uuid7()
+
+        event_for_user1 = create_test_event(
+            event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            user_id=user1,
+            data={"for": "user1"},
+        )
+
+        received_by_user2: list[SSEEvent] = []
+        no_event_received = True
+
+        async def collect_user2_events():
+            nonlocal no_event_received
+            async for e in sse_subscriber.subscribe(user2):
+                received_by_user2.append(e)
+                no_event_received = False
+                break
+
+        # Subscribe as user2
+        subscriber_task = asyncio.create_task(collect_user2_events())
+        await asyncio.sleep(0.1)
+
+        # Publish to user1 (user2 should NOT receive)
+        await sse_publisher.publish(event_for_user1)
+
+        # Wait briefly - user2 should NOT receive anything
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=0.5)
+        except asyncio.TimeoutError:
+            # Expected - no event should arrive
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        # User2 should not have received user1's event
+        assert len(received_by_user2) == 0
+        assert no_event_received is True
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestErrorHandling:
+    """Test error handling in pub/sub operations."""
+
+    @pytest.mark.asyncio
+    async def test_publisher_fail_open_on_invalid_redis(self):
+        """Test publisher doesn't raise even with bad Redis connection."""
+        from redis.asyncio import Redis
+
+        # Create publisher with disconnected client
+        # (Connection will fail but publisher should not raise)
+        bad_client: Redis[bytes] = Redis.from_url(  # type: ignore[type-arg]
+            "redis://nonexistent-host:6379",
+            socket_connect_timeout=0.1,
+        )
+        publisher = RedisSSEPublisher(
+            redis_client=bad_client,
+            logger=logging.getLogger("test.fail"),
+        )
+
+        event = create_test_event()
+
+        # Should not raise (fail-open)
+        await publisher.publish(event)
+        await publisher.broadcast(event)
+
+        await bad_client.aclose()

--- a/tests/integration/test_sse_redis_streams.py
+++ b/tests/integration/test_sse_redis_streams.py
@@ -1,0 +1,430 @@
+"""Integration tests for SSE Redis Streams retention.
+
+Tests the RedisSSEPublisher and RedisSSESubscriber implementations
+with retention enabled, verifying Redis Streams storage and replay.
+
+Architecture:
+    - Tests against real Redis (not mocked)
+    - Uses test environment Redis
+    - Tests Redis Streams XADD and XRANGE
+    - Tests get_missed_events replay
+    - Uses fresh Redis connections per test
+
+Reference:
+    - src/infrastructure/sse/redis_publisher.py
+    - src/infrastructure/sse/redis_subscriber.py
+"""
+
+import logging
+
+import pytest
+import pytest_asyncio
+from uuid_extensions import uuid7
+
+from src.domain.events.sse_event import SSEEvent, SSEEventType
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def sse_publisher_with_retention(redis_test_client):
+    """Provide an SSE publisher with retention enabled."""
+    return RedisSSEPublisher(
+        redis_client=redis_test_client,
+        enable_retention=True,
+        retention_max_len=100,
+        retention_ttl_seconds=3600,
+        logger=logging.getLogger("test.sse.publisher"),
+    )
+
+
+@pytest_asyncio.fixture
+async def sse_subscriber_with_retention(redis_test_client):
+    """Provide an SSE subscriber with retention enabled."""
+    return RedisSSESubscriber(
+        redis_client=redis_test_client,
+        enable_retention=True,
+        logger=logging.getLogger("test.sse.subscriber"),
+    )
+
+
+def create_test_event(
+    event_type: SSEEventType = SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+    user_id=None,
+    data=None,
+) -> SSEEvent:
+    """Create an SSEEvent for testing."""
+    return SSEEvent(
+        event_type=event_type,
+        user_id=user_id or uuid7(),
+        data=data or {"test": "data"},
+    )
+
+
+# =============================================================================
+# Stream Storage Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestStreamStorage:
+    """Tests for Redis Streams event storage."""
+
+    @pytest.mark.asyncio
+    async def test_event_stored_in_stream_when_retention_enabled(
+        self, redis_test_client, sse_publisher_with_retention
+    ):
+        """Test event is stored in Redis Stream when retention enabled."""
+        user_id = uuid7()
+        event = create_test_event(
+            event_type=SSEEventType.SYNC_HOLDINGS_COMPLETED,
+            user_id=user_id,
+            data={"count": 10},
+        )
+
+        # Publish event (should store in stream)
+        await sse_publisher_with_retention.publish(event)
+
+        # Verify event is in stream
+        stream_key = SSEChannelKeys.user_stream(user_id)
+        entries = await redis_test_client.xrange(stream_key, "-", "+")
+
+        assert len(entries) >= 1
+
+        # Find our event
+        entry_id, entry_data = entries[-1]  # Last entry
+        assert entry_data.get("event_id") == str(event.event_id)
+        assert entry_data.get("event_type") == "sync.holdings.completed"
+
+    @pytest.mark.asyncio
+    async def test_multiple_events_stored_in_stream(
+        self, redis_test_client, sse_publisher_with_retention
+    ):
+        """Test multiple events are stored in order."""
+        user_id = uuid7()
+
+        events = [
+            create_test_event(
+                event_type=SSEEventType.SYNC_TRANSACTIONS_STARTED,
+                user_id=user_id,
+                data={"step": 1},
+            ),
+            create_test_event(
+                event_type=SSEEventType.SYNC_TRANSACTIONS_COMPLETED,
+                user_id=user_id,
+                data={"step": 2},
+            ),
+        ]
+
+        # Publish events
+        for event in events:
+            await sse_publisher_with_retention.publish(event)
+
+        # Verify both in stream
+        stream_key = SSEChannelKeys.user_stream(user_id)
+        entries = await redis_test_client.xrange(stream_key, "-", "+")
+
+        assert len(entries) >= 2
+
+        # Check order (should be in chronological order)
+        event_ids = [e[1].get("event_id") for e in entries[-2:]]
+        assert event_ids[0] == str(events[0].event_id)
+        assert event_ids[1] == str(events[1].event_id)
+
+    @pytest.mark.asyncio
+    async def test_stream_has_ttl_set(
+        self, redis_test_client, sse_publisher_with_retention
+    ):
+        """Test stream has TTL set after first event."""
+        user_id = uuid7()
+        event = create_test_event(user_id=user_id)
+
+        await sse_publisher_with_retention.publish(event)
+
+        stream_key = SSEChannelKeys.user_stream(user_id)
+        ttl = await redis_test_client.ttl(stream_key)
+
+        # TTL should be set (positive value)
+        assert ttl > 0
+        assert ttl <= 3600  # Our configured TTL
+
+
+# =============================================================================
+# Missed Events Replay Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestMissedEventsReplay:
+    """Tests for get_missed_events replay functionality."""
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_returns_events_after_last_id(
+        self,
+        redis_test_client,
+        sse_publisher_with_retention,
+        sse_subscriber_with_retention,
+    ):
+        """Test get_missed_events returns events after last_event_id."""
+        user_id = uuid7()
+
+        # Publish three events
+        event1 = create_test_event(
+            event_type=SSEEventType.IMPORT_STARTED,
+            user_id=user_id,
+            data={"step": 1},
+        )
+        event2 = create_test_event(
+            event_type=SSEEventType.IMPORT_PROGRESS,
+            user_id=user_id,
+            data={"step": 2},
+        )
+        event3 = create_test_event(
+            event_type=SSEEventType.IMPORT_COMPLETED,
+            user_id=user_id,
+            data={"step": 3},
+        )
+
+        for event in [event1, event2, event3]:
+            await sse_publisher_with_retention.publish(event)
+
+        # Get events after event1 (should return event2 and event3)
+        missed = await sse_subscriber_with_retention.get_missed_events(
+            user_id=user_id,
+            last_event_id=event1.event_id,
+        )
+
+        assert len(missed) == 2
+        assert missed[0].event_id == event2.event_id
+        assert missed[0].data == {"step": 2}
+        assert missed[1].event_id == event3.event_id
+        assert missed[1].data == {"step": 3}
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_empty_when_no_events_after(
+        self,
+        redis_test_client,
+        sse_publisher_with_retention,
+        sse_subscriber_with_retention,
+    ):
+        """Test get_missed_events returns empty when last_id is most recent."""
+        user_id = uuid7()
+
+        event = create_test_event(user_id=user_id)
+        await sse_publisher_with_retention.publish(event)
+
+        # Get events after the only event (should be empty)
+        missed = await sse_subscriber_with_retention.get_missed_events(
+            user_id=user_id,
+            last_event_id=event.event_id,
+        )
+
+        assert missed == []
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_empty_when_retention_disabled(
+        self, redis_test_client
+    ):
+        """Test get_missed_events returns empty when retention disabled."""
+        user_id = uuid7()
+
+        # Publisher with retention (stores events)
+        publisher = RedisSSEPublisher(
+            redis_client=redis_test_client,
+            enable_retention=True,
+        )
+
+        # Subscriber WITHOUT retention
+        subscriber = RedisSSESubscriber(
+            redis_client=redis_test_client,
+            enable_retention=False,
+        )
+
+        event = create_test_event(user_id=user_id)
+        await publisher.publish(event)
+
+        # Should return empty even though events exist
+        missed = await subscriber.get_missed_events(
+            user_id=user_id,
+            last_event_id=uuid7(),  # Any UUID
+        )
+
+        assert missed == []
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_with_category_filter(
+        self,
+        redis_test_client,
+        sse_publisher_with_retention,
+        sse_subscriber_with_retention,
+    ):
+        """Test get_missed_events respects category filter."""
+        user_id = uuid7()
+
+        # Publish events of different categories
+        sync_event = create_test_event(
+            event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            user_id=user_id,
+            data={"category": "data_sync"},
+        )
+        ai_event = create_test_event(
+            event_type=SSEEventType.AI_RESPONSE_COMPLETE,
+            user_id=user_id,
+            data={"category": "ai"},
+        )
+
+        # Need a starting point event
+        start_event = create_test_event(
+            event_type=SSEEventType.SYNC_ACCOUNTS_STARTED,
+            user_id=user_id,
+            data={"start": True},
+        )
+
+        for event in [start_event, sync_event, ai_event]:
+            await sse_publisher_with_retention.publish(event)
+
+        # Get only data_sync events
+        missed = await sse_subscriber_with_retention.get_missed_events(
+            user_id=user_id,
+            last_event_id=start_event.event_id,
+            categories=["data_sync"],
+        )
+
+        # Should only have the sync event
+        assert len(missed) == 1
+        assert missed[0].event_id == sync_event.event_id
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_unknown_last_id_returns_empty(
+        self,
+        redis_test_client,
+        sse_publisher_with_retention,
+        sse_subscriber_with_retention,
+    ):
+        """Test get_missed_events returns empty if last_id not found."""
+        user_id = uuid7()
+
+        event = create_test_event(user_id=user_id)
+        await sse_publisher_with_retention.publish(event)
+
+        # Use a UUID that doesn't exist in the stream
+        fake_last_id = uuid7()
+
+        missed = await sse_subscriber_with_retention.get_missed_events(
+            user_id=user_id,
+            last_event_id=fake_last_id,
+        )
+
+        # Should return empty since we never "found" the last_id
+        assert missed == []
+
+
+# =============================================================================
+# Stream Pruning Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestStreamPruning:
+    """Tests for stream MAXLEN pruning."""
+
+    @pytest.mark.asyncio
+    async def test_stream_respects_maxlen(self, redis_test_client):
+        """Test stream is pruned to respect MAXLEN."""
+        user_id = uuid7()
+
+        # Create publisher with small MAXLEN
+        publisher = RedisSSEPublisher(
+            redis_client=redis_test_client,
+            enable_retention=True,
+            retention_max_len=5,  # Small for testing
+        )
+
+        # Publish more than MAXLEN events
+        for i in range(10):
+            event = create_test_event(
+                user_id=user_id,
+                data={"index": i},
+            )
+            await publisher.publish(event)
+
+        # Check stream length (should be approximately MAXLEN)
+        stream_key = SSEChannelKeys.user_stream(user_id)
+        length = await redis_test_client.xlen(stream_key)
+
+        # MAXLEN ~ uses approximate trimming, so can be significantly over
+        # Redis approximate trimming typically keeps up to 2x MAXLEN
+        # but trims when stream exceeds threshold
+        assert length <= 15  # Approximate MAXLEN allows significant variance
+
+
+# =============================================================================
+# Error Recovery Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestErrorRecovery:
+    """Tests for error handling and recovery."""
+
+    @pytest.mark.asyncio
+    async def test_get_missed_events_handles_corrupted_entry(
+        self,
+        redis_test_client,
+        sse_subscriber_with_retention,
+    ):
+        """Test get_missed_events handles corrupted stream entries gracefully."""
+        user_id = uuid7()
+        stream_key = SSEChannelKeys.user_stream(user_id)
+
+        # Manually add a valid event
+        valid_event = create_test_event(user_id=user_id, data={"valid": True})
+        await redis_test_client.xadd(
+            stream_key,
+            {
+                "event_id": str(valid_event.event_id),
+                "event_type": valid_event.event_type.value,
+                "data": '{"valid": true}',
+                "occurred_at": valid_event.occurred_at.isoformat(),
+            },
+        )
+
+        # Manually add a corrupted entry (invalid JSON in data field)
+        await redis_test_client.xadd(
+            stream_key,
+            {
+                "event_id": str(uuid7()),
+                "event_type": "sync.accounts.completed",
+                "data": "not valid json {{{",
+                "occurred_at": valid_event.occurred_at.isoformat(),
+            },
+        )
+
+        # Add another valid event after the corrupted one
+        valid_event2 = create_test_event(user_id=user_id, data={"valid": "two"})
+        await redis_test_client.xadd(
+            stream_key,
+            {
+                "event_id": str(valid_event2.event_id),
+                "event_type": valid_event2.event_type.value,
+                "data": '{"valid": "two"}',
+                "occurred_at": valid_event2.occurred_at.isoformat(),
+            },
+        )
+
+        # Should skip corrupted entry and return valid ones
+        missed = await sse_subscriber_with_retention.get_missed_events(
+            user_id=user_id,
+            last_event_id=valid_event.event_id,
+        )
+
+        # Only the second valid event should be returned
+        # (corrupted is skipped, and we start after valid_event)
+        assert len(missed) == 1
+        assert missed[0].data == {"valid": "two"}

--- a/tests/unit/test_domain_sse_event.py
+++ b/tests/unit/test_domain_sse_event.py
@@ -1,0 +1,464 @@
+"""Unit tests for SSE event types and serialization.
+
+Tests cover:
+- SSEEvent dataclass creation and immutability
+- to_sse_format() wire format serialization
+- to_dict() / from_dict() round-trip
+- SSEEventType enum completeness
+- SSEEventCategory mapping
+- get_category_for_event_type() lookup
+
+Architecture:
+    - Unit tests for domain layer (no dependencies)
+    - Tests immutability and serialization
+    - Validates event type to category mapping completeness
+"""
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from uuid_extensions import uuid7
+
+from src.domain.events.sse_event import (
+    SSEEvent,
+    SSEEventCategory,
+    SSEEventType,
+    _EVENT_TYPE_TO_CATEGORY,
+    get_category_for_event_type,
+)
+
+
+# =============================================================================
+# Test Fixtures and Helpers
+# =============================================================================
+
+
+def create_sse_event(
+    event_type: SSEEventType = SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+    user_id: UUID | None = None,
+    data: dict[str, object] | None = None,
+    event_id: UUID | None = None,
+) -> SSEEvent:
+    """Helper to create SSEEvent instances for testing."""
+    return SSEEvent(
+        event_type=event_type,
+        user_id=user_id or uuid7(),
+        data=data or {"test_key": "test_value"},
+        event_id=event_id or uuid7(),
+    )
+
+
+# =============================================================================
+# SSEEventCategory Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEEventCategory:
+    """Test SSEEventCategory enum."""
+
+    def test_all_categories_defined(self):
+        """Test all expected categories are defined."""
+        expected = {
+            "data_sync",
+            "provider",
+            "ai",
+            "import",
+            "portfolio",
+            "security",
+        }
+        actual = {cat.value for cat in SSEEventCategory}
+        assert actual == expected
+
+    def test_categories_are_lowercase_snake_case(self):
+        """Test category values follow lowercase snake_case convention."""
+        for category in SSEEventCategory:
+            assert category.value == category.value.lower()
+            assert category.value.isidentifier() or "_" in category.value
+
+
+# =============================================================================
+# SSEEventType Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEEventType:
+    """Test SSEEventType enum."""
+
+    def test_event_types_count(self):
+        """Test total number of event types."""
+        # 9 data_sync + 4 provider + 3 ai + 4 import + 2 portfolio + 3 security = 25
+        assert len(SSEEventType) == 25
+
+    def test_event_types_use_dot_notation(self):
+        """Test all event types use dot notation (e.g., sync.accounts.started)."""
+        for event_type in SSEEventType:
+            assert "." in event_type.value, f"{event_type.name} should use dot notation"
+
+    def test_data_sync_events(self):
+        """Test data sync event types are defined."""
+        sync_events = [
+            SSEEventType.SYNC_ACCOUNTS_STARTED,
+            SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            SSEEventType.SYNC_ACCOUNTS_FAILED,
+            SSEEventType.SYNC_TRANSACTIONS_STARTED,
+            SSEEventType.SYNC_TRANSACTIONS_COMPLETED,
+            SSEEventType.SYNC_TRANSACTIONS_FAILED,
+            SSEEventType.SYNC_HOLDINGS_STARTED,
+            SSEEventType.SYNC_HOLDINGS_COMPLETED,
+            SSEEventType.SYNC_HOLDINGS_FAILED,
+        ]
+        for event in sync_events:
+            assert event.value.startswith("sync.")
+
+    def test_provider_events(self):
+        """Test provider event types are defined."""
+        provider_events = [
+            SSEEventType.PROVIDER_TOKEN_EXPIRING,
+            SSEEventType.PROVIDER_TOKEN_REFRESHED,
+            SSEEventType.PROVIDER_TOKEN_FAILED,
+            SSEEventType.PROVIDER_DISCONNECTED,
+        ]
+        for event in provider_events:
+            assert event.value.startswith("provider.")
+
+    def test_ai_events(self):
+        """Test AI event types are defined."""
+        ai_events = [
+            SSEEventType.AI_RESPONSE_CHUNK,
+            SSEEventType.AI_TOOL_EXECUTING,
+            SSEEventType.AI_RESPONSE_COMPLETE,
+        ]
+        for event in ai_events:
+            assert event.value.startswith("ai.")
+
+    def test_import_events(self):
+        """Test import event types are defined."""
+        import_events = [
+            SSEEventType.IMPORT_STARTED,
+            SSEEventType.IMPORT_PROGRESS,
+            SSEEventType.IMPORT_COMPLETED,
+            SSEEventType.IMPORT_FAILED,
+        ]
+        for event in import_events:
+            assert event.value.startswith("import.")
+
+    def test_portfolio_events(self):
+        """Test portfolio event types are defined."""
+        portfolio_events = [
+            SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+        ]
+        for event in portfolio_events:
+            assert event.value.startswith("portfolio.")
+
+    def test_security_events(self):
+        """Test security event types are defined."""
+        security_events = [
+            SSEEventType.SECURITY_SESSION_NEW,
+            SSEEventType.SECURITY_SESSION_SUSPICIOUS,
+            SSEEventType.SECURITY_SESSION_EXPIRING,
+        ]
+        for event in security_events:
+            assert event.value.startswith("security.")
+
+
+# =============================================================================
+# Category Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCategoryMapping:
+    """Test event type to category mapping."""
+
+    def test_all_event_types_have_category_mapping(self):
+        """CRITICAL: Every SSEEventType must have a category mapping."""
+        missing = []
+        for event_type in SSEEventType:
+            if event_type not in _EVENT_TYPE_TO_CATEGORY:
+                missing.append(event_type.name)
+
+        assert not missing, (
+            f"SSEEventTypes missing category mapping:\n"
+            f"{chr(10).join(f'  - {m}' for m in missing)}\n\n"
+            f"Fix: Add mapping to _EVENT_TYPE_TO_CATEGORY in sse_event.py"
+        )
+
+    def test_get_category_for_event_type_returns_correct_category(self):
+        """Test get_category_for_event_type returns expected categories."""
+        # Data sync events → DATA_SYNC
+        assert (
+            get_category_for_event_type(SSEEventType.SYNC_ACCOUNTS_STARTED)
+            == SSEEventCategory.DATA_SYNC
+        )
+        assert (
+            get_category_for_event_type(SSEEventType.SYNC_TRANSACTIONS_COMPLETED)
+            == SSEEventCategory.DATA_SYNC
+        )
+
+        # Provider events → PROVIDER
+        assert (
+            get_category_for_event_type(SSEEventType.PROVIDER_TOKEN_EXPIRING)
+            == SSEEventCategory.PROVIDER
+        )
+
+        # AI events → AI
+        assert (
+            get_category_for_event_type(SSEEventType.AI_RESPONSE_CHUNK)
+            == SSEEventCategory.AI
+        )
+
+        # Import events → IMPORT
+        assert (
+            get_category_for_event_type(SSEEventType.IMPORT_PROGRESS)
+            == SSEEventCategory.IMPORT
+        )
+
+        # Portfolio events → PORTFOLIO
+        assert (
+            get_category_for_event_type(SSEEventType.PORTFOLIO_BALANCE_UPDATED)
+            == SSEEventCategory.PORTFOLIO
+        )
+
+        # Security events → SECURITY
+        assert (
+            get_category_for_event_type(SSEEventType.SECURITY_SESSION_NEW)
+            == SSEEventCategory.SECURITY
+        )
+
+
+# =============================================================================
+# SSEEvent Creation Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEEventCreation:
+    """Test SSEEvent dataclass creation."""
+
+    def test_event_created_with_required_fields(self):
+        """Test SSEEvent can be created with required fields."""
+        user_id = uuid7()
+        event = SSEEvent(
+            event_type=SSEEventType.SYNC_ACCOUNTS_COMPLETED,
+            user_id=user_id,
+            data={"count": 5},
+        )
+        assert event.event_type == SSEEventType.SYNC_ACCOUNTS_COMPLETED
+        assert event.user_id == user_id
+        assert event.data == {"count": 5}
+
+    def test_event_generates_uuid7_event_id_by_default(self):
+        """Test event_id is auto-generated as UUID v7."""
+        event = create_sse_event()
+        assert isinstance(event.event_id, UUID)
+        # UUID v7 starts with version nibble 7
+        assert (event.event_id.int >> 76) & 0xF == 7
+
+    def test_event_generates_utc_timestamp_by_default(self):
+        """Test occurred_at is auto-generated as UTC datetime."""
+        before = datetime.now(UTC)
+        event = create_sse_event()
+        after = datetime.now(UTC)
+
+        assert before <= event.occurred_at <= after
+        assert event.occurred_at.tzinfo is not None
+
+    def test_event_is_immutable(self):
+        """Test SSEEvent is frozen (immutable)."""
+        event = create_sse_event()
+        with pytest.raises(AttributeError):
+            event.event_type = SSEEventType.AI_RESPONSE_CHUNK  # type: ignore
+
+    def test_event_category_property(self):
+        """Test category property returns correct category."""
+        event = create_sse_event(event_type=SSEEventType.PROVIDER_DISCONNECTED)
+        assert event.category == SSEEventCategory.PROVIDER
+
+
+# =============================================================================
+# SSE Wire Format Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEWireFormat:
+    """Test to_sse_format() wire format serialization."""
+
+    def test_to_sse_format_contains_event_id(self):
+        """Test SSE format includes event ID."""
+        event_id = uuid7()
+        event = create_sse_event(event_id=event_id)
+        formatted = event.to_sse_format()
+
+        assert f"id: {event_id}" in formatted
+
+    def test_to_sse_format_contains_event_type(self):
+        """Test SSE format includes event type."""
+        event = create_sse_event(event_type=SSEEventType.AI_RESPONSE_CHUNK)
+        formatted = event.to_sse_format()
+
+        assert "event: ai.response.chunk" in formatted
+
+    def test_to_sse_format_contains_json_data(self):
+        """Test SSE format includes JSON data."""
+        event = create_sse_event(data={"key": "value", "count": 42})
+        formatted = event.to_sse_format()
+
+        # Extract the data line
+        for line in formatted.split("\n"):
+            if line.startswith("data: "):
+                json_str = line[6:]  # Remove "data: " prefix
+                parsed = json.loads(json_str)
+                assert parsed == {"key": "value", "count": 42}
+                return
+
+        pytest.fail("data line not found in SSE format")
+
+    def test_to_sse_format_ends_with_double_newline(self):
+        """Test SSE message ends with double newline (per spec)."""
+        event = create_sse_event()
+        formatted = event.to_sse_format()
+
+        assert formatted.endswith("\n\n")
+
+    def test_to_sse_format_field_order(self):
+        """Test SSE format field order: id, event, data."""
+        event_id = uuid7()
+        event = create_sse_event(
+            event_id=event_id,
+            event_type=SSEEventType.IMPORT_STARTED,
+            data={"file": "test.qfx"},
+        )
+        formatted = event.to_sse_format()
+        lines = formatted.strip().split("\n")
+
+        assert lines[0].startswith("id:")
+        assert lines[1].startswith("event:")
+        assert lines[2].startswith("data:")
+
+    def test_to_sse_format_handles_complex_data(self):
+        """Test SSE format handles nested JSON data."""
+        complex_data: dict[str, object] = {
+            "nested": {"key": "value"},
+            "list": [1, 2, 3],
+            "unicode": "日本語",
+            "null": None,
+        }
+        event = create_sse_event(data=complex_data)
+        formatted = event.to_sse_format()
+
+        # Extract and parse data
+        for line in formatted.split("\n"):
+            if line.startswith("data: "):
+                parsed = json.loads(line[6:])
+                assert parsed == complex_data
+                return
+
+        pytest.fail("data line not found")
+
+
+# =============================================================================
+# Dictionary Serialization Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDictionarySerialization:
+    """Test to_dict() and from_dict() methods."""
+
+    def test_to_dict_contains_all_fields(self):
+        """Test to_dict includes all event fields."""
+        event = create_sse_event()
+        d = event.to_dict()
+
+        assert "event_id" in d
+        assert "event_type" in d
+        assert "user_id" in d
+        assert "data" in d
+        assert "occurred_at" in d
+
+    def test_to_dict_serializes_uuid_as_string(self):
+        """Test UUIDs are serialized as strings."""
+        event_id = uuid7()
+        user_id = uuid7()
+        event = create_sse_event(event_id=event_id, user_id=user_id)
+        d = event.to_dict()
+
+        assert d["event_id"] == str(event_id)
+        assert d["user_id"] == str(user_id)
+
+    def test_to_dict_serializes_event_type_as_string(self):
+        """Test event_type is serialized as string value."""
+        event = create_sse_event(event_type=SSEEventType.SECURITY_SESSION_NEW)
+        d = event.to_dict()
+
+        assert d["event_type"] == "security.session.new"
+
+    def test_to_dict_serializes_datetime_as_iso(self):
+        """Test occurred_at is serialized as ISO format."""
+        event = create_sse_event()
+        d = event.to_dict()
+
+        # Should be parseable as ISO format
+        parsed = datetime.fromisoformat(d["occurred_at"])
+        assert parsed == event.occurred_at
+
+    def test_from_dict_creates_equivalent_event(self):
+        """Test from_dict creates equivalent SSEEvent."""
+        original = create_sse_event()
+        d = original.to_dict()
+        restored = SSEEvent.from_dict(d)
+
+        assert restored.event_id == original.event_id
+        assert restored.event_type == original.event_type
+        assert restored.user_id == original.user_id
+        assert restored.data == original.data
+        assert restored.occurred_at == original.occurred_at
+
+    def test_round_trip_preserves_all_data(self):
+        """Test to_dict/from_dict round-trip preserves all data."""
+        original = SSEEvent(
+            event_type=SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+            user_id=uuid7(),
+            data={"account_id": "abc", "holdings_count": 15},
+        )
+        restored = SSEEvent.from_dict(original.to_dict())
+
+        # Equal in all fields
+        assert original.event_id == restored.event_id
+        assert original.event_type == restored.event_type
+        assert original.user_id == restored.user_id
+        assert original.data == restored.data
+        # Timestamps should be equal (may differ slightly due to precision)
+        assert (
+            abs((original.occurred_at - restored.occurred_at).total_seconds()) < 0.001
+        )
+
+    def test_from_dict_raises_on_invalid_event_type(self):
+        """Test from_dict raises ValueError for invalid event type."""
+        d = {
+            "event_id": str(uuid7()),
+            "event_type": "invalid.event.type",
+            "user_id": str(uuid7()),
+            "data": {},
+            "occurred_at": datetime.now(UTC).isoformat(),
+        }
+        with pytest.raises(ValueError):
+            SSEEvent.from_dict(d)
+
+    def test_from_dict_raises_on_missing_field(self):
+        """Test from_dict raises KeyError for missing required field."""
+        d = {
+            "event_id": str(uuid7()),
+            # Missing event_type
+            "user_id": str(uuid7()),
+            "data": {},
+            "occurred_at": datetime.now(UTC).isoformat(),
+        }
+        with pytest.raises(KeyError):
+            SSEEvent.from_dict(d)

--- a/tests/unit/test_domain_sse_registry_compliance.py
+++ b/tests/unit/test_domain_sse_registry_compliance.py
@@ -1,0 +1,264 @@
+"""SSE Registry Compliance Tests - FAIL FAST on drift.
+
+These tests verify the SSE Event Registry remains synchronized with:
+- SSEEventType enum (all types must have metadata)
+- Category consistency (registry category must match enum mapping)
+- Statistics accuracy (counts must match actual data)
+
+Tests FAIL if:
+- SSEEventType exists but has no metadata in SSE_EVENT_REGISTRY
+- Registry metadata category doesn't match _EVENT_TYPE_TO_CATEGORY
+- Statistics counts are inaccurate
+
+This ensures the SSE registry remains the single source of truth.
+
+Reference:
+    - src/domain/events/sse_event.py (SSEEventType, _EVENT_TYPE_TO_CATEGORY)
+    - src/domain/events/sse_registry.py (SSE_EVENT_REGISTRY)
+"""
+
+import pytest
+
+from src.domain.events.sse_event import (
+    SSEEventCategory,
+    SSEEventType,
+    get_category_for_event_type,
+)
+from src.domain.events.sse_registry import (
+    SSE_EVENT_REGISTRY,
+    get_all_sse_event_types,
+    get_events_by_category,
+    get_registry_statistics,
+    get_sse_event_metadata,
+)
+
+
+# =============================================================================
+# Registry Completeness Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRegistryCompleteness:
+    """Verify SSE registry is complete and accurate."""
+
+    def test_registry_not_empty(self):
+        """Registry must contain event metadata."""
+        assert len(SSE_EVENT_REGISTRY) > 0, "SSE_EVENT_REGISTRY is empty!"
+
+    def test_all_sse_event_types_have_registry_metadata(self):
+        """CRITICAL: Every SSEEventType must have metadata in SSE_EVENT_REGISTRY.
+
+        This test FAILS if:
+        - SSEEventType enum has a value
+        - But SSE_EVENT_REGISTRY has no metadata for it
+
+        Fix: Add missing metadata to SSE_EVENT_REGISTRY in sse_registry.py
+        """
+        registered_types = {m.event_type for m in SSE_EVENT_REGISTRY}
+        missing = []
+
+        for event_type in SSEEventType:
+            if event_type not in registered_types:
+                missing.append(event_type.name)
+
+        assert not missing, (
+            f"\n❌ SSE REGISTRY COMPLIANCE FAILURE: Event types missing metadata\n\n"
+            f"Missing from SSE_EVENT_REGISTRY:\n"
+            f"{chr(10).join(f'  - {m}' for m in missing)}\n\n"
+            f"Fix: Add SSEEventMetadata entries to src/domain/events/sse_registry.py"
+        )
+
+    def test_all_metadata_has_required_fields(self):
+        """Every metadata entry must have complete required fields."""
+        for meta in SSE_EVENT_REGISTRY:
+            assert meta.event_type is not None, "event_type missing"
+            assert meta.category is not None, "category missing"
+            assert meta.description, "description is empty"
+            # payload_fields can be empty but must exist
+            assert meta.payload_fields is not None
+
+
+# =============================================================================
+# Category Consistency Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCategoryConsistency:
+    """Verify category mappings are consistent across modules."""
+
+    def test_registry_category_matches_event_type_mapping(self):
+        """CRITICAL: Registry category must match _EVENT_TYPE_TO_CATEGORY.
+
+        This test FAILS if:
+        - SSE_EVENT_REGISTRY says event is in category X
+        - But _EVENT_TYPE_TO_CATEGORY says it's in category Y
+
+        Fix: Ensure both sources agree on category assignment.
+        """
+        mismatches = []
+
+        for meta in SSE_EVENT_REGISTRY:
+            expected_category = get_category_for_event_type(meta.event_type)
+            if meta.category != expected_category:
+                mismatches.append(
+                    f"{meta.event_type.name}: registry={meta.category.value}, "
+                    f"mapping={expected_category.value}"
+                )
+
+        assert not mismatches, (
+            f"\n❌ SSE REGISTRY COMPLIANCE FAILURE: Category mismatches\n\n"
+            f"The following events have inconsistent category assignments:\n"
+            f"{chr(10).join(f'  - {m}' for m in mismatches)}\n\n"
+            f"Fix: Ensure SSE_EVENT_REGISTRY and _EVENT_TYPE_TO_CATEGORY agree"
+        )
+
+
+# =============================================================================
+# Helper Function Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRegistryHelpers:
+    """Test SSE registry helper functions."""
+
+    def test_get_sse_event_metadata_returns_correct_metadata(self):
+        """Test get_sse_event_metadata returns matching metadata."""
+        meta = get_sse_event_metadata(SSEEventType.SYNC_ACCOUNTS_COMPLETED)
+        assert meta is not None
+        assert meta.event_type == SSEEventType.SYNC_ACCOUNTS_COMPLETED
+        assert meta.category == SSEEventCategory.DATA_SYNC
+
+    def test_get_sse_event_metadata_returns_none_for_missing(self):
+        """Test get_sse_event_metadata returns None for unregistered type.
+
+        Note: This test creates a mock scenario since all types should be
+        registered. Testing with a valid but conceptually "missing" lookup.
+        """
+        # All types should be registered, so we verify that
+        for event_type in SSEEventType:
+            meta = get_sse_event_metadata(event_type)
+            assert meta is not None, f"Missing metadata for {event_type.name}"
+
+    def test_get_events_by_category_returns_correct_events(self):
+        """Test get_events_by_category filters correctly."""
+        data_sync_events = get_events_by_category(SSEEventCategory.DATA_SYNC)
+
+        # Should have 9 data sync events
+        assert len(data_sync_events) == 9
+
+        # All should be DATA_SYNC category
+        for meta in data_sync_events:
+            assert meta.category == SSEEventCategory.DATA_SYNC
+
+    def test_get_all_sse_event_types_returns_all_types(self):
+        """Test get_all_sse_event_types returns all registered types."""
+        types = get_all_sse_event_types()
+
+        # Should match registry length
+        assert len(types) == len(SSE_EVENT_REGISTRY)
+
+        # Should contain all SSEEventType values
+        for meta in SSE_EVENT_REGISTRY:
+            assert meta.event_type in types
+
+
+# =============================================================================
+# Statistics Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRegistryStatistics:
+    """Verify registry statistics are accurate."""
+
+    def test_statistics_total_event_types_accurate(self):
+        """Test total_event_types matches actual registry length."""
+        stats = get_registry_statistics()
+        assert stats["total_event_types"] == len(SSE_EVENT_REGISTRY)
+
+    def test_statistics_category_counts_accurate(self):
+        """Test category counts match actual data."""
+        stats = get_registry_statistics()
+        by_category = stats["by_category"]
+        assert isinstance(by_category, dict)
+
+        # Verify counts match helper function results
+        for category in SSEEventCategory:
+            expected_count = len(get_events_by_category(category))
+            actual_count = by_category.get(category.value, 0)
+            assert actual_count == expected_count, (
+                f"Category {category.value} count mismatch: "
+                f"stats={actual_count}, actual={expected_count}"
+            )
+
+    def test_statistics_expected_counts(self):
+        """Test expected counts for each category."""
+        stats = get_registry_statistics()
+        by_category = stats["by_category"]
+        assert isinstance(by_category, dict)
+
+        # Expected counts based on sse_event.py event definitions
+        expected = {
+            "data_sync": 9,
+            "provider": 4,
+            "ai": 3,
+            "import": 4,
+            "portfolio": 2,
+            "security": 3,
+        }
+
+        for cat_name, expected_count in expected.items():
+            actual_count = by_category.get(cat_name, 0)
+            assert actual_count == expected_count, (
+                f"Category {cat_name}: expected {expected_count}, got {actual_count}"
+            )
+
+    def test_statistics_total_equals_sum_of_categories(self):
+        """Test total equals sum of all category counts."""
+        stats = get_registry_statistics()
+        total = stats["total_event_types"]
+        by_category = stats["by_category"]
+        assert isinstance(by_category, dict)
+        category_sum = sum(by_category.values())
+
+        assert total == category_sum, (
+            f"Total ({total}) != sum of categories ({category_sum})"
+        )
+
+
+# =============================================================================
+# No Duplicate Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestNoDuplicates:
+    """Verify no duplicate entries in registry."""
+
+    def test_no_duplicate_event_types_in_registry(self):
+        """Each event type should appear exactly once in registry."""
+        event_types = [m.event_type for m in SSE_EVENT_REGISTRY]
+        duplicates = [t for t in event_types if event_types.count(t) > 1]
+
+        assert not duplicates, (
+            f"Duplicate event types in SSE_EVENT_REGISTRY: {set(duplicates)}"
+        )
+
+    def test_no_duplicate_descriptions(self):
+        """Event descriptions should be unique (prevent copy-paste errors)."""
+        descriptions = [m.description for m in SSE_EVENT_REGISTRY]
+        seen: set[str] = set()
+        duplicates = []
+
+        for desc in descriptions:
+            if desc in seen:
+                duplicates.append(desc)
+            seen.add(desc)
+
+        assert not duplicates, (
+            f"Duplicate descriptions found (possible copy-paste error):\n"
+            f"{chr(10).join(f'  - {d}' for d in duplicates)}"
+        )

--- a/tests/unit/test_infrastructure_sse_channel_keys.py
+++ b/tests/unit/test_infrastructure_sse_channel_keys.py
@@ -1,0 +1,302 @@
+"""Unit tests for SSE Redis channel key generation.
+
+Tests cover:
+- SSEChannelKeys.user_channel() - per-user pub/sub channel
+- SSEChannelKeys.broadcast_channel() - global broadcast channel
+- SSEChannelKeys.user_stream() - Redis Streams key for retention
+- SSEChannelKeys.parse_user_id_from_channel() - reverse lookup
+- SSEChannelKeys.is_broadcast_channel() - channel type detection
+
+Architecture:
+    - Unit tests for infrastructure layer (no Redis connection)
+    - Tests key format consistency
+    - Validates parsing and detection logic
+"""
+
+from uuid import UUID
+
+import pytest
+from uuid_extensions import uuid7
+
+from src.core.constants import SSE_CHANNEL_PREFIX
+from src.infrastructure.sse.channel_keys import SSEChannelKeys
+
+
+# =============================================================================
+# User Channel Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUserChannel:
+    """Test SSEChannelKeys.user_channel()."""
+
+    def test_user_channel_format(self):
+        """Test user channel uses correct format."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        expected = f"{SSE_CHANNEL_PREFIX}:user:{user_id}"
+        assert channel == expected
+
+    def test_user_channel_uses_sse_prefix(self):
+        """Test user channel starts with SSE prefix from constants."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        assert channel.startswith(f"{SSE_CHANNEL_PREFIX}:")
+
+    def test_user_channel_includes_user_id(self):
+        """Test user channel contains the user ID."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        assert str(user_id) in channel
+
+    def test_different_users_get_different_channels(self):
+        """Test each user gets a unique channel."""
+        user1 = uuid7()
+        user2 = uuid7()
+
+        channel1 = SSEChannelKeys.user_channel(user1)
+        channel2 = SSEChannelKeys.user_channel(user2)
+
+        assert channel1 != channel2
+
+
+# =============================================================================
+# Broadcast Channel Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestBroadcastChannel:
+    """Test SSEChannelKeys.broadcast_channel()."""
+
+    def test_broadcast_channel_format(self):
+        """Test broadcast channel uses correct format."""
+        channel = SSEChannelKeys.broadcast_channel()
+
+        expected = f"{SSE_CHANNEL_PREFIX}:broadcast"
+        assert channel == expected
+
+    def test_broadcast_channel_uses_sse_prefix(self):
+        """Test broadcast channel starts with SSE prefix."""
+        channel = SSEChannelKeys.broadcast_channel()
+
+        assert channel.startswith(f"{SSE_CHANNEL_PREFIX}:")
+
+    def test_broadcast_channel_is_deterministic(self):
+        """Test broadcast channel is always the same."""
+        channel1 = SSEChannelKeys.broadcast_channel()
+        channel2 = SSEChannelKeys.broadcast_channel()
+
+        assert channel1 == channel2
+
+
+# =============================================================================
+# User Stream Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUserStream:
+    """Test SSEChannelKeys.user_stream()."""
+
+    def test_user_stream_format(self):
+        """Test user stream uses correct format."""
+        user_id = uuid7()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        expected = f"{SSE_CHANNEL_PREFIX}:stream:user:{user_id}"
+        assert stream == expected
+
+    def test_user_stream_uses_sse_prefix(self):
+        """Test user stream starts with SSE prefix."""
+        user_id = uuid7()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        assert stream.startswith(f"{SSE_CHANNEL_PREFIX}:")
+
+    def test_user_stream_includes_stream_segment(self):
+        """Test user stream includes 'stream' segment."""
+        user_id = uuid7()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        assert ":stream:" in stream
+
+    def test_user_stream_different_from_user_channel(self):
+        """Test user stream is distinct from user channel."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        assert channel != stream
+        assert "stream" not in channel
+        assert "stream" in stream
+
+
+# =============================================================================
+# Parse User ID Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestParseUserIdFromChannel:
+    """Test SSEChannelKeys.parse_user_id_from_channel()."""
+
+    def test_parse_valid_user_channel(self):
+        """Test parsing valid user channel returns UUID."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        parsed = SSEChannelKeys.parse_user_id_from_channel(channel)
+
+        assert parsed == user_id
+
+    def test_parse_broadcast_channel_returns_none(self):
+        """Test parsing broadcast channel returns None."""
+        channel = SSEChannelKeys.broadcast_channel()
+
+        parsed = SSEChannelKeys.parse_user_id_from_channel(channel)
+
+        assert parsed is None
+
+    def test_parse_user_stream_returns_none(self):
+        """Test parsing user stream returns None (different format)."""
+        user_id = uuid7()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        parsed = SSEChannelKeys.parse_user_id_from_channel(stream)
+
+        assert parsed is None
+
+    def test_parse_invalid_channel_format_returns_none(self):
+        """Test parsing invalid channel format returns None."""
+        invalid_channels = [
+            "invalid",
+            "sse",
+            "sse:",
+            "sse:user",
+            "sse:user:",
+            f"{SSE_CHANNEL_PREFIX}:other:something",
+            "wrong:prefix:user:abc123",
+        ]
+
+        for channel in invalid_channels:
+            parsed = SSEChannelKeys.parse_user_id_from_channel(channel)
+            assert parsed is None, f"Should return None for: {channel}"
+
+    def test_parse_invalid_uuid_returns_none(self):
+        """Test parsing channel with invalid UUID returns None."""
+        channel = f"{SSE_CHANNEL_PREFIX}:user:not-a-valid-uuid"
+
+        parsed = SSEChannelKeys.parse_user_id_from_channel(channel)
+
+        assert parsed is None
+
+    def test_parse_returns_uuid_type(self):
+        """Test parse returns proper UUID type."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        parsed = SSEChannelKeys.parse_user_id_from_channel(channel)
+
+        assert isinstance(parsed, UUID)
+
+
+# =============================================================================
+# Is Broadcast Channel Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIsBroadcastChannel:
+    """Test SSEChannelKeys.is_broadcast_channel()."""
+
+    def test_broadcast_channel_returns_true(self):
+        """Test broadcast channel is correctly identified."""
+        channel = SSEChannelKeys.broadcast_channel()
+
+        assert SSEChannelKeys.is_broadcast_channel(channel) is True
+
+    def test_user_channel_returns_false(self):
+        """Test user channel is not broadcast."""
+        user_id = uuid7()
+        channel = SSEChannelKeys.user_channel(user_id)
+
+        assert SSEChannelKeys.is_broadcast_channel(channel) is False
+
+    def test_user_stream_returns_false(self):
+        """Test user stream is not broadcast."""
+        user_id = uuid7()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        assert SSEChannelKeys.is_broadcast_channel(stream) is False
+
+    def test_invalid_channel_returns_false(self):
+        """Test invalid channels are not broadcast."""
+        invalid_channels = [
+            "sse:broadcast:extra",
+            "broadcast",
+            "sse:broadcasts",
+            "",
+        ]
+
+        for channel in invalid_channels:
+            assert SSEChannelKeys.is_broadcast_channel(channel) is False, (
+                f"Should return False for: {channel}"
+            )
+
+
+# =============================================================================
+# Consistency Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestKeyConsistency:
+    """Test key generation consistency and correctness."""
+
+    def test_prefix_from_constants(self):
+        """Test all keys use prefix from constants.py."""
+        user_id = uuid7()
+
+        user_ch = SSEChannelKeys.user_channel(user_id)
+        broadcast = SSEChannelKeys.broadcast_channel()
+        stream = SSEChannelKeys.user_stream(user_id)
+
+        # All should start with the constant prefix
+        for key in [user_ch, broadcast, stream]:
+            assert key.startswith(SSE_CHANNEL_PREFIX), (
+                f"Key should start with '{SSE_CHANNEL_PREFIX}': {key}"
+            )
+
+    def test_no_hardcoded_prefix(self):
+        """Test prefix is not hardcoded (uses constant)."""
+        # This test verifies the DRY principle - prefix should come from constant
+        # If SSE_CHANNEL_PREFIX is "sse", this will pass
+        # If someone hardcodes "sse:" instead of using the constant, this might
+        # still pass but the consistency with other code would be broken
+
+        assert SSE_CHANNEL_PREFIX == "sse", (
+            "Expected SSE_CHANNEL_PREFIX to be 'sse' - update test if changed"
+        )
+
+    def test_keys_are_redis_safe(self):
+        """Test generated keys are valid Redis key names."""
+        user_id = uuid7()
+
+        keys = [
+            SSEChannelKeys.user_channel(user_id),
+            SSEChannelKeys.broadcast_channel(),
+            SSEChannelKeys.user_stream(user_id),
+        ]
+
+        for key in keys:
+            # Redis keys can be any binary string, but we use ASCII-safe chars
+            assert key.isascii(), f"Key should be ASCII: {key}"
+            # No spaces
+            assert " " not in key, f"Key should not contain spaces: {key}"
+            # No newlines
+            assert "\n" not in key, f"Key should not contain newlines: {key}"

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "dashtam"
-version = "1.8.2"
+version = "1.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

This PR implements the **SSE (Server-Sent Events) Foundation Infrastructure** for real-time server-to-client event streaming in Dashtam.

## Changes

### Domain Layer
- `SSEEvent` dataclass with wire format serialization (`to_sse_format()`, `to_dict()`, `from_dict()`)
- `SSEEventType` enum (25 event types across 6 categories)
- `SSEEventCategory` enum (data_sync, provider, ai, import, portfolio, security)
- `SSEEventMetadata` and `SSE_EVENT_REGISTRY` (registry pattern, 25 entries)
- `SSEPublisherProtocol` and `SSESubscriberProtocol` (hexagonal ports)

### Infrastructure Layer
- `RedisSSEPublisher` - Publishes events via Redis pub/sub, optional Streams retention
- `RedisSSESubscriber` - Async generator subscription with category filtering
- `SSEChannelKeys` - Centralized channel/stream key generation
- `SSEEventHandler` - Subscribes to domain events, transforms to SSE events

### Presentation Layer
- `GET /api/v1/events` endpoint with StreamingResponse
- Route registry entry with `RateLimitPolicy.SSE_STREAM`
- Authentication via existing Bearer token

### Container & Configuration
- `get_sse_publisher()` - App-scoped singleton
- `get_sse_subscriber()` - Request-scoped factory
- 6 constants in `src/core/constants.py`
- `sse_enable_retention` setting in `config.py`

## Testing
- 69 unit tests (domain events, registry compliance)
- 25 integration tests (Redis pub/sub, Streams retention)
- 12 API tests (endpoint authentication, headers, streaming)
- **All 2,550 tests pass** with 88% coverage

## Documentation
- `docs/architecture/sse-architecture.md` (1400+ lines)
- `docs/architecture/sse-registry.md` (300+ lines)
- Updated CHANGELOG.md with v1.9.0 release notes

## Version
`1.8.2` → `1.9.0` (MINOR: new feature)

---

Co-Authored-By: Warp <agent@warp.dev>