### PR TITLE
feat(sse): Provider health SSE mappings and badge fixes (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Dashtam
+# dashtam-api
 
 > Secure financial data aggregation API with hexagonal architecture, CQRS, and domain-driven design
 
-[![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://faiyaz7283.github.io/Dashtam/)
-[![Test Suite](https://github.com/faiyaz7283/Dashtam/workflows/Test%20Suite/badge.svg)](https://github.com/faiyaz7283/Dashtam/actions)
-[![codecov](https://codecov.io/gh/faiyaz7283/Dashtam/branch/development/graph/badge.svg)](https://codecov.io/gh/faiyaz7283/Dashtam)
+[![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://faiyaz7283.github.io/dashtam-api/)
+[![Test Suite](https://github.com/faiyaz7283/dashtam-api/workflows/Test%20Suite/badge.svg)](https://github.com/faiyaz7283/dashtam-api/actions)
+[![codecov](https://codecov.io/gh/faiyaz7283/dashtam-api/branch/development/graph/badge.svg)](https://codecov.io/gh/faiyaz7283/dashtam-api)
 [![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.128+-green.svg)](https://fastapi.tiangolo.com)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/env/.env.ci.example
+++ b/env/.env.ci.example
@@ -56,6 +56,14 @@ CACHE_SCHWAB_TTL=300        # Schwab API response cache: 5 minutes
 CACHE_ACCOUNTS_TTL=300      # Account list cache: 5 minutes
 CACHE_SECURITY_TTL=60       # Security config cache: 1 minute
 
+# Background Jobs Configuration (dashtam-jobs)
+# The API monitors the dashtam-jobs background worker service via shared Redis.
+# In CI, uses same Redis instance as cache (REDIS_URL fallback).
+#
+# JOBS_QUEUE_NAME must match dashtam-jobs service configuration.
+# JOBS_REDIS_URL=redis://redis:6379/1  # Optional: use different DB
+JOBS_QUEUE_NAME=dashtam:jobs
+
 # Security Configuration (CI test keys - never use in production)
 SECRET_KEY=ci-test-secret-key-never-use-in-production-32-chars-long!
 ENCRYPTION_KEY=ci-key-for-encryption-test-32!@#

--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -17,6 +17,22 @@ CACHE_SCHWAB_TTL=300        # Schwab API response cache: 5 minutes
 CACHE_ACCOUNTS_TTL=300      # Account list cache: 5 minutes
 CACHE_SECURITY_TTL=60       # Security config cache: 1 minute
 
+# Background Jobs Configuration (dashtam-jobs)
+# The API monitors the dashtam-jobs background worker service via shared Redis.
+# Both services use the same queue name to communicate.
+#
+# JOBS_REDIS_URL (optional):
+#   - If not set, falls back to REDIS_URL (recommended for development)
+#   - For production, consider a dedicated Redis instance for job isolation
+#   - Example: JOBS_REDIS_URL=redis://redis-jobs:6379/0
+#
+# JOBS_QUEUE_NAME (required):
+#   - Must match the queue name in dashtam-jobs service
+#   - API uses this to query queue length (LLEN) and job results
+#
+# JOBS_REDIS_URL=redis://redis:6379/0
+JOBS_QUEUE_NAME=dashtam:jobs
+
 # Application Configuration
 APP_NAME=Dashtam
 ENVIRONMENT=development

--- a/env/.env.prod.example
+++ b/env/.env.prod.example
@@ -17,6 +17,23 @@ CACHE_SCHWAB_TTL=300        # Schwab API response cache: 5 minutes
 CACHE_ACCOUNTS_TTL=300      # Account list cache: 5 minutes
 CACHE_SECURITY_TTL=60       # Security config cache: 1 minute
 
+# Background Jobs Configuration (dashtam-jobs)
+# The API monitors the dashtam-jobs background worker service via shared Redis.
+# Both services use the same queue name to communicate.
+#
+# JOBS_REDIS_URL (recommended for production):
+#   - Use a dedicated Redis instance for job queue isolation
+#   - Prevents cache traffic from affecting job queue throughput
+#   - Requires adding a redis-jobs service to docker-compose
+#   - Example: JOBS_REDIS_URL=redis://redis-jobs:6379/0
+#
+# JOBS_QUEUE_NAME (required):
+#   - Must match the queue name in dashtam-jobs service
+#   - API uses this to query queue length (LLEN) and job results
+#
+# JOBS_REDIS_URL=redis://redis-jobs:6379/0
+JOBS_QUEUE_NAME=dashtam:jobs
+
 # SSE (Server-Sent Events) Configuration
 # Enable retention for Last-Event-ID replay support
 # Production MUST be true for reconnection replay (network drops, mobile, etc.)

--- a/env/.env.test.example
+++ b/env/.env.test.example
@@ -89,6 +89,14 @@ CACHE_SCHWAB_TTL=300        # Schwab API response cache: 5 minutes
 CACHE_ACCOUNTS_TTL=300      # Account list cache: 5 minutes
 CACHE_SECURITY_TTL=60       # Security config cache: 1 minute
 
+# Background Jobs Configuration (dashtam-jobs)
+# The API monitors the dashtam-jobs background worker service via shared Redis.
+# In tests, uses same Redis instance as cache (REDIS_URL fallback).
+#
+# JOBS_QUEUE_NAME must match dashtam-jobs service configuration.
+# JOBS_REDIS_URL=redis://redis:6379/1  # Optional: use different DB
+JOBS_QUEUE_NAME=dashtam:jobs
+
 # Test-specific flags
 TESTING=true
 DISABLE_EXTERNAL_CALLS=true

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -160,6 +160,18 @@ class Settings(BaseSettings):
         description="Security config (token versions) cache TTL in seconds (default: 1 minute)",
     )
 
+    # Background Jobs configuration (dashtam-jobs)
+    jobs_redis_url: str | None = Field(
+        default=None,
+        description="Redis URL for background jobs service. "
+        "If not set, falls back to redis_url. "
+        "Jobs use separate queue (dashtam:jobs) for task scheduling.",
+    )
+    jobs_queue_name: str = Field(
+        default="dashtam:jobs",
+        description="Redis queue name for background jobs (must match dashtam-jobs config)",
+    )
+
     # SSE (Server-Sent Events) configuration
     sse_enable_retention: bool = Field(
         default=False,

--- a/src/core/container/__init__.py
+++ b/src/core/container/__init__.py
@@ -45,6 +45,7 @@ from src.core.container.infrastructure import (
     get_device_enricher,
     get_email_service,
     get_encryption_service,
+    get_jobs_monitor,
     get_location_enricher,
     get_logger,
     get_password_reset_token_service,
@@ -114,6 +115,7 @@ __all__ = [
     "get_refresh_token_service",
     "get_password_reset_token_service",
     "get_provider_factory",
+    "get_jobs_monitor",
     # Events
     "get_event_bus",
     # SSE

--- a/src/core/container/handler_factory.py
+++ b/src/core/container/handler_factory.py
@@ -132,16 +132,15 @@ def get_type_name(annotation: Any) -> str:
 def analyze_handler_dependencies(handler_class: type) -> dict[str, dict[str, Any]]:
     """Analyze handler __init__ to discover dependencies.
 
+    Introspects the handler's ``__init__`` method to discover required
+    dependencies and their types.
+
     Args:
         handler_class: Handler class to analyze.
 
     Returns:
-        Dict mapping param name -> {type_name, annotation, is_optional}.
-
-    Example:
-        >>> deps = analyze_handler_dependencies(RegisterUserHandler)
-        >>> deps['user_repo']['type_name']
-        'UserRepository'
+        Dict mapping parameter names to dependency info dicts.
+        Each info dict contains keys: type_name (str), annotation, is_optional (bool).
     """
     try:
         # Use getattr to avoid mypy's unsound __init__ access warning

--- a/src/infrastructure/enums/infrastructure_error_code.py
+++ b/src/infrastructure/enums/infrastructure_error_code.py
@@ -45,3 +45,7 @@ class InfrastructureErrorCode(Enum):
     PROVIDER_CONNECTION_FAILED = "provider_connection_failed"
     PROVIDER_AUTH_REQUIRED = "provider_auth_required"
     PROVIDER_RATE_LIMITED = "provider_rate_limited"
+
+    # General infrastructure errors
+    UNEXPECTED_ERROR = "unexpected_error"
+    CONNECTION_ERROR = "connection_error"

--- a/src/infrastructure/jobs/__init__.py
+++ b/src/infrastructure/jobs/__init__.py
@@ -1,0 +1,21 @@
+"""Background jobs infrastructure package.
+
+This package provides integration with the dashtam-jobs background worker service.
+It enables the API to monitor job queue status and health without directly
+depending on the jobs service code.
+
+Architecture:
+- JobsMonitor: Queries jobs Redis for queue status and health
+- Uses same Redis instance as dashtam-jobs (configurable via JOBS_REDIS_URL)
+- No code dependency on dashtam-jobs (shared config via environment)
+
+Usage:
+    from src.core.container import get_jobs_monitor
+
+    monitor = get_jobs_monitor()
+    health = await monitor.check_health()
+"""
+
+from src.infrastructure.jobs.monitor import JobsMonitor
+
+__all__ = ["JobsMonitor"]

--- a/src/infrastructure/jobs/monitor.py
+++ b/src/infrastructure/jobs/monitor.py
@@ -1,0 +1,188 @@
+"""Background jobs monitor for querying job queue status.
+
+This module provides JobsMonitor, which connects to the dashtam-jobs Redis
+instance to query queue length, job status, and health. It enables the API
+to monitor the background jobs service without code dependencies.
+
+Architecture:
+- Uses redis.asyncio for async Redis operations
+- Follows fail-open pattern for resilience
+- Returns Result types for error handling
+- No dependency on dashtam-jobs code (shared config via environment)
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from src.core.enums import ErrorCode
+from src.core.result import Failure, Result, Success
+from src.infrastructure.enums import InfrastructureErrorCode
+from src.infrastructure.errors import InfrastructureError
+
+
+@dataclass(frozen=True, kw_only=True)
+class JobsHealthStatus:
+    """Health status of the background jobs service.
+
+    Attributes:
+        healthy: Whether the jobs Redis is reachable.
+        queue_length: Number of jobs waiting in the queue.
+        redis_connected: Whether Redis connection is active.
+        error: Error message if unhealthy.
+    """
+
+    healthy: bool
+    queue_length: int
+    redis_connected: bool
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:  # noqa: PLW3201
+        """Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dict representation of health status.
+        """
+        return {
+            "healthy": self.healthy,
+            "queue_length": self.queue_length,
+            "redis_connected": self.redis_connected,
+            "error": self.error,
+        }
+
+
+class JobsMonitor:
+    """Monitor for background jobs service.
+
+    Connects to the jobs Redis instance to query queue status and health.
+    This class does not depend on dashtam-jobs code - it only queries Redis
+    directly using the same queue name configured in dashtam-jobs.
+
+    Attributes:
+        _redis: Async Redis client instance.
+        _queue_name: Name of the jobs queue in Redis.
+    """
+
+    def __init__(self, redis_client: Redis, queue_name: str = "dashtam:jobs") -> None:
+        """Initialize jobs monitor.
+
+        Args:
+            redis_client: Async Redis client instance.
+            queue_name: Name of the jobs queue (must match dashtam-jobs config).
+        """
+        self._redis = redis_client
+        self._queue_name = queue_name
+
+    async def check_health(self) -> Result[JobsHealthStatus, InfrastructureError]:
+        """Check health of the background jobs service.
+
+        Verifies Redis connectivity and returns queue status.
+
+        Returns:
+            Result with JobsHealthStatus on success, or InfrastructureError.
+        """
+        try:
+            # Ping Redis to verify connectivity
+            await self._redis.ping()  # type: ignore[misc]
+
+            # Get queue length
+            queue_length = await self._redis.llen(self._queue_name)  # type: ignore[misc]
+
+            return Success(
+                value=JobsHealthStatus(
+                    healthy=True,
+                    queue_length=queue_length,
+                    redis_connected=True,
+                )
+            )
+        except RedisError as e:
+            return Success(
+                value=JobsHealthStatus(
+                    healthy=False,
+                    queue_length=0,
+                    redis_connected=False,
+                    error=f"Redis connection failed: {e}",
+                )
+            )
+        except Exception as e:
+            return Failure(
+                error=InfrastructureError(
+                    code=ErrorCode.VALIDATION_FAILED,
+                    infrastructure_code=InfrastructureErrorCode.UNEXPECTED_ERROR,
+                    message="Unexpected error checking jobs health",
+                    details={"error": str(e), "type": type(e).__name__},
+                )
+            )
+
+    async def get_queue_length(self) -> Result[int, InfrastructureError]:
+        """Get the number of jobs waiting in the queue.
+
+        Returns:
+            Result with queue length on success, or InfrastructureError.
+        """
+        try:
+            length = await self._redis.llen(self._queue_name)  # type: ignore[misc]
+            return Success(value=length)
+        except RedisError as e:
+            return Failure(
+                error=InfrastructureError(
+                    code=ErrorCode.VALIDATION_FAILED,
+                    infrastructure_code=InfrastructureErrorCode.CONNECTION_ERROR,
+                    message="Failed to get jobs queue length",
+                    details={"error": str(e), "queue_name": self._queue_name},
+                )
+            )
+
+    async def get_job_result(
+        self, task_id: str
+    ) -> Result[dict[str, Any] | None, InfrastructureError]:
+        """Get the result of a completed job by task ID.
+
+        TaskIQ stores results with keys like 'taskiq:result:{task_id}'.
+
+        Args:
+            task_id: The unique identifier of the task.
+
+        Returns:
+            Result with job result dict if found, None if not found,
+            or InfrastructureError.
+        """
+        try:
+            # TaskIQ result backend key format
+            result_key = f"taskiq:result:{task_id}"
+            raw_result = await self._redis.get(result_key)
+
+            if raw_result is None:
+                return Success(value=None)
+
+            result = (
+                raw_result.decode("utf-8")
+                if isinstance(raw_result, bytes)
+                else raw_result
+            )
+            return Success(value=json.loads(result))
+        except RedisError as e:
+            return Failure(
+                error=InfrastructureError(
+                    code=ErrorCode.VALIDATION_FAILED,
+                    infrastructure_code=InfrastructureErrorCode.CONNECTION_ERROR,
+                    message="Failed to get job result",
+                    details={"error": str(e), "task_id": task_id},
+                )
+            )
+        except Exception as e:
+            return Failure(
+                error=InfrastructureError(
+                    code=ErrorCode.VALIDATION_FAILED,
+                    infrastructure_code=InfrastructureErrorCode.UNEXPECTED_ERROR,
+                    message="Unexpected error getting job result",
+                    details={
+                        "error": str(e),
+                        "task_id": task_id,
+                        "type": type(e).__name__,
+                    },
+                )
+            )

--- a/src/presentation/routers/api/v1/admin/jobs.py
+++ b/src/presentation/routers/api/v1/admin/jobs.py
@@ -1,0 +1,86 @@
+"""Background jobs admin handlers.
+
+Handler functions for admin background jobs monitoring endpoint.
+Routes are registered via ROUTE_REGISTRY in routes/registry.py.
+
+Handlers:
+    get_jobs_status - Get jobs service status
+
+All handlers require:
+    - JWT authentication (valid access token)
+    - Admin role (Casbin RBAC check)
+"""
+
+from typing import TYPE_CHECKING
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+
+from src.core.container import get_jobs_monitor
+from src.core.result import Failure
+from src.presentation.routers.api.middleware.auth_dependencies import (
+    CurrentUser,
+    get_current_user,
+)
+from src.application.errors import ApplicationError, ApplicationErrorCode
+from src.presentation.routers.api.middleware.authorization_dependencies import (
+    require_casbin_role,
+)
+from src.presentation.routers.api.middleware.trace_middleware import get_trace_id
+from src.presentation.routers.api.v1.errors import ErrorResponseBuilder
+from src.schemas.jobs_schemas import JobsStatusResponse
+
+if TYPE_CHECKING:
+    from src.infrastructure.jobs.monitor import JobsMonitor
+
+
+# =============================================================================
+# Jobs Status
+# =============================================================================
+
+
+async def get_jobs_status(
+    request: Request,
+    current_user: CurrentUser = Depends(get_current_user),
+    _admin_check: None = Depends(require_casbin_role("admin")),
+    monitor: "JobsMonitor" = Depends(get_jobs_monitor),
+) -> JobsStatusResponse | JSONResponse:
+    """Get background jobs service status.
+
+    GET /api/v1/admin/jobs → 200 OK
+
+    Returns detailed status of the dashtam-jobs background worker service,
+    including queue length, Redis connectivity, and health status.
+
+    Requires admin role (Casbin RBAC).
+
+    Args:
+        request: FastAPI request object.
+        current_user: Authenticated admin user (from JWT).
+        _admin_check: Admin role verification (Casbin).
+        monitor: JobsMonitor instance for querying job queue status.
+
+    Returns:
+        JobsStatusResponse on success (200 OK).
+        JSONResponse with error on failure.
+    """
+    result = await monitor.check_health()
+
+    if isinstance(result, Failure):
+        error = ApplicationError(
+            code=ApplicationErrorCode.COMMAND_EXECUTION_FAILED,
+            message="Failed to check jobs status",
+        )
+        return ErrorResponseBuilder.from_application_error(
+            error=error,
+            request=request,
+            trace_id=get_trace_id() or "",
+        )
+
+    status = result.value
+    return JobsStatusResponse(
+        healthy=status.healthy,
+        queue_length=status.queue_length,
+        redis_connected=status.redis_connected,
+        error=status.error,
+    )

--- a/src/presentation/routers/api/v1/routes/registry.py
+++ b/src/presentation/routers/api/v1/routes/registry.py
@@ -39,6 +39,7 @@ from src.presentation.routers.api.v1.accounts import (
     list_accounts_by_connection,
     sync_accounts,
 )
+from src.presentation.routers.api.v1.admin.jobs import get_jobs_status
 from src.presentation.routers.api.v1.admin.token_rotation import (
     create_global_rotation,
     create_user_rotation,
@@ -115,6 +116,7 @@ from src.schemas.provider_schemas import (
     ProviderConnectionResponse,
     TokenRefreshResponse,
 )
+from src.schemas.jobs_schemas import JobsStatusResponse
 from src.schemas.rotation_schemas import (
     GlobalRotationResponse,
     SecurityConfigResponse,
@@ -758,7 +760,7 @@ ROUTE_REGISTRY: list[RouteMetadata] = [
         rate_limit_policy=RateLimitPolicy.API_READ,
     ),
     # =========================================================================
-    # Admin Resource (3 endpoints)
+    # Admin Resource (4 endpoints)
     # =========================================================================
     RouteMetadata(
         method=HTTPMethod.POST,
@@ -815,6 +817,26 @@ ROUTE_REGISTRY: list[RouteMetadata] = [
         errors=[
             ErrorSpec(status=401, description="Not authenticated"),
             ErrorSpec(status=403, description="Not authorized (admin only)"),
+        ],
+        idempotency=IdempotencyLevel.SAFE,
+        auth_policy=AuthPolicy(level=AuthLevel.ADMIN, role="admin"),
+        rate_limit_policy=RateLimitPolicy.API_READ,
+    ),
+    RouteMetadata(
+        method=HTTPMethod.GET,
+        path="/admin/jobs",
+        handler=get_jobs_status,
+        resource="admin",
+        tags=["Admin"],
+        summary="Get background jobs status",
+        description="Admin-only. Returns status of the dashtam-jobs background worker service including queue length and health.",
+        operation_id="get_jobs_status",
+        response_model=JobsStatusResponse,
+        status_code=200,
+        errors=[
+            ErrorSpec(status=401, description="Not authenticated"),
+            ErrorSpec(status=403, description="Not authorized (admin only)"),
+            ErrorSpec(status=500, description="Failed to check jobs status"),
         ],
         idempotency=IdempotencyLevel.SAFE,
         auth_policy=AuthPolicy(level=AuthLevel.ADMIN, role="admin"),

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -27,6 +27,7 @@ from src.schemas.auth_schemas import (
     PasswordResetCreateRequest,
     PasswordResetCreateResponse,
 )
+from src.schemas.jobs_schemas import JobsStatusResponse
 from src.schemas.session_schemas import (
     SessionListResponse,
     SessionResponse,
@@ -60,4 +61,6 @@ __all__ = [
     "PasswordResetTokenCreateResponse",
     "PasswordResetCreateRequest",
     "PasswordResetCreateResponse",
+    # Admin - Jobs
+    "JobsStatusResponse",
 ]

--- a/src/schemas/jobs_schemas.py
+++ b/src/schemas/jobs_schemas.py
@@ -1,0 +1,53 @@
+"""Background jobs status request/response schemas.
+
+Pydantic models for admin API background jobs monitoring endpoints.
+Admin-only operations for monitoring the dashtam-jobs background worker service.
+
+RESTful Endpoints (admin-only):
+    GET    /api/v1/admin/jobs    - Get jobs service status
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# =============================================================================
+# Jobs Status Response
+# =============================================================================
+
+
+class JobsStatusResponse(BaseModel):
+    """Response schema for jobs service status.
+
+    GET /api/v1/admin/jobs
+    Returns: 200 OK
+
+    Admin-only. Returns detailed status of the background jobs service.
+    """
+
+    healthy: bool = Field(
+        ...,
+        description="Whether the jobs service is healthy (Redis connected and responsive)",
+    )
+    queue_length: int = Field(
+        ...,
+        description="Number of jobs currently waiting in the queue",
+    )
+    redis_connected: bool = Field(
+        ...,
+        description="Whether the jobs Redis instance is connected",
+    )
+    error: str | None = Field(
+        None,
+        description="Error message if unhealthy (null when healthy)",
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "healthy": True,
+                "queue_length": 3,
+                "redis_connected": True,
+                "error": None,
+            }
+        }
+    )

--- a/tests/api/test_admin_jobs_api.py
+++ b/tests/api/test_admin_jobs_api.py
@@ -1,0 +1,302 @@
+"""API tests for admin background jobs endpoint.
+
+Tests the complete HTTP request/response cycle for admin jobs monitoring:
+- GET /api/v1/admin/jobs (jobs status)
+
+Architecture:
+- Uses real app with dependency overrides
+- Mocks JobsMonitor and authentication dependencies
+- Tests validation, status codes, and error responses
+- Verifies 401/403 for unauthenticated/unauthorized access
+"""
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from uuid_extensions import uuid7
+
+from src.core.container import get_authorization, get_jobs_monitor
+from src.core.enums import ErrorCode
+from src.core.result import Failure, Success
+from src.infrastructure.enums import InfrastructureErrorCode
+from src.infrastructure.errors import InfrastructureError
+from src.infrastructure.jobs.monitor import JobsHealthStatus
+from src.main import app
+from src.presentation.routers.api.middleware.auth_dependencies import (
+    CurrentUser,
+    get_current_user,
+)
+
+
+# =============================================================================
+# Test Doubles
+# =============================================================================
+
+
+class StubJobsMonitor:
+    """Stub JobsMonitor for testing."""
+
+    def __init__(
+        self, healthy: bool = True, queue_length: int = 5, redis_connected: bool = True
+    ):
+        self._healthy = healthy
+        self._queue_length = queue_length
+        self._redis_connected = redis_connected
+
+    async def check_health(self) -> Success[JobsHealthStatus]:
+        return Success(
+            value=JobsHealthStatus(
+                healthy=self._healthy,
+                queue_length=self._queue_length,
+                redis_connected=self._redis_connected,
+                error=None if self._healthy else "Redis connection failed",
+            )
+        )
+
+
+class FailingJobsMonitor:
+    """Stub JobsMonitor that returns Failure."""
+
+    async def check_health(self):
+        return Failure(
+            error=InfrastructureError(
+                code=ErrorCode.VALIDATION_FAILED,
+                infrastructure_code=InfrastructureErrorCode.UNEXPECTED_ERROR,
+                message="Unexpected error checking jobs health",
+            )
+        )
+
+
+class StubAuthorizationProtocol:
+    """Stub authorization that always allows admin."""
+
+    async def check_permission(self, user_id, resource: str, action: str) -> bool:
+        return True
+
+    async def has_role(self, user_id, role: str) -> bool:
+        return role == "admin"
+
+
+class StubAuthorizationDenied:
+    """Stub authorization that denies admin role."""
+
+    async def check_permission(self, user_id, resource: str, action: str) -> bool:
+        return False
+
+    async def has_role(self, user_id, role: str) -> bool:
+        return False
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def admin_user():
+    """Create admin user for authenticated requests."""
+    return CurrentUser(
+        user_id=uuid7(),
+        email="admin@example.com",
+        roles=["admin"],
+    )
+
+
+@pytest.fixture
+def regular_user():
+    """Create regular (non-admin) user."""
+    return CurrentUser(
+        user_id=uuid7(),
+        email="user@example.com",
+        roles=["user"],
+    )
+
+
+@pytest.fixture
+def healthy_monitor():
+    """Create stub monitor returning healthy status."""
+    return StubJobsMonitor(healthy=True, queue_length=10)
+
+
+@pytest.fixture
+def unhealthy_monitor():
+    """Create stub monitor returning unhealthy status."""
+    return StubJobsMonitor(healthy=False, queue_length=0, redis_connected=False)
+
+
+@pytest.fixture
+def failing_monitor():
+    """Create stub monitor that returns Failure."""
+    return FailingJobsMonitor()
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(admin_user, healthy_monitor):
+    """Override app dependencies with test doubles (admin access by default)."""
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    app.dependency_overrides[get_authorization] = lambda: StubAuthorizationProtocol()
+    app.dependency_overrides[get_jobs_monitor] = lambda: healthy_monitor
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client():
+    """Create test client with real app."""
+    return TestClient(app)
+
+
+# =============================================================================
+# GET /api/v1/admin/jobs Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestAdminJobsEndpoint:
+    """Test GET /api/v1/admin/jobs endpoint."""
+
+    def test_returns_200_with_jobs_status(self, client) -> None:
+        """Should return 200 OK with jobs status for admin user."""
+        response = client.get("/api/v1/admin/jobs")
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_response_includes_healthy_field(self, client) -> None:
+        """Response should include healthy boolean field."""
+        response = client.get("/api/v1/admin/jobs")
+
+        data = response.json()
+        assert "healthy" in data
+        assert isinstance(data["healthy"], bool)
+
+    def test_response_includes_queue_length(self, client) -> None:
+        """Response should include queue_length field."""
+        response = client.get("/api/v1/admin/jobs")
+
+        data = response.json()
+        assert "queue_length" in data
+        assert isinstance(data["queue_length"], int)
+
+    def test_response_includes_redis_connected(self, client) -> None:
+        """Response should include redis_connected field."""
+        response = client.get("/api/v1/admin/jobs")
+
+        data = response.json()
+        assert "redis_connected" in data
+        assert isinstance(data["redis_connected"], bool)
+
+    def test_healthy_status_shows_correct_values(self, client, healthy_monitor) -> None:
+        """Healthy jobs service should return correct status values."""
+        app.dependency_overrides[get_jobs_monitor] = lambda: healthy_monitor
+
+        response = client.get("/api/v1/admin/jobs")
+
+        data = response.json()
+        assert data["healthy"] is True
+        assert data["queue_length"] == 10
+        assert data["redis_connected"] is True
+        assert data["error"] is None
+
+    def test_unhealthy_status_includes_error(
+        self, client, unhealthy_monitor, admin_user
+    ) -> None:
+        """Unhealthy jobs service should include error message."""
+        app.dependency_overrides[get_jobs_monitor] = lambda: unhealthy_monitor
+
+        response = client.get("/api/v1/admin/jobs")
+
+        data = response.json()
+        assert data["healthy"] is False
+        assert data["redis_connected"] is False
+        assert data["error"] is not None
+
+
+@pytest.mark.api
+class TestAdminJobsMonitorFailure:
+    """Test GET /api/v1/admin/jobs when monitor fails."""
+
+    def test_returns_error_response_on_monitor_failure(
+        self, client, failing_monitor, admin_user
+    ) -> None:
+        """Should return error response when monitor fails."""
+        app.dependency_overrides[get_jobs_monitor] = lambda: failing_monitor
+
+        response = client.get("/api/v1/admin/jobs")
+
+        # Should return RFC 9457 error response
+        assert response.status_code in (
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status.HTTP_200_OK,  # Some implementations return 200 with error field
+        )
+
+
+# =============================================================================
+# Authentication Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestAdminJobsAuthentication:
+    """Test that admin jobs endpoint requires authentication."""
+
+    def test_returns_401_without_authentication(self) -> None:
+        """Should return 401 Unauthorized without authentication."""
+        # Clear all overrides to test without auth
+        app.dependency_overrides.clear()
+
+        try:
+            client = TestClient(app)
+            response = client.get("/api/v1/admin/jobs")
+
+            # Returns 401 from HTTPBearer when no Authorization header
+            assert response.status_code in (
+                status.HTTP_401_UNAUTHORIZED,
+                status.HTTP_403_FORBIDDEN,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# =============================================================================
+# Authorization Tests
+# =============================================================================
+
+
+@pytest.mark.api
+class TestAdminJobsAuthorization:
+    """Test that admin jobs endpoint requires admin role."""
+
+    def test_returns_403_without_admin_role(
+        self, regular_user, healthy_monitor
+    ) -> None:
+        """Should return 403 Forbidden for non-admin user."""
+        # Setup: authenticated but non-admin user
+        app.dependency_overrides[get_current_user] = lambda: regular_user
+        app.dependency_overrides[get_authorization] = lambda: StubAuthorizationDenied()
+        app.dependency_overrides[get_jobs_monitor] = lambda: healthy_monitor
+
+        try:
+            client = TestClient(app)
+            response = client.get("/api/v1/admin/jobs")
+
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_admin_user_can_access(self, admin_user, healthy_monitor) -> None:
+        """Admin user should be able to access the endpoint."""
+        app.dependency_overrides[get_current_user] = lambda: admin_user
+        app.dependency_overrides[get_authorization] = (
+            lambda: StubAuthorizationProtocol()
+        )
+        app.dependency_overrides[get_jobs_monitor] = lambda: healthy_monitor
+
+        try:
+            client = TestClient(app)
+            response = client.get("/api/v1/admin/jobs")
+
+            assert response.status_code == status.HTTP_200_OK
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/api/test_system_routes.py
+++ b/tests/api/test_system_routes.py
@@ -1,12 +1,19 @@
 """API tests for non-versioned system routes.
 
 Validates behavior of root, health, and config endpoints exposed by the
-system router.
+system router, including /health/jobs endpoint for background jobs monitoring.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.core.config import settings
+from src.core.container import get_jobs_monitor
+from src.core.enums import ErrorCode
+from src.core.result import Failure, Success
+from src.infrastructure.enums import InfrastructureErrorCode
+from src.infrastructure.errors import InfrastructureError
+from src.infrastructure.jobs.monitor import JobsHealthStatus
 from src.main import app
 
 
@@ -51,3 +58,94 @@ def test_config_endpoint_behavior_depends_on_environment() -> None:
         assert (
             response.json()["detail"] == "Config endpoint only available in development"
         )
+
+
+# =============================================================================
+# /health/jobs endpoint tests
+# =============================================================================
+
+
+class StubJobsMonitor:
+    """Stub JobsMonitor for testing."""
+
+    def __init__(self, healthy: bool = True, queue_length: int = 5):
+        self._healthy = healthy
+        self._queue_length = queue_length
+
+    async def check_health(self) -> Success[JobsHealthStatus]:
+        return Success(
+            value=JobsHealthStatus(
+                healthy=self._healthy,
+                queue_length=self._queue_length,
+                redis_connected=self._healthy,
+                error=None if self._healthy else "Connection failed",
+            )
+        )
+
+
+class FailingJobsMonitor:
+    """Stub JobsMonitor that returns Failure."""
+
+    async def check_health(self):
+        return Failure(
+            error=InfrastructureError(
+                code=ErrorCode.VALIDATION_FAILED,
+                infrastructure_code=InfrastructureErrorCode.UNEXPECTED_ERROR,
+                message="Unexpected error",
+            )
+        )
+
+
+@pytest.fixture
+def healthy_jobs_client():
+    """Create client with healthy jobs mock."""
+    app.dependency_overrides[get_jobs_monitor] = lambda: StubJobsMonitor(healthy=True)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def unhealthy_jobs_client():
+    """Create client with unhealthy jobs mock."""
+    app.dependency_overrides[get_jobs_monitor] = lambda: StubJobsMonitor(healthy=False)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def failing_jobs_client():
+    """Create client with failing jobs monitor."""
+    app.dependency_overrides[get_jobs_monitor] = lambda: FailingJobsMonitor()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_health_jobs_returns_healthy_when_jobs_service_healthy(
+    healthy_jobs_client,
+) -> None:
+    """Health jobs endpoint should return healthy status when jobs service is healthy."""
+    response = healthy_jobs_client.get("/health/jobs")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"status": "healthy"}
+
+
+def test_health_jobs_returns_unhealthy_when_jobs_service_unhealthy(
+    unhealthy_jobs_client,
+) -> None:
+    """Health jobs endpoint should return unhealthy when jobs service is down."""
+    response = unhealthy_jobs_client.get("/health/jobs")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"status": "unhealthy"}
+
+
+def test_health_jobs_returns_unhealthy_on_monitor_failure(failing_jobs_client) -> None:
+    """Health jobs endpoint should return unhealthy when monitor fails."""
+    response = failing_jobs_client.get("/health/jobs")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"status": "unhealthy"}

--- a/tests/unit/test_domain_sse_provider_mappings.py
+++ b/tests/unit/test_domain_sse_provider_mappings.py
@@ -1,0 +1,313 @@
+"""Unit tests for SSE Provider Health Mappings (Issue #157).
+
+Tests cover:
+- All 3 domain-to-SSE mappings for provider events
+- Payload extraction for each event type
+- User ID extraction
+- Mapping registry integration
+
+Note:
+    The provider.token.expiring event is NOT covered here as it requires
+    a background job (not triggered by domain events). That will be
+    implemented in a separate issue once background job architecture
+    is established.
+
+Reference:
+    - src/domain/events/sse_registry.py
+    - GitHub Issue #157
+"""
+
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from uuid_extensions import uuid7
+
+from src.domain.events.provider_events import (
+    ProviderDisconnectionSucceeded,
+    ProviderTokenRefreshFailed,
+    ProviderTokenRefreshSucceeded,
+)
+from src.domain.events.sse_event import SSEEventType
+from src.domain.events.sse_registry import (
+    DOMAIN_TO_SSE_MAPPING,
+    get_domain_event_to_sse_mapping,
+    get_registry_statistics,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    """Provide a test user ID."""
+    return cast(UUID, uuid7())
+
+
+@pytest.fixture
+def connection_id() -> UUID:
+    """Provide a test connection ID."""
+    return cast(UUID, uuid7())
+
+
+@pytest.fixture
+def provider_id() -> UUID:
+    """Provide a test provider ID."""
+    return cast(UUID, uuid7())
+
+
+# =============================================================================
+# Registry Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestProviderMappingsRegistry:
+    """Test that provider mappings are properly registered."""
+
+    def test_all_provider_events_have_mappings(self):
+        """Verify all 3 provider domain events have SSE mappings."""
+        mapping = get_domain_event_to_sse_mapping()
+
+        # Provider token refresh events
+        assert ProviderTokenRefreshSucceeded in mapping
+        assert ProviderTokenRefreshFailed in mapping
+
+        # Provider disconnection event
+        assert ProviderDisconnectionSucceeded in mapping
+
+    def test_registry_statistics_include_provider_mappings(self):
+        """Verify registry statistics reflect provider mappings."""
+        stats = get_registry_statistics()
+
+        # Should have at least 12 mappings (9 data sync + 3 provider)
+        total_mappings = cast(int, stats["total_mappings"])
+        assert total_mappings >= 12
+
+    def test_mapping_list_contains_provider_entries(self):
+        """Verify DOMAIN_TO_SSE_MAPPING has provider entries."""
+        provider_types = {
+            SSEEventType.PROVIDER_TOKEN_REFRESHED,
+            SSEEventType.PROVIDER_TOKEN_FAILED,
+            SSEEventType.PROVIDER_DISCONNECTED,
+        }
+
+        mapped_types = {m.sse_event_type for m in DOMAIN_TO_SSE_MAPPING}
+        assert provider_types.issubset(mapped_types)
+
+
+# =============================================================================
+# Token Refresh Succeeded Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTokenRefreshSucceededMapping:
+    """Test ProviderTokenRefreshSucceeded domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test ProviderTokenRefreshSucceeded maps to PROVIDER_TOKEN_REFRESHED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshSucceeded]
+
+        assert m.sse_event_type == SSEEventType.PROVIDER_TOKEN_REFRESHED
+
+    def test_payload_extraction(self, user_id, connection_id, provider_id):
+        """Test payload is correctly extracted from ProviderTokenRefreshSucceeded."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshSucceeded]
+
+        event = ProviderTokenRefreshSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "connection_id": str(connection_id),
+            "provider_slug": "schwab",
+        }
+
+    def test_user_id_extraction(self, user_id, connection_id, provider_id):
+        """Test user_id is correctly extracted from ProviderTokenRefreshSucceeded."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshSucceeded]
+
+        event = ProviderTokenRefreshSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# Token Refresh Failed Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTokenRefreshFailedMapping:
+    """Test ProviderTokenRefreshFailed domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test ProviderTokenRefreshFailed maps to PROVIDER_TOKEN_FAILED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshFailed]
+
+        assert m.sse_event_type == SSEEventType.PROVIDER_TOKEN_FAILED
+
+    def test_payload_extraction_with_needs_reauth_true(
+        self, user_id, connection_id, provider_id
+    ):
+        """Test payload extraction when user action is needed."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshFailed]
+
+        event = ProviderTokenRefreshFailed(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            reason="refresh_token_expired",
+            needs_user_action=True,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "connection_id": str(connection_id),
+            "provider_slug": "schwab",
+            "needs_reauth": True,
+        }
+
+    def test_payload_extraction_with_needs_reauth_false(
+        self, user_id, connection_id, provider_id
+    ):
+        """Test payload extraction when user action is not needed."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshFailed]
+
+        event = ProviderTokenRefreshFailed(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="alpaca",
+            reason="network_error",
+            needs_user_action=False,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "connection_id": str(connection_id),
+            "provider_slug": "alpaca",
+            "needs_reauth": False,
+        }
+
+    def test_user_id_extraction(self, user_id, connection_id, provider_id):
+        """Test user_id is correctly extracted from ProviderTokenRefreshFailed."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderTokenRefreshFailed]
+
+        event = ProviderTokenRefreshFailed(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+            reason="test",
+            needs_user_action=False,
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# Provider Disconnection Succeeded Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestProviderDisconnectionSucceededMapping:
+    """Test ProviderDisconnectionSucceeded domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test ProviderDisconnectionSucceeded maps to PROVIDER_DISCONNECTED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderDisconnectionSucceeded]
+
+        assert m.sse_event_type == SSEEventType.PROVIDER_DISCONNECTED
+
+    def test_payload_extraction(self, user_id, connection_id, provider_id):
+        """Test payload is correctly extracted from ProviderDisconnectionSucceeded."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderDisconnectionSucceeded]
+
+        event = ProviderDisconnectionSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "connection_id": str(connection_id),
+            "provider_slug": "schwab",
+        }
+
+    def test_user_id_extraction(self, user_id, connection_id, provider_id):
+        """Test user_id is correctly extracted from ProviderDisconnectionSucceeded."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[ProviderDisconnectionSucceeded]
+
+        event = ProviderDisconnectionSucceeded(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider_id=provider_id,
+            provider_slug="schwab",
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# SSE Event Handler Integration Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEEventHandlerIntegration:
+    """Test that provider mappings work with SSEEventHandler."""
+
+    def test_handler_has_mapping_for_all_provider_events(self):
+        """Verify SSEEventHandler can find mappings for provider events."""
+        from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+        mock_publisher = MagicMock()
+        handler = SSEEventHandler(publisher=mock_publisher)
+
+        # All provider events should have mappings
+        assert handler.has_mapping_for(ProviderTokenRefreshSucceeded)
+        assert handler.has_mapping_for(ProviderTokenRefreshFailed)
+        assert handler.has_mapping_for(ProviderDisconnectionSucceeded)
+
+    def test_handler_returns_provider_events_in_mapped_types(self):
+        """Verify SSEEventHandler returns provider events in mapped types."""
+        from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+        mock_publisher = MagicMock()
+        handler = SSEEventHandler(publisher=mock_publisher)
+
+        mapped_types = handler.get_mapped_event_types()
+
+        # Should include all provider events
+        assert ProviderTokenRefreshSucceeded in mapped_types
+        assert ProviderTokenRefreshFailed in mapped_types
+        assert ProviderDisconnectionSucceeded in mapped_types

--- a/tests/unit/test_infrastructure_jobs_monitor.py
+++ b/tests/unit/test_infrastructure_jobs_monitor.py
@@ -1,0 +1,331 @@
+"""Unit tests for JobsMonitor.
+
+Tests cover:
+- check_health() - Redis reachable, unreachable, unexpected errors
+- get_queue_length() - success, Redis error
+- get_job_result() - found, not found, Redis error, unexpected error
+
+Architecture:
+- Pure unit tests (no external dependencies)
+- Uses AsyncMock for Redis client
+- Uses Result pattern (Success/Failure)
+- Tests infrastructure error types
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from src.core.result import Failure, Success
+from src.infrastructure.jobs.monitor import JobsHealthStatus, JobsMonitor
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_redis():
+    """Create mock Redis client."""
+    redis = AsyncMock()
+    redis.ping = AsyncMock(return_value=True)
+    redis.llen = AsyncMock(return_value=5)
+    redis.get = AsyncMock(return_value=None)
+    return redis
+
+
+@pytest.fixture
+def monitor(mock_redis):
+    """Create JobsMonitor with mocked Redis client."""
+    return JobsMonitor(redis_client=mock_redis, queue_name="test:jobs")
+
+
+# =============================================================================
+# Test: JobsHealthStatus
+# =============================================================================
+
+
+class TestJobsHealthStatus:
+    """Test JobsHealthStatus dataclass."""
+
+    def test_healthy_status_to_dict(self):
+        """Healthy status should serialize correctly."""
+        status = JobsHealthStatus(
+            healthy=True,
+            queue_length=10,
+            redis_connected=True,
+        )
+
+        result = status.to_dict()
+
+        assert result["healthy"] is True
+        assert result["queue_length"] == 10
+        assert result["redis_connected"] is True
+        assert result["error"] is None
+
+    def test_unhealthy_status_to_dict(self):
+        """Unhealthy status should include error message."""
+        status = JobsHealthStatus(
+            healthy=False,
+            queue_length=0,
+            redis_connected=False,
+            error="Connection refused",
+        )
+
+        result = status.to_dict()
+
+        assert result["healthy"] is False
+        assert result["redis_connected"] is False
+        assert result["error"] == "Connection refused"
+
+    def test_status_is_immutable(self):
+        """JobsHealthStatus should be frozen (immutable)."""
+        status = JobsHealthStatus(
+            healthy=True,
+            queue_length=5,
+            redis_connected=True,
+        )
+
+        with pytest.raises(AttributeError):
+            status.healthy = False  # type: ignore[misc]
+
+
+# =============================================================================
+# Test: check_health()
+# =============================================================================
+
+
+class TestJobsMonitorCheckHealth:
+    """Test check_health method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_healthy_when_redis_reachable(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should return healthy status when Redis is reachable."""
+        mock_redis.llen.return_value = 3
+
+        result = await monitor.check_health()
+
+        assert isinstance(result, Success)
+        status = result.value
+        assert status.healthy is True
+        assert status.queue_length == 3
+        assert status.redis_connected is True
+        assert status.error is None
+
+    @pytest.mark.asyncio
+    async def test_pings_redis_to_verify_connectivity(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should ping Redis to verify connectivity."""
+        await monitor.check_health()
+
+        mock_redis.ping.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_queries_queue_length(self, monitor, mock_redis) -> None:
+        """Should query queue length using configured queue name."""
+        await monitor.check_health()
+
+        mock_redis.llen.assert_called_once_with("test:jobs")
+
+    @pytest.mark.asyncio
+    async def test_returns_unhealthy_when_redis_fails(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should return unhealthy status when Redis connection fails."""
+        mock_redis.ping.side_effect = RedisError("Connection refused")
+
+        result = await monitor.check_health()
+
+        # RedisError returns Success with unhealthy status (fail-open pattern)
+        assert isinstance(result, Success)
+        status = result.value
+        assert status.healthy is False
+        assert status.queue_length == 0
+        assert status.redis_connected is False
+        assert "Connection refused" in str(status.error)
+
+    @pytest.mark.asyncio
+    async def test_returns_unhealthy_when_llen_fails(self, monitor, mock_redis) -> None:
+        """Should return unhealthy status when llen fails."""
+        mock_redis.llen.side_effect = RedisError("Timeout")
+
+        result = await monitor.check_health()
+
+        assert isinstance(result, Success)
+        status = result.value
+        assert status.healthy is False
+        assert "Timeout" in str(status.error)
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_unexpected_error(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should return Failure on unexpected (non-Redis) errors."""
+        mock_redis.ping.side_effect = RuntimeError("Unexpected error")
+
+        result = await monitor.check_health()
+
+        assert isinstance(result, Failure)
+        assert "Unexpected error" in result.error.message
+
+
+# =============================================================================
+# Test: get_queue_length()
+# =============================================================================
+
+
+class TestJobsMonitorGetQueueLength:
+    """Test get_queue_length method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_queue_length(self, monitor, mock_redis) -> None:
+        """Should return queue length from Redis."""
+        mock_redis.llen.return_value = 42
+
+        result = await monitor.get_queue_length()
+
+        assert isinstance(result, Success)
+        assert result.value == 42
+
+    @pytest.mark.asyncio
+    async def test_uses_configured_queue_name(self, monitor, mock_redis) -> None:
+        """Should use the configured queue name."""
+        await monitor.get_queue_length()
+
+        mock_redis.llen.assert_called_once_with("test:jobs")
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_queue(self, monitor, mock_redis) -> None:
+        """Should return 0 for empty queue."""
+        mock_redis.llen.return_value = 0
+
+        result = await monitor.get_queue_length()
+
+        assert isinstance(result, Success)
+        assert result.value == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_redis_error(self, monitor, mock_redis) -> None:
+        """Should return Failure when Redis fails."""
+        mock_redis.llen.side_effect = RedisError("Connection lost")
+
+        result = await monitor.get_queue_length()
+
+        assert isinstance(result, Failure)
+        assert "Failed to get jobs queue length" in result.error.message
+        assert result.error.details is not None
+        assert "Connection lost" in result.error.details["error"]
+
+
+# =============================================================================
+# Test: get_job_result()
+# =============================================================================
+
+
+class TestJobsMonitorGetJobResult:
+    """Test get_job_result method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_result_not_found(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should return None when job result doesn't exist."""
+        mock_redis.get.return_value = None
+
+        result = await monitor.get_job_result("task-123")
+
+        assert isinstance(result, Success)
+        assert result.value is None
+
+    @pytest.mark.asyncio
+    async def test_queries_correct_key_format(self, monitor, mock_redis) -> None:
+        """Should query TaskIQ result key format."""
+        await monitor.get_job_result("abc-123")
+
+        mock_redis.get.assert_called_once_with("taskiq:result:abc-123")
+
+    @pytest.mark.asyncio
+    async def test_returns_parsed_json_result(self, monitor, mock_redis) -> None:
+        """Should parse and return JSON result."""
+        job_result = {"return_value": "success", "is_err": False}
+        mock_redis.get.return_value = json.dumps(job_result).encode("utf-8")
+
+        result = await monitor.get_job_result("task-456")
+
+        assert isinstance(result, Success)
+        assert result.value == job_result
+
+    @pytest.mark.asyncio
+    async def test_handles_string_result(self, monitor, mock_redis) -> None:
+        """Should handle string result (not bytes)."""
+        job_result = {"status": "completed"}
+        mock_redis.get.return_value = json.dumps(job_result)
+
+        result = await monitor.get_job_result("task-789")
+
+        assert isinstance(result, Success)
+        assert result.value == job_result
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_redis_error(self, monitor, mock_redis) -> None:
+        """Should return Failure when Redis fails."""
+        mock_redis.get.side_effect = RedisError("Read timeout")
+
+        result = await monitor.get_job_result("task-error")
+
+        assert isinstance(result, Failure)
+        assert "Failed to get job result" in result.error.message
+        assert result.error.details is not None
+        assert "task-error" in result.error.details["task_id"]
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_invalid_json(self, monitor, mock_redis) -> None:
+        """Should return Failure when result is invalid JSON."""
+        mock_redis.get.return_value = b"not valid json"
+
+        result = await monitor.get_job_result("task-bad-json")
+
+        assert isinstance(result, Failure)
+        assert "Unexpected error" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_unexpected_error(
+        self, monitor, mock_redis
+    ) -> None:
+        """Should return Failure on unexpected errors."""
+        mock_redis.get.side_effect = TypeError("Unexpected")
+
+        result = await monitor.get_job_result("task-unexpected")
+
+        assert isinstance(result, Failure)
+        assert "Unexpected error" in result.error.message
+        assert result.error.details is not None
+        assert "TypeError" in result.error.details["type"]
+
+
+# =============================================================================
+# Test: Constructor
+# =============================================================================
+
+
+class TestJobsMonitorInit:
+    """Test JobsMonitor initialization."""
+
+    def test_uses_default_queue_name(self, mock_redis):
+        """Should use default queue name if not specified."""
+        monitor = JobsMonitor(redis_client=mock_redis)
+
+        # Access private attribute for testing
+        assert monitor._queue_name == "dashtam:jobs"
+
+    def test_uses_custom_queue_name(self, mock_redis):
+        """Should use custom queue name when specified."""
+        monitor = JobsMonitor(redis_client=mock_redis, queue_name="custom:queue")
+
+        assert monitor._queue_name == "custom:queue"


### PR DESCRIPTION
## Summary

Complete Issue #157 (Provider Connection Health Notifications) - API side.

## Changes

### SSE Provider Health Mappings
- Domain-to-SSE mappings for provider token events:
  - `ProviderTokenRefreshSucceeded` → `provider.token.refreshed`
  - `ProviderTokenRefreshFailed` → `provider.token.failed`
  - `ProviderDisconnectionSucceeded` → `provider.disconnected`

### API Integration for dashtam-jobs Monitoring
- Integration support for jobs service

### Documentation
- Fix GitHub badge URLs: `Dashtam` → `dashtam-api`

## Related

- Closes #157 (API portion)
- Jobs portion already released in dashtam-jobs v0.2.0

Co-Authored-By: Warp <agent@warp.dev>