### PR TITLE
feat(sse): add balance and portfolio update notifications (#257)

### DIFF
--- a/docs/architecture/sse-architecture.md
+++ b/docs/architecture/sse-architecture.md
@@ -326,22 +326,29 @@ SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
     ),
     
     # ═══════════════════════════════════════════════════════════════════════
-    # Portfolio Events (2 event types)
-    # Implementation: GitHub Issue #5 - SSE: Balance/Portfolio Updates
+    # Portfolio Events (3 event types)
+    # Implementation: GitHub Issue #257 - SSE: Balance/Portfolio Updates
     # ═══════════════════════════════════════════════════════════════════════
     SSEEventMetadata(
         event_type="portfolio.balance.updated",
         category=SSECategory.PORTFOLIO,
-        source_domain_events=(),  # Triggered after sync, not direct event
+        source_domain_events=(AccountBalanceUpdated,),
         description="Account balance updated after sync",
-        payload_fields=("account_id", "previous_balance", "new_balance", "currency"),
+        payload_fields=("account_id", "previous_balance", "new_balance", "delta", "currency"),
     ),
     SSEEventMetadata(
         event_type="portfolio.holdings.updated",
         category=SSECategory.PORTFOLIO,
-        source_domain_events=(),  # Triggered after sync
+        source_domain_events=(AccountHoldingsUpdated,),
         description="Holdings updated after sync",
-        payload_fields=("account_id", "holdings_count"),
+        payload_fields=("account_id", "holdings_count", "created_count", "updated_count", "deactivated_count"),
+    ),
+    SSEEventMetadata(
+        event_type="portfolio.networth.updated",
+        category=SSECategory.PORTFOLIO,
+        source_domain_events=(PortfolioNetWorthRecalculated,),
+        description="Portfolio net worth recalculated after sync",
+        payload_fields=("previous_net_worth", "new_net_worth", "delta", "currency", "account_count"),
     ),
     
     # ═══════════════════════════════════════════════════════════════════════

--- a/docs/architecture/sse-registry.md
+++ b/docs/architecture/sse-registry.md
@@ -40,13 +40,13 @@ SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
         description="Account sync operation completed successfully",
         payload_fields=["connection_id", "provider_slug", "account_count"],
     ),
-    # ... 24 more event types
+    # ... 28 more event types
 ]
 ```
 
 **Benefits**:
 
-- ✅ All 25 SSE event types cataloged with complete metadata
+- ✅ All 29 SSE event types cataloged with complete metadata
 - ✅ 6 categories for client-side filtering
 - ✅ Self-enforcing compliance tests
 - ✅ Helper functions for easy access
@@ -84,7 +84,7 @@ class SSEEventType(StrEnum):
     PROVIDER_TOKEN_REFRESHED = "provider.token.refreshed"
     # ... more
 
-    # AI (3 types), Import (4 types), Portfolio (2 types), Security (3 types)
+    # AI (3 types), Import (4 types), Portfolio (3 types), Security (6 types)
 ```
 
 **Naming Convention**:
@@ -173,20 +173,20 @@ SSE_EVENT_REGISTRY: list[SSEEventMetadata] = [
         description="Account sync operation completed successfully",
         payload_fields=["connection_id", "provider_slug", "account_count"],
     ),
-    # ... 23 more entries
+    # ... 27 more entries
 ]
 ```
 
 **Event Type Distribution**:
 
 | Category | Count | Event Types |
-|----------|-------|-------------|
+|----------|-------|--------------|
 | DATA_SYNC | 9 | Accounts, Transactions, Holdings (started/completed/failed) |
 | PROVIDER | 4 | Token expiring/refreshed/failed, Disconnected |
 | AI | 3 | Response chunk, Tool executing, Response complete |
 | IMPORT | 4 | Started, Progress, Completed, Failed |
-| PORTFOLIO | 2 | Balance updated, Holdings updated |
-| SECURITY | 3 | Session new/suspicious/expiring |
+| PORTFOLIO | 3 | Balance updated, Holdings updated, Net worth updated |
+| SECURITY | 6 | Session new/revoked/suspicious, Password changed, Login failed |
 
 ### 5. DomainToSSEMapping (Dataclass)
 
@@ -298,8 +298,8 @@ def get_registry_statistics() -> dict[str, int]:
         >>> stats = get_registry_statistics()
         >>> print(stats)
         {
-            "total_event_types": 25,
-            "total_mappings": 9,
+            "total_event_types": 29,
+            "total_mappings": 24,
             "by_category": {
                 "data_sync": 9,
                 "provider": 4,
@@ -336,7 +336,7 @@ _EVENT_TYPE_TO_CATEGORY: dict[SSEEventType, SSEEventCategory] = {
     # Data Sync
     SSEEventType.SYNC_ACCOUNTS_STARTED: SSEEventCategory.DATA_SYNC,
     SSEEventType.SYNC_ACCOUNTS_COMPLETED: SSEEventCategory.DATA_SYNC,
-    # ... all 25 mappings
+    # ... all 29 mappings
 }
 
 def get_category_for_event_type(event_type: SSEEventType) -> SSEEventCategory:
@@ -386,8 +386,8 @@ def test_statistics_expected_counts():
         "provider": 4,
         "ai": 3,
         "import": 4,
-        "portfolio": 2,
-        "security": 3,
+        "portfolio": 3,
+        "security": 6,
     }
     for cat_name, count in expected.items():
         assert stats["by_category"][cat_name] == count

--- a/src/application/cqrs/registry.py
+++ b/src/application/cqrs/registry.py
@@ -140,6 +140,7 @@ from src.application.queries.holding_queries import (
     ListHoldingsByAccount,
     ListHoldingsByUser,
 )
+from src.application.queries.portfolio_queries import GetUserNetWorth
 from src.application.queries.provider_queries import (
     GetProviderConnection,
     ListProviderConnections,
@@ -189,6 +190,9 @@ from src.application.queries.handlers.get_holding_handler import GetHoldingHandl
 from src.application.queries.handlers.list_holdings_handler import (
     ListHoldingsByAccountHandler,
     ListHoldingsByUserHandler,
+)
+from src.application.queries.handlers.get_user_networth_handler import (
+    GetUserNetWorthHandler,
 )
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -616,5 +620,16 @@ QUERY_REGISTRY: list[QueryMetadata] = [
         is_paginated=False,  # Moderate number of holdings per user
         cache_policy=CachePolicy.SHORT,
         description="List all holdings for a user across all accounts",
+    ),
+    # ═══════════════════════════════════════════════════════════════════════
+    # Portfolio Queries (1 query - Issue #257)
+    # ═══════════════════════════════════════════════════════════════════════
+    QueryMetadata(
+        query_class=GetUserNetWorth,
+        handler_class=GetUserNetWorthHandler,
+        category=CQRSCategory.DATA_SYNC,
+        is_paginated=False,
+        cache_policy=CachePolicy.SHORT,  # Real-time updates via SSE
+        description="Get aggregated net worth for a user",
     ),
 ]

--- a/src/application/dtos/__init__.py
+++ b/src/application/dtos/__init__.py
@@ -29,6 +29,7 @@ from src.application.dtos.auth_dtos import (
 )
 from src.application.dtos.import_dtos import ImportResult
 from src.application.dtos.sync_dtos import (
+    BalanceChange,
     SyncAccountsResult,
     SyncHoldingsResult,
     SyncTransactionsResult,
@@ -41,6 +42,7 @@ __all__ = [
     "GlobalRotationResult",
     "UserRotationResult",
     # Sync DTOs
+    "BalanceChange",
     "SyncAccountsResult",
     "SyncTransactionsResult",
     "SyncHoldingsResult",

--- a/src/application/dtos/sync_dtos.py
+++ b/src/application/dtos/sync_dtos.py
@@ -7,12 +7,34 @@ DTOs:
     - SyncAccountsResult: Result from SyncAccounts command
     - SyncTransactionsResult: Result from SyncTransactions command
     - SyncHoldingsResult: Result from SyncHoldings command
+    - BalanceChange: Tracks balance changes for portfolio events
 
 Reference:
     - docs/architecture/cqrs.md (DTOs section)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from decimal import Decimal
+from uuid import UUID
+
+
+@dataclass
+class BalanceChange:
+    """Tracks balance change for a single account during sync.
+
+    Used to emit AccountBalanceUpdated events after sync completes.
+
+    Attributes:
+        account_id: Account whose balance changed.
+        previous: Balance before sync.
+        current: Balance after sync.
+        currency: Currency code.
+    """
+
+    account_id: UUID
+    previous: Decimal
+    current: Decimal
+    currency: str
 
 
 @dataclass
@@ -25,6 +47,7 @@ class SyncAccountsResult:
         unchanged: Number of accounts unchanged.
         errors: Number of accounts that failed to sync.
         message: Human-readable summary.
+        balance_changes: List of balance changes for portfolio events.
     """
 
     created: int
@@ -32,6 +55,7 @@ class SyncAccountsResult:
     unchanged: int
     errors: int
     message: str
+    balance_changes: list[BalanceChange] = field(default_factory=list)
 
 
 @dataclass

--- a/src/application/event_handlers/__init__.py
+++ b/src/application/event_handlers/__init__.py
@@ -1,0 +1,18 @@
+"""Application event handlers for reactive aggregation.
+
+This module contains event handlers that listen to domain events and perform
+reactive aggregation - computing derived values and emitting new events.
+
+These handlers use MANUAL WIRING (not registry-driven auto-wiring) because:
+1. Custom method names (not handle_{workflow}_{phase})
+2. Stateful coordination (queries repositories and caches)
+3. Emits derived events (not just side effects)
+
+See: docs/architecture/domain-events.md Section 5.2 for pattern documentation.
+"""
+
+from src.application.event_handlers.portfolio_event_handler import (
+    PortfolioEventHandler,
+)
+
+__all__ = ["PortfolioEventHandler"]

--- a/src/application/event_handlers/portfolio_event_handler.py
+++ b/src/application/event_handlers/portfolio_event_handler.py
@@ -1,0 +1,199 @@
+"""Portfolio event handler for net worth calculation.
+
+Reacts to balance and holdings changes, recalculates net worth,
+and emits PortfolioNetWorthRecalculated events.
+
+Architecture:
+    - Application layer (coordination/aggregation logic)
+    - App-scoped singleton (created once at startup)
+    - Subscribes to AccountBalanceUpdated and AccountHoldingsUpdated
+    - Emits PortfolioNetWorthRecalculated when net worth changes
+
+Pattern:
+    This is a REACTIVE AGGREGATION handler:
+    1. Listens to AccountBalanceUpdated and AccountHoldingsUpdated
+    2. Queries repository to calculate current net worth
+    3. Compares with cached previous value
+    4. Emits PortfolioNetWorthRecalculated if changed
+
+Reference:
+    - docs/architecture/domain-events-architecture.md
+    - Implementation Plan: Issue #257, Phase 6
+"""
+
+from decimal import Decimal
+from uuid import UUID
+
+from uuid_extensions import uuid7
+
+from src.core.result import Failure
+from src.domain.events.portfolio_events import (
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
+from src.domain.protocols.cache_protocol import CacheProtocol
+from src.domain.protocols.event_bus_protocol import EventBusProtocol
+from src.domain.protocols.logger_protocol import LoggerProtocol
+from src.infrastructure.persistence.database import Database
+
+
+class PortfolioEventHandler:
+    """Event handler for portfolio net worth calculation.
+
+    Reacts to balance/holdings changes and emits net worth events.
+    Follows same pattern as LoggingEventHandler, AuditEventHandler.
+
+    App-scoped singleton, subscribed at container startup.
+
+    Creates database sessions on-demand (same pattern as AuditEventHandler).
+    Gets session from event_bus context when handling events.
+
+    Attributes:
+        _database: Database instance for creating sessions.
+        _cache: For storing previous net worth values.
+        _event_bus: For publishing PortfolioNetWorthRecalculated and getting sessions.
+        _logger: For structured logging.
+
+    Example:
+        >>> # Container creates and subscribes at startup
+        >>> handler = PortfolioEventHandler(
+        ...     database=get_database(),
+        ...     cache=get_cache(),
+        ...     event_bus=get_event_bus(),
+        ...     logger=get_logger(),
+        ... )
+        >>> event_bus.subscribe(AccountBalanceUpdated, handler.handle_balance_updated)
+        >>> event_bus.subscribe(AccountHoldingsUpdated, handler.handle_holdings_updated)
+    """
+
+    def __init__(
+        self,
+        database: Database,
+        cache: CacheProtocol,
+        event_bus: EventBusProtocol,
+        logger: LoggerProtocol,
+    ) -> None:
+        """Initialize handler with dependencies.
+
+        Args:
+            database: Database instance for creating sessions on-demand.
+            cache: Cache for storing previous net worth values.
+            event_bus: Event bus for publishing derived events and getting session context.
+            logger: Logger protocol implementation from container.
+        """
+        self._database = database
+        self._cache = cache
+        self._event_bus = event_bus
+        self._logger = logger
+
+    async def handle_balance_updated(self, event: AccountBalanceUpdated) -> None:
+        """React to balance change, recalculate net worth.
+
+        Args:
+            event: AccountBalanceUpdated event with user_id.
+        """
+        self._logger.debug(
+            "balance_updated_recalculating_networth",
+            user_id=str(event.user_id),
+            account_id=str(event.account_id),
+            delta=str(event.delta),
+        )
+        await self._recalculate_networth(event.user_id)
+
+    async def handle_holdings_updated(self, event: AccountHoldingsUpdated) -> None:
+        """React to holdings change, recalculate net worth.
+
+        Args:
+            event: AccountHoldingsUpdated event with user_id.
+        """
+        self._logger.debug(
+            "holdings_updated_recalculating_networth",
+            user_id=str(event.user_id),
+            account_id=str(event.account_id),
+            holdings_count=event.holdings_count,
+        )
+        await self._recalculate_networth(event.user_id)
+
+    async def _recalculate_networth(self, user_id: UUID) -> None:
+        """Calculate current net worth and emit event if changed.
+
+        Creates a database session, queries repository for current total,
+        compares with cached previous value, and emits PortfolioNetWorthRecalculated
+        if the value changed.
+
+        Args:
+            user_id: User whose net worth to recalculate.
+        """
+        try:
+            # Create session and repository for this query
+            async with self._database.get_session() as session:
+                from src.infrastructure.persistence.repositories import (
+                    AccountRepository,
+                )
+
+                account_repo = AccountRepository(session=session)
+
+                # Query current total from repository
+                current = await account_repo.sum_balances_for_user(user_id)
+                account_count = await account_repo.count_for_user(user_id)
+
+            # Get previous from cache (fail-open if cache unavailable)
+            cache_key = f"portfolio:networth:{user_id}"
+            cached_result = await self._cache.get(cache_key)
+
+            previous = Decimal("0")
+            if isinstance(cached_result, Failure):
+                # Cache error - fail open, assume previous was 0
+                self._logger.warning(
+                    "cache_unavailable_for_networth",
+                    user_id=str(user_id),
+                    fallback="previous=0",
+                )
+            elif cached_result.value is not None:
+                previous = Decimal(cached_result.value)
+
+            # Update cache with current value (fail-open if cache unavailable)
+            set_result = await self._cache.set(cache_key, str(current))
+            if isinstance(set_result, Failure):
+                self._logger.warning(
+                    "cache_set_failed_for_networth",
+                    user_id=str(user_id),
+                )
+
+            # Emit event only if net worth changed
+            if current != previous:
+                await self._event_bus.publish(
+                    PortfolioNetWorthRecalculated(
+                        event_id=uuid7(),
+                        user_id=user_id,
+                        previous_net_worth=previous,
+                        new_net_worth=current,
+                        delta=current - previous,
+                        currency="USD",  # TODO: Get user's base currency from settings
+                        account_count=account_count,
+                    )
+                )
+                self._logger.info(
+                    "portfolio_networth_recalculated",
+                    user_id=str(user_id),
+                    previous=str(previous),
+                    current=str(current),
+                    delta=str(current - previous),
+                    account_count=account_count,
+                )
+            else:
+                self._logger.debug(
+                    "portfolio_networth_unchanged",
+                    user_id=str(user_id),
+                    net_worth=str(current),
+                )
+
+        except Exception as e:
+            # Log error but don't propagate - portfolio calculation is not critical
+            # to the sync operation's success
+            self._logger.error(
+                "portfolio_networth_recalculation_failed",
+                error=e,
+                user_id=str(user_id),
+            )

--- a/src/application/queries/handlers/get_user_networth_handler.py
+++ b/src/application/queries/handlers/get_user_networth_handler.py
@@ -1,0 +1,88 @@
+"""GetUserNetWorth query handler.
+
+Handles requests to calculate user's aggregated net worth.
+Returns DTO with total balance across all active accounts.
+
+Architecture:
+- Application layer handler (orchestrates data retrieval)
+- Returns Result[DTO, str] (explicit error handling)
+- NO domain events (queries are side-effect free)
+
+Reference:
+    - docs/architecture/cqrs-pattern.md
+    - Implementation Plan: Issue #257, Phase 7
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.application.queries.portfolio_queries import GetUserNetWorth
+from src.core.result import Result, Success
+from src.domain.protocols.account_repository import AccountRepository
+
+
+@dataclass
+class NetWorthResult:
+    """Net worth result DTO.
+
+    Represents aggregated portfolio value for API response.
+
+    Attributes:
+        net_worth: Total balance across all active accounts.
+        account_count: Number of active accounts included in calculation.
+        currency: Base currency for calculation (currently always USD).
+    """
+
+    net_worth: Decimal
+    account_count: int
+    currency: str
+
+
+class GetUserNetWorthHandler:
+    """Handler for GetUserNetWorth query.
+
+    Calculates total balance across all active accounts for a user.
+    Uses AccountRepository aggregate methods.
+
+    Dependencies (injected via constructor):
+        - AccountRepository: For querying account balances
+    """
+
+    def __init__(
+        self,
+        account_repo: AccountRepository,
+    ) -> None:
+        """Initialize handler with dependencies.
+
+        Args:
+            account_repo: Repository for account balance queries.
+        """
+        self._account_repo = account_repo
+
+    async def handle(self, query: GetUserNetWorth) -> Result[NetWorthResult, str]:
+        """Handle GetUserNetWorth query.
+
+        Calculates net worth by summing all active account balances.
+
+        Args:
+            query: GetUserNetWorth query with user_id.
+
+        Returns:
+            Success(NetWorthResult): Net worth calculated successfully.
+
+        Note:
+            This query always succeeds - returns 0 if user has no accounts.
+            No failure cases since we're just summing balances.
+        """
+        # Query aggregated balance and account count
+        total = await self._account_repo.sum_balances_for_user(query.user_id)
+        count = await self._account_repo.count_for_user(query.user_id)
+
+        # Map to DTO
+        dto = NetWorthResult(
+            net_worth=total,
+            account_count=count,
+            currency="USD",  # TODO: Get user's base currency from settings
+        )
+
+        return Success(value=dto)

--- a/src/application/queries/portfolio_queries.py
+++ b/src/application/queries/portfolio_queries.py
@@ -1,0 +1,40 @@
+"""Portfolio queries (CQRS read operations).
+
+Queries for portfolio-level data (net worth, aggregated balances, etc.).
+These are immutable dataclasses for explicit client requests.
+
+Pattern:
+- Queries are data containers (no logic)
+- Handlers fetch and return data
+- Queries never change state
+- Queries do NOT emit domain events
+
+Reference:
+    - docs/architecture/cqrs-pattern.md
+    - Implementation Plan: Issue #257, Phase 7
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True, kw_only=True)
+class GetUserNetWorth:
+    """Get aggregated net worth for a user.
+
+    Calculates total balance across all active accounts.
+    Used for explicit client requests (e.g., dashboard load).
+
+    Note: Real-time updates use SSE events (portfolio.networth.updated),
+    not polling this query.
+
+    Attributes:
+        user_id: User whose net worth to calculate.
+
+    Example:
+        >>> query = GetUserNetWorth(user_id=user_id)
+        >>> result = await handler.handle(query)
+        >>> net_worth = result.value.net_worth
+    """
+
+    user_id: UUID

--- a/src/domain/events/portfolio_events.py
+++ b/src/domain/events/portfolio_events.py
@@ -1,0 +1,110 @@
+"""Portfolio domain events (Issue #257).
+
+These are OPERATIONAL events for real-time portfolio value notifications.
+They are NOT part of a 3-state workflow (ATTEMPT → OUTCOME) since sync operations
+already handle that pattern. These events represent computed changes that SSE
+clients need to know about.
+
+Events:
+1. AccountBalanceUpdated - Balance changed during sync
+2. AccountHoldingsUpdated - Holdings changed during sync
+3. PortfolioNetWorthRecalculated - Net worth changed (aggregated)
+
+Handlers:
+- LoggingEventHandler: ALL events (DEBUG level)
+- SSEEventHandler: ALL events (broadcast to client)
+
+Note:
+    These events don't require audit since the underlying sync operations
+    already have full audit coverage (AccountSyncSucceeded, etc.).
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from src.domain.events.base_event import DomainEvent
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class AccountBalanceUpdated(DomainEvent):
+    """Emitted after account balance changes during sync.
+
+    This is an OPERATIONAL event for real-time SSE notifications.
+    Allows clients to update UI without polling.
+
+    Triggers:
+    - LoggingEventHandler: Log balance change (DEBUG)
+    - SSEEventHandler: Broadcast via SSE (portfolio.balance.updated)
+
+    Attributes:
+        user_id: User who owns the account.
+        account_id: Account whose balance changed.
+        previous_balance: Balance before sync.
+        new_balance: Balance after sync.
+        delta: Change amount (new_balance - previous_balance).
+        currency: Currency code (e.g., "USD").
+    """
+
+    user_id: UUID
+    account_id: UUID
+    previous_balance: Decimal
+    new_balance: Decimal
+    delta: Decimal
+    currency: str
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class AccountHoldingsUpdated(DomainEvent):
+    """Emitted after holdings change during sync.
+
+    This is an OPERATIONAL event for real-time SSE notifications.
+    Allows clients to update UI without polling.
+
+    Triggers:
+    - LoggingEventHandler: Log holdings change (DEBUG)
+    - SSEEventHandler: Broadcast via SSE (portfolio.holdings.updated)
+
+    Attributes:
+        user_id: User who owns the account.
+        account_id: Account whose holdings changed.
+        holdings_count: Total holdings after sync.
+        created_count: New holdings created.
+        updated_count: Existing holdings updated.
+        deactivated_count: Holdings marked inactive.
+    """
+
+    user_id: UUID
+    account_id: UUID
+    holdings_count: int
+    created_count: int
+    updated_count: int
+    deactivated_count: int
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PortfolioNetWorthRecalculated(DomainEvent):
+    """Emitted after net worth is recalculated.
+
+    This is an OPERATIONAL event for real-time SSE notifications.
+    Triggered by PortfolioEventHandler after balance/holdings changes.
+
+    Triggers:
+    - LoggingEventHandler: Log net worth change (INFO)
+    - SSEEventHandler: Broadcast via SSE (portfolio.networth.updated)
+
+    Attributes:
+        user_id: User whose net worth changed.
+        previous_net_worth: Net worth before change.
+        new_net_worth: Net worth after change.
+        delta: Change amount (new - previous).
+        currency: Base currency for calculation (e.g., "USD").
+        account_count: Number of active accounts in calculation.
+    """
+
+    user_id: UUID
+    previous_net_worth: Decimal
+    new_net_worth: Decimal
+    delta: Decimal
+    currency: str
+    account_count: int

--- a/src/domain/events/registry.py
+++ b/src/domain/events/registry.py
@@ -118,6 +118,11 @@ from src.domain.events.data_events import (
     FileImportFailed,
     FileImportProgress,
 )
+from src.domain.events.portfolio_events import (
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
 
 
 class EventCategory(Enum):
@@ -750,6 +755,37 @@ EVENT_REGISTRY: list[EventMetadata] = [
         requires_logging=True,
         requires_audit=False,  # Progress events don't need audit records
         audit_action_name="FILE_IMPORT_PROGRESS",  # For registry consistency
+    ),
+    # ═══════════════════════════════════════════════════════════
+    # Portfolio Events (3 events - Issue #257)
+    # OPERATIONAL events for SSE notifications (no audit needed)
+    # ═══════════════════════════════════════════════════════════
+    EventMetadata(
+        event_class=AccountBalanceUpdated,
+        category=EventCategory.DATA_SYNC,
+        workflow_name="account_balance_updated",
+        phase=WorkflowPhase.OPERATIONAL,
+        requires_logging=True,
+        requires_audit=False,  # Underlying sync already audited
+        audit_action_name="ACCOUNT_BALANCE_UPDATED",  # For registry consistency
+    ),
+    EventMetadata(
+        event_class=AccountHoldingsUpdated,
+        category=EventCategory.DATA_SYNC,
+        workflow_name="account_holdings_updated",
+        phase=WorkflowPhase.OPERATIONAL,
+        requires_logging=True,
+        requires_audit=False,  # Underlying sync already audited
+        audit_action_name="ACCOUNT_HOLDINGS_UPDATED",  # For registry consistency
+    ),
+    EventMetadata(
+        event_class=PortfolioNetWorthRecalculated,
+        category=EventCategory.DATA_SYNC,
+        workflow_name="portfolio_networth_recalculated",
+        phase=WorkflowPhase.OPERATIONAL,
+        requires_logging=True,
+        requires_audit=False,  # Underlying sync already audited
+        audit_action_name="PORTFOLIO_NETWORTH_RECALCULATED",  # For registry consistency
     ),
 ]
 

--- a/src/domain/events/sse_event.py
+++ b/src/domain/events/sse_event.py
@@ -118,6 +118,7 @@ class SSEEventType(StrEnum):
     # =========================================================================
     PORTFOLIO_BALANCE_UPDATED = "portfolio.balance.updated"
     PORTFOLIO_HOLDINGS_UPDATED = "portfolio.holdings.updated"
+    PORTFOLIO_NETWORTH_UPDATED = "portfolio.networth.updated"
 
     # =========================================================================
     # SECURITY EVENTS
@@ -159,6 +160,7 @@ _EVENT_TYPE_TO_CATEGORY: dict[SSEEventType, SSEEventCategory] = {
     # Portfolio
     SSEEventType.PORTFOLIO_BALANCE_UPDATED: SSEEventCategory.PORTFOLIO,
     SSEEventType.PORTFOLIO_HOLDINGS_UPDATED: SSEEventCategory.PORTFOLIO,
+    SSEEventType.PORTFOLIO_NETWORTH_UPDATED: SSEEventCategory.PORTFOLIO,
     # Security
     SSEEventType.SECURITY_SESSION_NEW: SSEEventCategory.SECURITY,
     SSEEventType.SECURITY_SESSION_SUSPICIOUS: SSEEventCategory.SECURITY,

--- a/src/domain/protocols/account_repository.py
+++ b/src/domain/protocols/account_repository.py
@@ -8,6 +8,7 @@ Reference:
 """
 
 from datetime import timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Protocol
 from uuid import UUID
 
@@ -207,5 +208,43 @@ class AccountRepository(Protocol):
 
         Example:
             >>> await repo.delete(account_id)
+        """
+        ...
+
+    async def sum_balances_for_user(self, user_id: UUID) -> Decimal:
+        """Sum all active account balances for a user.
+
+        Used for portfolio net worth calculation.
+        Only includes active accounts (is_active=True).
+
+        Args:
+            user_id: User's unique identifier.
+
+        Returns:
+            Total balance across all active accounts (Decimal).
+            Returns 0 if user has no active accounts.
+
+        Example:
+            >>> total = await repo.sum_balances_for_user(user_id)
+            >>> print(f"Net worth: {total}")
+        """
+        ...
+
+    async def count_for_user(self, user_id: UUID) -> int:
+        """Count active accounts for a user.
+
+        Used for portfolio statistics.
+        Only includes active accounts (is_active=True).
+
+        Args:
+            user_id: User's unique identifier.
+
+        Returns:
+            Number of active accounts.
+            Returns 0 if user has no active accounts.
+
+        Example:
+            >>> count = await repo.count_for_user(user_id)
+            >>> print(f"Active accounts: {count}")
         """
         ...

--- a/src/infrastructure/events/handlers/logging_event_handler.py
+++ b/src/infrastructure/events/handlers/logging_event_handler.py
@@ -140,6 +140,12 @@ from src.domain.events.data_events import (
     FileImportFailed,
     FileImportProgress,
 )
+from src.domain.events.portfolio_events import (
+    # Portfolio Events (operational)
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
 from src.domain.protocols.logger_protocol import LoggerProtocol
 
 
@@ -1361,4 +1367,81 @@ class LoggingEventHandler:
             progress_percent=event.progress_percent,
             records_processed=event.records_processed,
             total_records=event.total_records,
+        )
+
+    # =========================================================================
+    # Portfolio Event Handlers (Issue #257)
+    # OPERATIONAL events for SSE notifications - logged at DEBUG level
+    # =========================================================================
+
+    async def handle_account_balance_updated_operational(
+        self,
+        event: AccountBalanceUpdated,
+    ) -> None:
+        """Log account balance update (DEBUG level).
+
+        Method name follows auto-wiring pattern: handle_{workflow_name}_{phase}
+        AccountBalanceUpdated uses workflow_name='account_balance_updated' + phase=OPERATIONAL.
+
+        Uses DEBUG level since these events are operational (SSE notifications)
+        and the underlying sync operation is already logged at INFO level.
+        """
+        self._logger.debug(
+            "account_balance_updated",
+            event_id=str(event.event_id),
+            occurred_at=event.occurred_at.isoformat(),
+            user_id=str(event.user_id),
+            account_id=str(event.account_id),
+            previous_balance=str(event.previous_balance),
+            new_balance=str(event.new_balance),
+            delta=str(event.delta),
+            currency=event.currency,
+        )
+
+    async def handle_account_holdings_updated_operational(
+        self,
+        event: AccountHoldingsUpdated,
+    ) -> None:
+        """Log account holdings update (DEBUG level).
+
+        Method name follows auto-wiring pattern: handle_{workflow_name}_{phase}
+        AccountHoldingsUpdated uses workflow_name='account_holdings_updated' + phase=OPERATIONAL.
+
+        Uses DEBUG level since these events are operational (SSE notifications)
+        and the underlying sync operation is already logged at INFO level.
+        """
+        self._logger.debug(
+            "account_holdings_updated",
+            event_id=str(event.event_id),
+            occurred_at=event.occurred_at.isoformat(),
+            user_id=str(event.user_id),
+            account_id=str(event.account_id),
+            holdings_count=event.holdings_count,
+            created_count=event.created_count,
+            updated_count=event.updated_count,
+            deactivated_count=event.deactivated_count,
+        )
+
+    async def handle_portfolio_networth_recalculated_operational(
+        self,
+        event: PortfolioNetWorthRecalculated,
+    ) -> None:
+        """Log portfolio net worth recalculation (INFO level).
+
+        Method name follows auto-wiring pattern: handle_{workflow_name}_{phase}
+        PortfolioNetWorthRecalculated uses workflow_name='portfolio_networth_recalculated' + phase=OPERATIONAL.
+
+        Uses INFO level since net worth changes are significant portfolio events
+        that users/ops teams care about monitoring.
+        """
+        self._logger.info(
+            "portfolio_networth_recalculated",
+            event_id=str(event.event_id),
+            occurred_at=event.occurred_at.isoformat(),
+            user_id=str(event.user_id),
+            previous_net_worth=str(event.previous_net_worth),
+            new_net_worth=str(event.new_net_worth),
+            delta=str(event.delta),
+            currency=event.currency,
+            account_count=event.account_count,
         )

--- a/tests/integration/test_sse_portfolio_events.py
+++ b/tests/integration/test_sse_portfolio_events.py
@@ -1,0 +1,392 @@
+"""Integration tests for SSE Portfolio event delivery.
+
+Tests the portfolio notification flow through Redis pub/sub, verifying
+that portfolio events are properly delivered to the user's active SSE
+connections.
+
+Architecture:
+    - Tests against real Redis (not mocked)
+    - Uses test environment Redis
+    - Tests portfolio event pub/sub delivery
+    - Tests category filtering for portfolio events
+    - Tests all 3 portfolio event types
+
+Reference:
+    - docs/architecture/sse-architecture.md
+    - GitHub Issue #257
+"""
+
+import asyncio
+import logging
+
+import pytest
+import pytest_asyncio
+from uuid_extensions import uuid7
+
+from src.domain.events.sse_event import SSEEvent, SSEEventType
+from src.infrastructure.sse.redis_publisher import RedisSSEPublisher
+from src.infrastructure.sse.redis_subscriber import RedisSSESubscriber
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def sse_publisher(redis_test_client):
+    """Provide an SSE publisher for each test."""
+    return RedisSSEPublisher(
+        redis_client=redis_test_client,
+        enable_retention=False,
+        logger=logging.getLogger("test.sse.portfolio.publisher"),
+    )
+
+
+@pytest_asyncio.fixture
+async def sse_subscriber(redis_test_client):
+    """Provide an SSE subscriber for each test."""
+    return RedisSSESubscriber(
+        redis_client=redis_test_client,
+        enable_retention=False,
+        logger=logging.getLogger("test.sse.portfolio.subscriber"),
+    )
+
+
+def create_portfolio_event(
+    event_type: SSEEventType,
+    user_id=None,
+    data=None,
+) -> SSEEvent:
+    """Create a portfolio SSEEvent for testing."""
+    return SSEEvent(
+        event_type=event_type,
+        user_id=user_id or uuid7(),
+        data=data or {},
+    )
+
+
+# =============================================================================
+# Portfolio Event Delivery Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestPortfolioEventDelivery:
+    """Test portfolio events are delivered through pub/sub."""
+
+    @pytest.mark.asyncio
+    async def test_balance_updated_event_delivered(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test PORTFOLIO_BALANCE_UPDATED event is delivered to user."""
+        user_id = uuid7()
+        account_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            user_id=user_id,
+            data={
+                "account_id": str(account_id),
+                "previous_balance": "1000.00",
+                "new_balance": "1500.00",
+                "delta": "500.00",
+                "currency": "USD",
+            },
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        await sse_publisher.publish(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.event_type == SSEEventType.PORTFOLIO_BALANCE_UPDATED
+        assert received.data["account_id"] == str(account_id)
+        assert received.data["new_balance"] == "1500.00"
+        assert received.data["delta"] == "500.00"
+
+    @pytest.mark.asyncio
+    async def test_holdings_updated_event_delivered(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test PORTFOLIO_HOLDINGS_UPDATED event is delivered to user."""
+        user_id = uuid7()
+        account_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+            user_id=user_id,
+            data={
+                "account_id": str(account_id),
+                "holdings_count": 15,
+                "created_count": 3,
+                "updated_count": 10,
+                "deactivated_count": 2,
+            },
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        await sse_publisher.publish(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.event_type == SSEEventType.PORTFOLIO_HOLDINGS_UPDATED
+        assert received.data["account_id"] == str(account_id)
+        assert received.data["holdings_count"] == 15
+        assert received.data["created_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_networth_updated_event_delivered(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test PORTFOLIO_NETWORTH_UPDATED event is delivered to user."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_NETWORTH_UPDATED,
+            user_id=user_id,
+            data={
+                "previous_net_worth": "50000.00",
+                "new_net_worth": "52500.75",
+                "delta": "2500.75",
+                "currency": "USD",
+                "account_count": 5,
+            },
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        await sse_publisher.publish(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.event_type == SSEEventType.PORTFOLIO_NETWORTH_UPDATED
+        assert received.data["new_net_worth"] == "52500.75"
+        assert received.data["delta"] == "2500.75"
+        assert received.data["account_count"] == 5
+
+
+# =============================================================================
+# Category Filtering Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestPortfolioCategoryFiltering:
+    """Test portfolio events are correctly categorized."""
+
+    @pytest.mark.asyncio
+    async def test_portfolio_category_filter_accepts_balance_event(
+        self, sse_subscriber
+    ):
+        """Test portfolio category filter accepts balance update events."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            user_id=user_id,
+            data={"account_id": str(uuid7())},
+        )
+
+        assert sse_subscriber.filter_by_categories(event, ["portfolio"]) is True
+
+    @pytest.mark.asyncio
+    async def test_portfolio_category_filter_accepts_holdings_event(
+        self, sse_subscriber
+    ):
+        """Test portfolio category filter accepts holdings update events."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+            user_id=user_id,
+            data={"account_id": str(uuid7())},
+        )
+
+        assert sse_subscriber.filter_by_categories(event, ["portfolio"]) is True
+
+    @pytest.mark.asyncio
+    async def test_portfolio_category_filter_accepts_networth_event(
+        self, sse_subscriber
+    ):
+        """Test portfolio category filter accepts networth update events."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_NETWORTH_UPDATED,
+            user_id=user_id,
+            data={"new_net_worth": "50000.00"},
+        )
+
+        assert sse_subscriber.filter_by_categories(event, ["portfolio"]) is True
+
+    @pytest.mark.asyncio
+    async def test_portfolio_event_rejected_by_other_category(self, sse_subscriber):
+        """Test portfolio events are rejected by non-portfolio category filter."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_NETWORTH_UPDATED,
+            user_id=user_id,
+            data={"new_net_worth": "50000.00"},
+        )
+
+        # Portfolio event should not pass data_sync filter
+        assert sse_subscriber.filter_by_categories(event, ["data_sync"]) is False
+
+    @pytest.mark.asyncio
+    async def test_portfolio_event_passes_no_filter(self, sse_subscriber):
+        """Test portfolio events pass when no filter specified."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            user_id=user_id,
+        )
+
+        assert sse_subscriber.filter_by_categories(event, None) is True
+
+
+# =============================================================================
+# Negative Delta Tests (Portfolio Value Decrease)
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestPortfolioNegativeDelta:
+    """Test portfolio events with negative deltas (decreases)."""
+
+    @pytest.mark.asyncio
+    async def test_balance_decrease_event_delivered(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test balance decrease event is delivered correctly."""
+        user_id = uuid7()
+        account_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            user_id=user_id,
+            data={
+                "account_id": str(account_id),
+                "previous_balance": "5000.00",
+                "new_balance": "4500.00",
+                "delta": "-500.00",
+                "currency": "EUR",
+            },
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        await sse_publisher.publish(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.data["delta"] == "-500.00"
+        assert received.data["currency"] == "EUR"
+
+    @pytest.mark.asyncio
+    async def test_networth_decrease_event_delivered(
+        self, redis_test_client, sse_publisher, sse_subscriber
+    ):
+        """Test net worth decrease event is delivered correctly."""
+        user_id = uuid7()
+        event = create_portfolio_event(
+            event_type=SSEEventType.PORTFOLIO_NETWORTH_UPDATED,
+            user_id=user_id,
+            data={
+                "previous_net_worth": "100000.00",
+                "new_net_worth": "95000.00",
+                "delta": "-5000.00",
+                "currency": "USD",
+                "account_count": 3,
+            },
+        )
+
+        received_events: list[SSEEvent] = []
+
+        async def collect_events():
+            async for e in sse_subscriber.subscribe(user_id):
+                received_events.append(e)
+                break
+
+        subscriber_task = asyncio.create_task(collect_events())
+        await asyncio.sleep(0.1)
+
+        await sse_publisher.publish(event)
+
+        try:
+            await asyncio.wait_for(subscriber_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(received_events) == 1
+        received = received_events[0]
+        assert received.data["delta"] == "-5000.00"
+        assert received.data["previous_net_worth"] == "100000.00"
+        assert received.data["new_net_worth"] == "95000.00"

--- a/tests/unit/test_application_dtos.py
+++ b/tests/unit/test_application_dtos.py
@@ -323,6 +323,7 @@ class TestDTOModuleExports:
             "AuthTokens",
             "GlobalRotationResult",
             "UserRotationResult",
+            "BalanceChange",
             "SyncAccountsResult",
             "SyncTransactionsResult",
             "SyncHoldingsResult",
@@ -338,6 +339,7 @@ class TestDTOModuleExports:
         from src.application.dtos import (
             AuthenticatedUser,
             AuthTokens,
+            BalanceChange,
             GlobalRotationResult,
             ImportResult,
             SyncAccountsResult,
@@ -349,6 +351,7 @@ class TestDTOModuleExports:
         # All imports should work
         assert AuthenticatedUser is not None
         assert AuthTokens is not None
+        assert BalanceChange is not None
         assert GlobalRotationResult is not None
         assert UserRotationResult is not None
         assert SyncAccountsResult is not None

--- a/tests/unit/test_application_portfolio_event_handler.py
+++ b/tests/unit/test_application_portfolio_event_handler.py
@@ -1,0 +1,757 @@
+"""Unit tests for PortfolioEventHandler (Issue #257).
+
+Tests cover:
+- Handler initialization with dependencies
+- Balance updated event triggers net worth recalculation
+- Holdings updated event triggers net worth recalculation
+- Event emission when net worth changes
+- No event emission when net worth unchanged
+- Cache handling (get/set, fail-open behavior)
+- Error handling (non-critical, fail-open)
+- Logging at appropriate levels
+
+Test Strategy:
+- Mock protocols (LoggerProtocol, CacheProtocol, EventBusProtocol)
+- Mock Database and AccountRepository
+- Test behavior, not implementation details
+- Verify correct event emission based on net worth delta
+
+Reference:
+    - src/application/event_handlers/portfolio_event_handler.py
+    - GitHub Issue #257
+"""
+
+from decimal import Decimal
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from uuid_extensions import uuid7
+
+from src.application.event_handlers.portfolio_event_handler import PortfolioEventHandler
+from src.core.result import Failure, Success
+from src.domain.events.portfolio_events import (
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_logger():
+    """Create mock LoggerProtocol."""
+    logger = MagicMock()
+    logger.debug = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_cache():
+    """Create mock CacheProtocol."""
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=Success(value=None))
+    cache.set = AsyncMock(return_value=Success(value=None))
+    return cache
+
+
+@pytest.fixture
+def mock_event_bus():
+    """Create mock EventBusProtocol."""
+    event_bus = MagicMock()
+    event_bus.publish = AsyncMock(return_value=None)
+    return event_bus
+
+
+@pytest.fixture
+def mock_database():
+    """Create mock Database with session context manager."""
+    database = MagicMock()
+    # Mock session context manager
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    database.get_session = MagicMock(return_value=mock_session)
+    return database
+
+
+@pytest.fixture
+def mock_account_repo():
+    """Create mock AccountRepository."""
+    repo = MagicMock()
+    repo.sum_balances_for_user = AsyncMock(return_value=Decimal("10000.00"))
+    repo.count_for_user = AsyncMock(return_value=3)
+    return repo
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    """Provide a test user ID."""
+    return cast(UUID, uuid7())
+
+
+@pytest.fixture
+def account_id() -> UUID:
+    """Provide a test account ID."""
+    return cast(UUID, uuid7())
+
+
+@pytest.fixture
+def handler(mock_database, mock_cache, mock_event_bus, mock_logger):
+    """Create PortfolioEventHandler with mock dependencies."""
+    return PortfolioEventHandler(
+        database=mock_database,
+        cache=mock_cache,
+        event_bus=mock_event_bus,
+        logger=mock_logger,
+    )
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPortfolioEventHandlerInitialization:
+    """Test PortfolioEventHandler initialization."""
+
+    def test_handler_stores_dependencies(
+        self, mock_database, mock_cache, mock_event_bus, mock_logger
+    ):
+        """Test handler stores all dependencies."""
+        handler = PortfolioEventHandler(
+            database=mock_database,
+            cache=mock_cache,
+            event_bus=mock_event_bus,
+            logger=mock_logger,
+        )
+
+        assert handler._database is mock_database
+        assert handler._cache is mock_cache
+        assert handler._event_bus is mock_event_bus
+        assert handler._logger is mock_logger
+
+
+# =============================================================================
+# Balance Updated Event Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestHandleBalanceUpdated:
+    """Test handle_balance_updated method."""
+
+    @pytest.mark.asyncio
+    async def test_logs_debug_when_balance_updated(
+        self, handler, mock_logger, user_id, account_id, mock_account_repo
+    ):
+        """Test handler logs debug message when balance update received."""
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1500.00"),
+            delta=Decimal("500.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        mock_logger.debug.assert_any_call(
+            "balance_updated_recalculating_networth",
+            user_id=str(user_id),
+            account_id=str(account_id),
+            delta="500.00",
+        )
+
+    @pytest.mark.asyncio
+    async def test_calls_recalculate_networth(
+        self, handler, user_id, account_id, mock_account_repo
+    ):
+        """Test balance updated triggers net worth recalculation."""
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1500.00"),
+            delta=Decimal("500.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Verify repository was queried
+        mock_account_repo.sum_balances_for_user.assert_called_once_with(user_id)
+        mock_account_repo.count_for_user.assert_called_once_with(user_id)
+
+
+# =============================================================================
+# Holdings Updated Event Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestHandleHoldingsUpdated:
+    """Test handle_holdings_updated method."""
+
+    @pytest.mark.asyncio
+    async def test_logs_debug_when_holdings_updated(
+        self, handler, mock_logger, user_id, account_id, mock_account_repo
+    ):
+        """Test handler logs debug message when holdings update received."""
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=10,
+            created_count=2,
+            updated_count=5,
+            deactivated_count=3,
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_holdings_updated(event)
+
+        mock_logger.debug.assert_any_call(
+            "holdings_updated_recalculating_networth",
+            user_id=str(user_id),
+            account_id=str(account_id),
+            holdings_count=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_calls_recalculate_networth(
+        self, handler, user_id, account_id, mock_account_repo
+    ):
+        """Test holdings updated triggers net worth recalculation."""
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=10,
+            created_count=2,
+            updated_count=5,
+            deactivated_count=3,
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_holdings_updated(event)
+
+        # Verify repository was queried
+        mock_account_repo.sum_balances_for_user.assert_called_once_with(user_id)
+
+
+# =============================================================================
+# Net Worth Recalculation Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRecalculateNetworth:
+    """Test _recalculate_networth method behavior."""
+
+    @pytest.mark.asyncio
+    async def test_emits_event_when_networth_changed(
+        self,
+        handler,
+        mock_event_bus,
+        mock_cache,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test event emitted when net worth changes from cached value."""
+        # Setup: current net worth is 10000, cache returns previous as 8000
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("10000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=3)
+        mock_cache.get = AsyncMock(return_value=Success(value="8000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("3000.00"),
+            delta=Decimal("2000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Verify event was published
+        mock_event_bus.publish.assert_called_once()
+        published_event = mock_event_bus.publish.call_args[0][0]
+        assert isinstance(published_event, PortfolioNetWorthRecalculated)
+        assert published_event.user_id == user_id
+        assert published_event.previous_net_worth == Decimal("8000.00")
+        assert published_event.new_net_worth == Decimal("10000.00")
+        assert published_event.delta == Decimal("2000.00")
+        assert published_event.account_count == 3
+
+    @pytest.mark.asyncio
+    async def test_no_event_when_networth_unchanged(
+        self,
+        handler,
+        mock_event_bus,
+        mock_cache,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test no event emitted when net worth is unchanged."""
+        # Setup: current net worth equals cached value
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("10000.00")
+        )
+        mock_cache.get = AsyncMock(return_value=Success(value="10000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1000.00"),
+            delta=Decimal("0"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Verify no event was published
+        mock_event_bus.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_emits_event_when_cache_empty(
+        self,
+        handler,
+        mock_event_bus,
+        mock_cache,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test event emitted when cache has no previous value (first calculation)."""
+        # Setup: cache returns None (no previous value)
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("10000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=2)
+        mock_cache.get = AsyncMock(return_value=Success(value=None))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("10000.00"),
+            delta=Decimal("10000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Event should be published (10000 != 0)
+        mock_event_bus.publish.assert_called_once()
+        published_event = mock_event_bus.publish.call_args[0][0]
+        assert published_event.previous_net_worth == Decimal("0")
+        assert published_event.new_net_worth == Decimal("10000.00")
+
+    @pytest.mark.asyncio
+    async def test_logs_info_when_networth_changed(
+        self, handler, mock_logger, mock_cache, user_id, account_id, mock_account_repo
+    ):
+        """Test INFO log when net worth changes."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("15000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=4)
+        mock_cache.get = AsyncMock(return_value=Success(value="12000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("3000.00"),
+            delta=Decimal("3000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        mock_logger.info.assert_called_once_with(
+            "portfolio_networth_recalculated",
+            user_id=str(user_id),
+            previous="12000.00",
+            current="15000.00",
+            delta="3000.00",
+            account_count=4,
+        )
+
+    @pytest.mark.asyncio
+    async def test_logs_debug_when_networth_unchanged(
+        self, handler, mock_logger, mock_cache, user_id, account_id, mock_account_repo
+    ):
+        """Test DEBUG log when net worth is unchanged."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("10000.00")
+        )
+        mock_cache.get = AsyncMock(return_value=Success(value="10000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("0"),
+            delta=Decimal("0"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Should log debug for unchanged
+        mock_logger.debug.assert_any_call(
+            "portfolio_networth_unchanged",
+            user_id=str(user_id),
+            net_worth="10000.00",
+        )
+
+
+# =============================================================================
+# Cache Handling Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCacheHandling:
+    """Test cache get/set and fail-open behavior."""
+
+    @pytest.mark.asyncio
+    async def test_cache_key_format(
+        self, handler, mock_cache, user_id, account_id, mock_account_repo
+    ):
+        """Test cache uses correct key format."""
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        expected_key = f"portfolio:networth:{user_id}"
+        mock_cache.get.assert_called_once_with(expected_key)
+        mock_cache.set.assert_called_once()
+        actual_key = mock_cache.set.call_args[0][0]
+        assert actual_key == expected_key
+
+    @pytest.mark.asyncio
+    async def test_updates_cache_with_current_networth(
+        self, handler, mock_cache, user_id, account_id, mock_account_repo
+    ):
+        """Test cache is updated with current net worth value."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("25000.50")
+        )
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Verify cache.set called with stringified Decimal
+        mock_cache.set.assert_called_once()
+        _, value = mock_cache.set.call_args[0]
+        assert value == "25000.50"
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_cache_get_failure(
+        self,
+        handler,
+        mock_cache,
+        mock_event_bus,
+        mock_logger,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test handler continues with previous=0 when cache get fails."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("5000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=1)
+        mock_cache.get = AsyncMock(return_value=Failure(error="Cache connection error"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("5000.00"),
+            delta=Decimal("5000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Should log warning
+        mock_logger.warning.assert_any_call(
+            "cache_unavailable_for_networth",
+            user_id=str(user_id),
+            fallback="previous=0",
+        )
+        # Event should still be published (5000 != 0)
+        mock_event_bus.publish.assert_called_once()
+        published_event = mock_event_bus.publish.call_args[0][0]
+        assert published_event.previous_net_worth == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_cache_set_failure(
+        self, handler, mock_cache, mock_logger, user_id, account_id, mock_account_repo
+    ):
+        """Test handler continues when cache set fails."""
+        mock_cache.get = AsyncMock(return_value=Success(value=None))
+        mock_cache.set = AsyncMock(return_value=Failure(error="Cache write error"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        # Should log warning but not fail
+        mock_logger.warning.assert_called_with(
+            "cache_set_failed_for_networth",
+            user_id=str(user_id),
+        )
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestErrorHandling:
+    """Test error handling and fail-open behavior."""
+
+    @pytest.mark.asyncio
+    async def test_logs_error_on_repository_failure(
+        self, handler, mock_logger, user_id, account_id
+    ):
+        """Test error logged when repository query fails."""
+        mock_failing_repo = MagicMock()
+        mock_failing_repo.sum_balances_for_user = AsyncMock(
+            side_effect=Exception("Database connection failed")
+        )
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_failing_repo,
+        ):
+            # Should not raise - fail open
+            await handler.handle_balance_updated(event)
+
+        # Should log error
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "portfolio_networth_recalculation_failed"
+        assert call_args[1]["user_id"] == str(user_id)
+
+    @pytest.mark.asyncio
+    async def test_does_not_propagate_exception(
+        self, handler, mock_event_bus, user_id, account_id
+    ):
+        """Test exceptions don't propagate to caller."""
+        mock_failing_repo = MagicMock()
+        mock_failing_repo.sum_balances_for_user = AsyncMock(
+            side_effect=Exception("Unexpected error")
+        )
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_failing_repo,
+        ):
+            # This should complete without exception
+            await handler.handle_balance_updated(event)
+
+        # No event should be published on error
+        mock_event_bus.publish.assert_not_called()
+
+
+# =============================================================================
+# Integration with Event Bus Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestEventBusIntegration:
+    """Test handler produces correct events for event bus."""
+
+    @pytest.mark.asyncio
+    async def test_published_event_has_correct_structure(
+        self,
+        handler,
+        mock_event_bus,
+        mock_cache,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test PortfolioNetWorthRecalculated event has all required fields."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("50000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=5)
+        mock_cache.get = AsyncMock(return_value=Success(value="45000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("5000.00"),
+            delta=Decimal("5000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        mock_event_bus.publish.assert_called_once()
+        published = mock_event_bus.publish.call_args[0][0]
+
+        # Verify all fields
+        assert isinstance(published, PortfolioNetWorthRecalculated)
+        assert published.event_id is not None  # uuid7
+        assert published.user_id == user_id
+        assert published.previous_net_worth == Decimal("45000.00")
+        assert published.new_net_worth == Decimal("50000.00")
+        assert published.delta == Decimal("5000.00")
+        assert published.currency == "USD"
+        assert published.account_count == 5
+
+    @pytest.mark.asyncio
+    async def test_negative_delta_handled_correctly(
+        self,
+        handler,
+        mock_event_bus,
+        mock_cache,
+        user_id,
+        account_id,
+        mock_account_repo,
+    ):
+        """Test negative delta (net worth decrease) handled correctly."""
+        mock_account_repo.sum_balances_for_user = AsyncMock(
+            return_value=Decimal("8000.00")
+        )
+        mock_account_repo.count_for_user = AsyncMock(return_value=2)
+        mock_cache.get = AsyncMock(return_value=Success(value="10000.00"))
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("5000.00"),
+            new_balance=Decimal("3000.00"),
+            delta=Decimal("-2000.00"),
+            currency="USD",
+        )
+
+        with patch(
+            "src.infrastructure.persistence.repositories.AccountRepository",
+            return_value=mock_account_repo,
+        ):
+            await handler.handle_balance_updated(event)
+
+        mock_event_bus.publish.assert_called_once()
+        published = mock_event_bus.publish.call_args[0][0]
+        assert published.delta == Decimal("-2000.00")
+        assert published.previous_net_worth > published.new_net_worth

--- a/tests/unit/test_core_container_events.py
+++ b/tests/unit/test_core_container_events.py
@@ -134,12 +134,19 @@ class TestEventRegistryCompleteness:
 
         expected_sse = len(get_domain_event_to_sse_mapping())
 
+        # Count manual PortfolioEventHandler subscriptions (Issue #257)
+        # These are REACTIVE AGGREGATION handlers that don't fit the registry-driven pattern
+        # AccountBalanceUpdated -> handle_balance_updated
+        # AccountHoldingsUpdated -> handle_holdings_updated
+        expected_portfolio = 2
+
         expected_subscriptions = (
             expected_logging
             + expected_audit
             + expected_email
             + expected_session
             + expected_sse
+            + expected_portfolio
         )
 
         # Count actual subscriptions (sum of all handlers across all events)
@@ -156,9 +163,10 @@ class TestEventRegistryCompleteness:
             f"  - Email: {expected_email}\n"
             f"  - Session: {expected_session}\n"
             f"  - SSE: {expected_sse}\n"
+            f"  - Portfolio: {expected_portfolio}\n"
             f"Actual: {actual_subscriptions} subscriptions\n\n"
             f"If actual < expected: Container wiring bug (missing subscriptions)\n"
-            f"If actual > expected: Update EVENT_REGISTRY or SSE_EVENT_REGISTRY metadata"
+            f"If actual > expected: Update EVENT_REGISTRY, SSE_EVENT_REGISTRY, or manual handler counts"
         )
 
     def test_critical_events_have_audit_and_logging(self, event_bus) -> None:

--- a/tests/unit/test_domain_portfolio_events.py
+++ b/tests/unit/test_domain_portfolio_events.py
@@ -1,0 +1,370 @@
+"""Unit tests for portfolio domain events.
+
+Tests cover:
+- Event creation with all required fields
+- Immutability (frozen dataclass)
+- event_id auto-generation
+- occurred_at timestamp auto-generation
+- Decimal field handling
+- Each of 3 portfolio events
+
+Architecture:
+- Unit tests for domain events (no dependencies)
+- Validates OPERATIONAL events (not 3-state workflow)
+- Tests: AccountBalanceUpdated, AccountHoldingsUpdated, PortfolioNetWorthRecalculated
+
+Reference:
+    - Implementation Plan: Issue #257, Phase 9.2
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
+from src.domain.events.base_event import DomainEvent
+from src.domain.events.portfolio_events import (
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
+
+
+@pytest.mark.unit
+class TestAccountBalanceUpdatedEvent:
+    """Test AccountBalanceUpdated event."""
+
+    def test_creation_with_all_fields(self):
+        """Test event creation with all required fields."""
+        # Arrange
+        user_id = UUID("12345678-1234-5678-1234-567812345678")
+        account_id = UUID("87654321-4321-8765-4321-876543218765")
+
+        # Act
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1500.50"),
+            delta=Decimal("500.50"),
+            currency="USD",
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.account_id == account_id
+        assert event.previous_balance == Decimal("1000.00")
+        assert event.new_balance == Decimal("1500.50")
+        assert event.delta == Decimal("500.50")
+        assert event.currency == "USD"
+
+    def test_event_id_auto_generated(self):
+        """Test event_id is auto-generated when not provided."""
+        # Act
+        event = AccountBalanceUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        # Assert
+        assert event.event_id is not None
+        assert isinstance(event.event_id, UUID)
+
+    def test_occurred_at_auto_generated(self):
+        """Test occurred_at timestamp is auto-generated in UTC."""
+        # Arrange
+        before = datetime.now(UTC)
+
+        # Act
+        event = AccountBalanceUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        after = datetime.now(UTC)
+
+        # Assert
+        assert event.occurred_at is not None
+        assert isinstance(event.occurred_at, datetime)
+        assert event.occurred_at.tzinfo == UTC
+        assert before <= event.occurred_at <= after
+
+    def test_event_is_immutable(self):
+        """Test event is immutable (frozen dataclass)."""
+        # Arrange
+        event = AccountBalanceUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            event.new_balance = Decimal("200")  # type: ignore[misc]
+
+    def test_inherits_from_domain_event(self):
+        """Test event inherits from DomainEvent."""
+        # Act
+        event = AccountBalanceUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        # Assert
+        assert isinstance(event, DomainEvent)
+
+    def test_negative_delta_for_decrease(self):
+        """Test delta can be negative for balance decrease."""
+        # Act
+        event = AccountBalanceUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("800.00"),
+            delta=Decimal("-200.00"),
+            currency="USD",
+        )
+
+        # Assert
+        assert event.delta == Decimal("-200.00")
+        assert event.new_balance < event.previous_balance
+
+
+@pytest.mark.unit
+class TestAccountHoldingsUpdatedEvent:
+    """Test AccountHoldingsUpdated event."""
+
+    def test_creation_with_all_fields(self):
+        """Test event creation with all required fields."""
+        # Arrange
+        user_id = UUID("12345678-1234-5678-1234-567812345678")
+        account_id = UUID("87654321-4321-8765-4321-876543218765")
+
+        # Act
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=10,
+            created_count=3,
+            updated_count=5,
+            deactivated_count=2,
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.account_id == account_id
+        assert event.holdings_count == 10
+        assert event.created_count == 3
+        assert event.updated_count == 5
+        assert event.deactivated_count == 2
+
+    def test_event_id_auto_generated(self):
+        """Test event_id is auto-generated when not provided."""
+        # Act
+        event = AccountHoldingsUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            holdings_count=5,
+            created_count=1,
+            updated_count=2,
+            deactivated_count=0,
+        )
+
+        # Assert
+        assert event.event_id is not None
+        assert isinstance(event.event_id, UUID)
+
+    def test_event_is_immutable(self):
+        """Test event is immutable (frozen dataclass)."""
+        # Arrange
+        event = AccountHoldingsUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            holdings_count=5,
+            created_count=1,
+            updated_count=2,
+            deactivated_count=0,
+        )
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            event.holdings_count = 10  # type: ignore[misc]
+
+    def test_inherits_from_domain_event(self):
+        """Test event inherits from DomainEvent."""
+        # Act
+        event = AccountHoldingsUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            holdings_count=5,
+            created_count=1,
+            updated_count=2,
+            deactivated_count=0,
+        )
+
+        # Assert
+        assert isinstance(event, DomainEvent)
+
+    def test_zero_counts_valid(self):
+        """Test all counts can be zero (no changes)."""
+        # Act
+        event = AccountHoldingsUpdated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            account_id=UUID("87654321-4321-8765-4321-876543218765"),
+            holdings_count=0,
+            created_count=0,
+            updated_count=0,
+            deactivated_count=0,
+        )
+
+        # Assert
+        assert event.holdings_count == 0
+        assert event.created_count == 0
+        assert event.updated_count == 0
+        assert event.deactivated_count == 0
+
+
+@pytest.mark.unit
+class TestPortfolioNetWorthRecalculatedEvent:
+    """Test PortfolioNetWorthRecalculated event."""
+
+    def test_creation_with_all_fields(self):
+        """Test event creation with all required fields."""
+        # Arrange
+        user_id = UUID("12345678-1234-5678-1234-567812345678")
+
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("10000.00"),
+            new_net_worth=Decimal("12500.00"),
+            delta=Decimal("2500.00"),
+            currency="USD",
+            account_count=5,
+        )
+
+        # Assert
+        assert event.user_id == user_id
+        assert event.previous_net_worth == Decimal("10000.00")
+        assert event.new_net_worth == Decimal("12500.00")
+        assert event.delta == Decimal("2500.00")
+        assert event.currency == "USD"
+        assert event.account_count == 5
+
+    def test_event_id_auto_generated(self):
+        """Test event_id is auto-generated when not provided."""
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("1000"),
+            delta=Decimal("1000"),
+            currency="USD",
+            account_count=1,
+        )
+
+        # Assert
+        assert event.event_id is not None
+        assert isinstance(event.event_id, UUID)
+
+    def test_occurred_at_auto_generated(self):
+        """Test occurred_at timestamp is auto-generated in UTC."""
+        # Arrange
+        before = datetime.now(UTC)
+
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("1000"),
+            delta=Decimal("1000"),
+            currency="USD",
+            account_count=1,
+        )
+
+        after = datetime.now(UTC)
+
+        # Assert
+        assert event.occurred_at is not None
+        assert isinstance(event.occurred_at, datetime)
+        assert event.occurred_at.tzinfo == UTC
+        assert before <= event.occurred_at <= after
+
+    def test_event_is_immutable(self):
+        """Test event is immutable (frozen dataclass)."""
+        # Arrange
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("1000"),
+            delta=Decimal("1000"),
+            currency="USD",
+            account_count=1,
+        )
+
+        # Act & Assert
+        with pytest.raises(AttributeError):
+            event.new_net_worth = Decimal("2000")  # type: ignore[misc]
+
+    def test_inherits_from_domain_event(self):
+        """Test event inherits from DomainEvent."""
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("1000"),
+            delta=Decimal("1000"),
+            currency="USD",
+            account_count=1,
+        )
+
+        # Assert
+        assert isinstance(event, DomainEvent)
+
+    def test_negative_delta_for_decrease(self):
+        """Test delta can be negative for net worth decrease."""
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("10000.00"),
+            new_net_worth=Decimal("8000.00"),
+            delta=Decimal("-2000.00"),
+            currency="USD",
+            account_count=3,
+        )
+
+        # Assert
+        assert event.delta == Decimal("-2000.00")
+        assert event.new_net_worth < event.previous_net_worth
+
+    def test_zero_net_worth_valid(self):
+        """Test net worth can be zero (no accounts or all zero balances)."""
+        # Act
+        event = PortfolioNetWorthRecalculated(
+            user_id=UUID("12345678-1234-5678-1234-567812345678"),
+            previous_net_worth=Decimal("1000.00"),
+            new_net_worth=Decimal("0"),
+            delta=Decimal("-1000.00"),
+            currency="USD",
+            account_count=0,
+        )
+
+        # Assert
+        assert event.new_net_worth == Decimal("0")
+        assert event.account_count == 0

--- a/tests/unit/test_domain_sse_portfolio_mappings.py
+++ b/tests/unit/test_domain_sse_portfolio_mappings.py
@@ -1,0 +1,453 @@
+"""Unit tests for SSE Portfolio Notifications Mappings (Issue #257).
+
+Tests cover:
+- All 3 domain-to-SSE mappings for portfolio events
+- Payload extraction for each event type
+- User ID extraction
+- Decimal-to-string conversion for monetary values
+- Mapping registry integration
+
+Reference:
+    - src/domain/events/sse_registry.py
+    - src/domain/events/portfolio_events.py
+    - GitHub Issue #257
+"""
+
+from decimal import Decimal
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from uuid_extensions import uuid7
+
+from src.domain.events.portfolio_events import (
+    AccountBalanceUpdated,
+    AccountHoldingsUpdated,
+    PortfolioNetWorthRecalculated,
+)
+from src.domain.events.sse_event import SSEEventType
+from src.domain.events.sse_registry import (
+    DOMAIN_TO_SSE_MAPPING,
+    get_domain_event_to_sse_mapping,
+    get_registry_statistics,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def user_id() -> UUID:
+    """Provide a test user ID."""
+    return cast(UUID, uuid7())
+
+
+@pytest.fixture
+def account_id() -> UUID:
+    """Provide a test account ID."""
+    return cast(UUID, uuid7())
+
+
+# =============================================================================
+# Registry Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPortfolioMappingsRegistry:
+    """Test that portfolio mappings are properly registered."""
+
+    def test_all_portfolio_events_have_mappings(self):
+        """Verify all 3 portfolio domain events have SSE mappings."""
+        mapping = get_domain_event_to_sse_mapping()
+
+        assert AccountBalanceUpdated in mapping
+        assert AccountHoldingsUpdated in mapping
+        assert PortfolioNetWorthRecalculated in mapping
+
+    def test_registry_statistics_include_portfolio_mappings(self):
+        """Verify registry statistics reflect portfolio mappings."""
+        stats = get_registry_statistics()
+
+        # Should have at least 24 mappings (9 data sync + 3 provider + 4 import + 5 security + 3 portfolio)
+        total_mappings = cast(int, stats["total_mappings"])
+        assert total_mappings >= 24
+
+    def test_mapping_list_contains_portfolio_entries(self):
+        """Verify DOMAIN_TO_SSE_MAPPING has portfolio entries."""
+        portfolio_types = {
+            SSEEventType.PORTFOLIO_BALANCE_UPDATED,
+            SSEEventType.PORTFOLIO_HOLDINGS_UPDATED,
+            SSEEventType.PORTFOLIO_NETWORTH_UPDATED,
+        }
+
+        mapped_types = {m.sse_event_type for m in DOMAIN_TO_SSE_MAPPING}
+        assert portfolio_types.issubset(mapped_types)
+
+
+# =============================================================================
+# AccountBalanceUpdated Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAccountBalanceUpdatedMapping:
+    """Test AccountBalanceUpdated domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test AccountBalanceUpdated maps to PORTFOLIO_BALANCE_UPDATED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountBalanceUpdated]
+
+        assert m.sse_event_type == SSEEventType.PORTFOLIO_BALANCE_UPDATED
+
+    def test_payload_extraction(self, user_id, account_id):
+        """Test payload is correctly extracted from AccountBalanceUpdated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountBalanceUpdated]
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1250.50"),
+            delta=Decimal("250.50"),
+            currency="USD",
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "previous_balance": "1000.00",
+            "new_balance": "1250.50",
+            "delta": "250.50",
+            "currency": "USD",
+        }
+
+    def test_payload_extraction_with_negative_delta(self, user_id, account_id):
+        """Test payload extraction when balance decreases."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountBalanceUpdated]
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("5000.00"),
+            new_balance=Decimal("4500.75"),
+            delta=Decimal("-499.25"),
+            currency="EUR",
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "previous_balance": "5000.00",
+            "new_balance": "4500.75",
+            "delta": "-499.25",
+            "currency": "EUR",
+        }
+
+    def test_payload_extraction_with_zero_delta(self, user_id, account_id):
+        """Test payload extraction when balance is unchanged (edge case)."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountBalanceUpdated]
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("1000.00"),
+            new_balance=Decimal("1000.00"),
+            delta=Decimal("0"),
+            currency="GBP",
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "previous_balance": "1000.00",
+            "new_balance": "1000.00",
+            "delta": "0",
+            "currency": "GBP",
+        }
+
+    def test_user_id_extraction(self, user_id, account_id):
+        """Test user_id is correctly extracted from AccountBalanceUpdated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountBalanceUpdated]
+
+        event = AccountBalanceUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            previous_balance=Decimal("0"),
+            new_balance=Decimal("100"),
+            delta=Decimal("100"),
+            currency="USD",
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# AccountHoldingsUpdated Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAccountHoldingsUpdatedMapping:
+    """Test AccountHoldingsUpdated domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test AccountHoldingsUpdated maps to PORTFOLIO_HOLDINGS_UPDATED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountHoldingsUpdated]
+
+        assert m.sse_event_type == SSEEventType.PORTFOLIO_HOLDINGS_UPDATED
+
+    def test_payload_extraction(self, user_id, account_id):
+        """Test payload is correctly extracted from AccountHoldingsUpdated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountHoldingsUpdated]
+
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=15,
+            created_count=3,
+            updated_count=10,
+            deactivated_count=2,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "holdings_count": 15,
+            "created_count": 3,
+            "updated_count": 10,
+            "deactivated_count": 2,
+        }
+
+    def test_payload_extraction_with_all_zeros(self, user_id, account_id):
+        """Test payload extraction when no holdings changed (edge case)."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountHoldingsUpdated]
+
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=0,
+            created_count=0,
+            updated_count=0,
+            deactivated_count=0,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "holdings_count": 0,
+            "created_count": 0,
+            "updated_count": 0,
+            "deactivated_count": 0,
+        }
+
+    def test_payload_extraction_only_deactivations(self, user_id, account_id):
+        """Test payload extraction when only holdings are deactivated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountHoldingsUpdated]
+
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=5,
+            created_count=0,
+            updated_count=0,
+            deactivated_count=3,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "account_id": str(account_id),
+            "holdings_count": 5,
+            "created_count": 0,
+            "updated_count": 0,
+            "deactivated_count": 3,
+        }
+
+    def test_user_id_extraction(self, user_id, account_id):
+        """Test user_id is correctly extracted from AccountHoldingsUpdated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[AccountHoldingsUpdated]
+
+        event = AccountHoldingsUpdated(
+            user_id=user_id,
+            account_id=account_id,
+            holdings_count=10,
+            created_count=0,
+            updated_count=0,
+            deactivated_count=0,
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# PortfolioNetWorthRecalculated Mapping Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPortfolioNetWorthRecalculatedMapping:
+    """Test PortfolioNetWorthRecalculated domain-to-SSE mapping."""
+
+    def test_mapping_to_correct_sse_event_type(self):
+        """Test PortfolioNetWorthRecalculated maps to PORTFOLIO_NETWORTH_UPDATED."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        assert m.sse_event_type == SSEEventType.PORTFOLIO_NETWORTH_UPDATED
+
+    def test_payload_extraction(self, user_id):
+        """Test payload is correctly extracted from PortfolioNetWorthRecalculated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("50000.00"),
+            new_net_worth=Decimal("52500.75"),
+            delta=Decimal("2500.75"),
+            currency="USD",
+            account_count=5,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "previous_net_worth": "50000.00",
+            "new_net_worth": "52500.75",
+            "delta": "2500.75",
+            "currency": "USD",
+            "account_count": 5,
+        }
+
+    def test_payload_extraction_with_negative_delta(self, user_id):
+        """Test payload extraction when net worth decreases."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("100000.00"),
+            new_net_worth=Decimal("95000.00"),
+            delta=Decimal("-5000.00"),
+            currency="EUR",
+            account_count=3,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "previous_net_worth": "100000.00",
+            "new_net_worth": "95000.00",
+            "delta": "-5000.00",
+            "currency": "EUR",
+            "account_count": 3,
+        }
+
+    def test_payload_extraction_with_single_account(self, user_id):
+        """Test payload extraction with single account."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("10000.00"),
+            delta=Decimal("10000.00"),
+            currency="USD",
+            account_count=1,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "previous_net_worth": "0",
+            "new_net_worth": "10000.00",
+            "delta": "10000.00",
+            "currency": "USD",
+            "account_count": 1,
+        }
+
+    def test_payload_extraction_with_large_values(self, user_id):
+        """Test payload extraction with large monetary values."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("999999999.99"),
+            new_net_worth=Decimal("1000000000.00"),
+            delta=Decimal("0.01"),
+            currency="USD",
+            account_count=100,
+        )
+        payload = m.payload_extractor(event)
+
+        assert payload == {
+            "previous_net_worth": "999999999.99",
+            "new_net_worth": "1000000000.00",
+            "delta": "0.01",
+            "currency": "USD",
+            "account_count": 100,
+        }
+
+    def test_user_id_extraction(self, user_id):
+        """Test user_id is correctly extracted from PortfolioNetWorthRecalculated."""
+        mapping = get_domain_event_to_sse_mapping()
+        m = mapping[PortfolioNetWorthRecalculated]
+
+        event = PortfolioNetWorthRecalculated(
+            user_id=user_id,
+            previous_net_worth=Decimal("0"),
+            new_net_worth=Decimal("0"),
+            delta=Decimal("0"),
+            currency="USD",
+            account_count=0,
+        )
+
+        assert m.user_id_extractor(event) == user_id
+
+
+# =============================================================================
+# SSE Event Handler Integration Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSSEEventHandlerIntegration:
+    """Test that portfolio mappings work with SSEEventHandler."""
+
+    def test_handler_has_mapping_for_all_portfolio_events(self):
+        """Verify SSEEventHandler can find mappings for portfolio events."""
+        from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+        mock_publisher = MagicMock()
+        handler = SSEEventHandler(publisher=mock_publisher)
+
+        # All portfolio events should have mappings
+        assert handler.has_mapping_for(AccountBalanceUpdated)
+        assert handler.has_mapping_for(AccountHoldingsUpdated)
+        assert handler.has_mapping_for(PortfolioNetWorthRecalculated)
+
+    def test_handler_returns_portfolio_events_in_mapped_types(self):
+        """Verify SSEEventHandler returns portfolio events in mapped types."""
+        from src.infrastructure.sse.sse_event_handler import SSEEventHandler
+
+        mock_publisher = MagicMock()
+        handler = SSEEventHandler(publisher=mock_publisher)
+
+        mapped_types = handler.get_mapped_event_types()
+
+        # Should include all portfolio events
+        assert AccountBalanceUpdated in mapped_types
+        assert AccountHoldingsUpdated in mapped_types
+        assert PortfolioNetWorthRecalculated in mapped_types


### PR DESCRIPTION
## Summary
Implement real-time SSE notifications for portfolio changes after sync operations (Issue #257).

## Changes

### Domain Events
- **AccountBalanceUpdated**: Emitted when account balance changes during sync
- **AccountHoldingsUpdated**: Emitted when holdings change during sync  
- **PortfolioNetWorthRecalculated**: Emitted after net worth is recalculated

### SSE Event Types
- `PORTFOLIO_BALANCE_UPDATED`
- `PORTFOLIO_HOLDINGS_UPDATED`
- `PORTFOLIO_NETWORTH_UPDATED`

### Components
- **PortfolioEventHandler**: Reacts to balance/holdings changes, recalculates net worth
- **GetUserNetWorth query**: Optional explicit net worth query
- **LoggingEventHandler**: Added 3 operational logging methods
- **AccountRepository**: Added `sum_balances_for_user`, `count_for_user` methods

### Tests
- Unit tests for domain events (10 tests)
- Unit tests for SSE mappings (21 tests)
- Unit tests for PortfolioEventHandler (18 tests)
- Integration tests for SSE portfolio event delivery (10 tests)

## Verification
- `make verify` passes: 2765 tests, 89% coverage
- All formatting, linting, and type-checking pass

Closes #257

Co-Authored-By: Warp <agent@warp.dev>